### PR TITLE
fix(ProsePrompt): preserve line breaks and lists when copying prompt

### DIFF
--- a/src/runtime/components/prose/Prompt.vue
+++ b/src/runtime/components/prose/Prompt.vue
@@ -32,7 +32,7 @@ import { useClipboard } from '@vueuse/core'
 import { useAppConfig } from '#imports'
 import { useComponentProps } from '../../composables/useComponentProps'
 import { useLocale } from '../../composables/useLocale'
-import { getSlotChildrenText } from '../../utils'
+import { getSlotPromptText } from '../../utils'
 import { tv } from '../../utils/tv'
 import icons from '../../dictionary/icons'
 import B24Button from '../Button.vue'
@@ -55,7 +55,7 @@ const b24ui = computed(() => tv({ extend: tv(theme), ...(appConfig.b24ui?.prose?
 
 function getPromptText() {
   const children = slots.default?.()
-  return children ? getSlotChildrenText(children).trim() : ''
+  return children ? getSlotPromptText(children).trim() : ''
 }
 
 function copyPrompt() {

--- a/src/runtime/utils/index.ts
+++ b/src/runtime/utils/index.ts
@@ -189,6 +189,47 @@ export function getSlotChildrenText(children: any) {
   }).join('')
 }
 
+const PROMPT_BLOCK_TAGS = new Set(['p', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'blockquote'])
+
+function walkPromptNodes(children: any[]): string {
+  return children.map((node: any) => {
+    if (typeof node === 'string') return node
+    if (typeof node === 'number') return String(node)
+    if (!node || typeof node !== 'object') return ''
+
+    let inner: string
+    if (typeof node.children === 'string') {
+      inner = node.children
+    } else if (Array.isArray(node.children)) {
+      inner = walkPromptNodes(node.children)
+    } else if (node.children?.default) {
+      inner = walkPromptNodes(node.children.default())
+    } else {
+      inner = ''
+    }
+
+    const tag = typeof node.type === 'string' ? node.type.toLowerCase() : ''
+
+    if (PROMPT_BLOCK_TAGS.has(tag)) return `${inner}\n\n`
+    if (tag === 'pre') return `\n\`\`\`\n${inner.replace(/^`+|`+$/g, '')}\n\`\`\`\n\n`
+    if (tag === 'ul' || tag === 'ol') return `${inner}\n`
+    if (tag === 'li') return `- ${inner}\n`
+    if (tag === 'br') return '\n'
+    if (tag === 'hr') return '\n---\n\n'
+    if (tag === 'code') return `\`${inner}\``
+    if (tag === 'strong' || tag === 'b') return `**${inner}**`
+    if (tag === 'em' || tag === 'i') return `*${inner}*`
+    if (tag === 'a' && node.props?.href) return `[${inner}](${node.props.href})`
+
+    return inner
+  }).join('')
+}
+
+export function getSlotPromptText(children: any): string {
+  if (!Array.isArray(children)) return ''
+  return walkPromptNodes(children).replace(/\n{3,}/g, '\n\n')
+}
+
 export function transformUI(ui: any, uiProp?: any) {
   return Object.entries(ui).reduce((acc, [key, value]) => {
     acc[key] = typeof value === 'function' ? value({ class: uiProp?.[key] }) : value

--- a/test/utils/index.spec.ts
+++ b/test/utils/index.spec.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from 'vitest'
+import { h, Fragment } from 'vue'
+import { getSlotPromptText } from '../../src/runtime/utils'
+
+describe('getSlotPromptText', () => {
+  it('returns empty string for non-array input', () => {
+    expect(getSlotPromptText(undefined)).toBe('')
+    expect(getSlotPromptText(null)).toBe('')
+  })
+
+  it('extracts plain text from a single text node', () => {
+    const nodes = [{ type: Symbol('Text'), children: 'Hello world' }]
+    expect(getSlotPromptText(nodes)).toBe('Hello world')
+  })
+
+  it('inserts a paragraph break between <p> blocks', () => {
+    const nodes = [
+      h('p', null, 'First paragraph.'),
+      h('p', null, 'Second paragraph.')
+    ]
+    expect(getSlotPromptText(nodes).trim()).toBe('First paragraph.\n\nSecond paragraph.')
+  })
+
+  it('preserves bullet structure for unordered lists', () => {
+    const nodes = [
+      h('p', null, 'Intro:'),
+      h('ul', null, [
+        h('li', null, 'First item'),
+        h('li', null, 'Second item')
+      ])
+    ]
+    expect(getSlotPromptText(nodes).trim()).toBe('Intro:\n\n- First item\n- Second item')
+  })
+
+  it('preserves inline code with backticks', () => {
+    const nodes = [
+      h('p', null, ['Use the ', h('code', null, 'b24-ui-nuxt'), ' skill.'])
+    ]
+    expect(getSlotPromptText(nodes).trim()).toBe('Use the `b24-ui-nuxt` skill.')
+  })
+
+  it('preserves links as markdown', () => {
+    const nodes = [
+      h('p', null, [
+        'See ',
+        h('a', { href: 'https://example.com' }, 'docs'),
+        ' for details.'
+      ])
+    ]
+    expect(getSlotPromptText(nodes).trim()).toBe('See [docs](https://example.com) for details.')
+  })
+
+  it('treats <br> as a single newline', () => {
+    const nodes = [
+      h('p', null, ['Line 1', h('br'), 'Line 2'])
+    ]
+    expect(getSlotPromptText(nodes).trim()).toBe('Line 1\nLine 2')
+  })
+
+  it('collapses 3+ consecutive newlines into a paragraph break', () => {
+    const nodes = [
+      h('blockquote', null, h('p', null, 'Quoted.')),
+      h('p', null, 'Next.')
+    ]
+    expect(getSlotPromptText(nodes).trim()).toBe('Quoted.\n\nNext.')
+  })
+
+  it('walks Fragment children', () => {
+    const nodes = [
+      h(Fragment, null, [
+        h('p', null, 'A'),
+        h('p', null, 'B')
+      ])
+    ]
+    expect(getSlotPromptText(nodes).trim()).toBe('A\n\nB')
+  })
+
+  it('handles a realistic prompt with paragraphs and a list', () => {
+    const nodes = [
+      h('p', null, ['Lean on the ', h('code', null, 'b24-ui-nuxt'), ' skill.']),
+      h('p', null, 'Before writing any code:'),
+      h('ul', null, [
+        h('li', null, 'Which entity?'),
+        h('li', null, 'What trigger?')
+      ]),
+      h('p', null, 'Then assemble the popover.')
+    ]
+    expect(getSlotPromptText(nodes).trim()).toBe(
+      'Lean on the `b24-ui-nuxt` skill.\n\n'
+      + 'Before writing any code:\n\n'
+      + '- Which entity?\n'
+      + '- What trigger?\n\n'
+      + 'Then assemble the popover.'
+    )
+  })
+})


### PR DESCRIPTION
## Summary

`ProsePrompt` collapsed paragraphs, list items and `<br>`s into a single line when the user pressed **Copy** on a `::prompt` block.

Root cause: the copy handler relied on the generic `getSlotChildrenText` helper, which recursively joins every text leaf of the VNode tree with an empty string. MDC renders markdown into `<p>` / `<ul>` / `<li>` / `<br>` VNodes, so all visual block boundaries are lost. `.trim()` in `Prompt.vue` could not recover them — there were no `\n`s left to begin with.

## Changes

- `src/runtime/utils/index.ts` — add `getSlotPromptText`. It walks the VNode tree by tag, restoring a markdown-shaped string:
  - `\n\n` after `p`, `h1`–`h6`, `blockquote`
  - `\n` after `ul` / `ol`, `- ` + `\n` for `li`
  - `\n` for `br`, `\n---\n\n` for `hr`
  - backticks for inline `code`, `**…**` for `strong`/`b`, `*…*` for `em`/`i`, `[…](href)` for `a`, triple-backticks for `pre`
  - collapses `\n{3,}` to `\n\n` to avoid runaway gaps from nested blocks
  - also handles raw strings inside `children` arrays (the original helper silently dropped these)
- `src/runtime/components/prose/Prompt.vue` — switch the copy handler to `getSlotPromptText`.
- `test/utils/index.spec.ts` — 10 new cases (paragraphs, lists, inline code, links, `<br>`, fragments, a realistic prompt with mixed inline/block content).

The original `getSlotChildrenText` is left untouched, so `PageCard` / `PageFeature` / `Header` aria-label generation keeps its previous behavior.

## Test plan

- [x] `pnpm lint` clean
- [x] `pnpm test:nuxt` — 108 files / 2408 tests pass (incl. the 10 new ones)
- [ ] Manually copy from a `::prompt` block in the docs and verify paragraphs / list items land on separate lines

https://claude.ai/code/session_017sVpofYXPFQsRzyJXpejS1

---
_Generated by [Claude Code](https://claude.ai/code/session_017sVpofYXPFQsRzyJXpejS1)_