### PR TITLE
fix(ProsePrompt): walk rendered DOM when copying (re-fix #19)

### DIFF
--- a/src/runtime/components/prose/Prompt.vue
+++ b/src/runtime/components/prose/Prompt.vue
@@ -27,12 +27,12 @@ export interface ProsePromptSlots {
 </script>
 
 <script setup lang="ts">
-import { computed } from 'vue'
+import { computed, useTemplateRef } from 'vue'
 import { useClipboard } from '@vueuse/core'
 import { useAppConfig } from '#imports'
 import { useComponentProps } from '../../composables/useComponentProps'
 import { useLocale } from '../../composables/useLocale'
-import { getSlotPromptText } from '../../utils'
+import { extractPromptText } from '../../utils'
 import { tv } from '../../utils/tv'
 import icons from '../../dictionary/icons'
 import B24Button from '../Button.vue'
@@ -42,7 +42,7 @@ defineOptions({ inheritAttrs: false })
 const _props = withDefaults(defineProps<ProsePromptProps>(), {
   actions: () => ['copy']
 })
-const slots = defineSlots<ProsePromptSlots>()
+defineSlots<ProsePromptSlots>()
 
 const props = useComponentProps('prose.prompt', _props)
 
@@ -50,12 +50,13 @@ const { t } = useLocale()
 const { copy, copied } = useClipboard()
 const appConfig = useAppConfig() as ProsePrompt['AppConfig']
 
+const bodyRef = useTemplateRef<HTMLElement>('bodyRef')
+
 // eslint-disable-next-line vue/no-dupe-keys
 const b24ui = computed(() => tv({ extend: tv(theme), ...(appConfig.b24ui?.prose?.prompt || {}) })())
 
 function getPromptText() {
-  const children = slots.default?.()
-  return children ? getSlotPromptText(children).trim() : ''
+  return extractPromptText(bodyRef.value)
 }
 
 function copyPrompt() {
@@ -85,6 +86,9 @@ function openInWindsurf() {
       <p v-if="props.description" data-slot="description" :class="b24ui.description({ class: props.b24ui?.description })">
         {{ props.description }}
       </p>
+      <div ref="bodyRef" data-slot="body" hidden>
+        <slot />
+      </div>
     </div>
 
     <div data-slot="actions" :class="b24ui.actions({ class: props.b24ui?.actions })">

--- a/src/runtime/utils/index.ts
+++ b/src/runtime/utils/index.ts
@@ -191,43 +191,47 @@ export function getSlotChildrenText(children: any) {
 
 const PROMPT_BLOCK_TAGS = new Set(['p', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'blockquote'])
 
-function walkPromptNodes(children: any[]): string {
-  return children.map((node: any) => {
-    if (typeof node === 'string') return node
-    if (typeof node === 'number') return String(node)
-    if (!node || typeof node !== 'object') return ''
+function walkPromptElement(node: Node): string {
+  if (node.nodeType === 3) {
+    const text = node.textContent || ''
+    // Pure-whitespace text nodes that span newlines are HTML-formatting
+    // artifacts between block elements and should be ignored.
+    if (text.includes('\n') && !text.trim()) return ''
+    return text
+  }
+  if (node.nodeType !== 1) return ''
 
-    let inner: string
-    if (typeof node.children === 'string') {
-      inner = node.children
-    } else if (Array.isArray(node.children)) {
-      inner = walkPromptNodes(node.children)
-    } else if (node.children?.default) {
-      inner = walkPromptNodes(node.children.default())
-    } else {
-      inner = ''
-    }
+  const element = node as Element
+  const tag = element.tagName.toLowerCase()
 
-    const tag = typeof node.type === 'string' ? node.type.toLowerCase() : ''
+  let inner = ''
+  node.childNodes.forEach((child) => {
+    inner += walkPromptElement(child)
+  })
 
-    if (PROMPT_BLOCK_TAGS.has(tag)) return `${inner}\n\n`
-    if (tag === 'pre') return `\n\`\`\`\n${inner.replace(/^`+|`+$/g, '')}\n\`\`\`\n\n`
-    if (tag === 'ul' || tag === 'ol') return `${inner}\n`
-    if (tag === 'li') return `- ${inner}\n`
-    if (tag === 'br') return '\n'
-    if (tag === 'hr') return '\n---\n\n'
-    if (tag === 'code') return `\`${inner}\``
-    if (tag === 'strong' || tag === 'b') return `**${inner}**`
-    if (tag === 'em' || tag === 'i') return `*${inner}*`
-    if (tag === 'a' && node.props?.href) return `[${inner}](${node.props.href})`
+  if (PROMPT_BLOCK_TAGS.has(tag)) return `${inner}\n\n`
+  if (tag === 'pre') return `\n\`\`\`\n${inner.replace(/^`+|`+$/g, '')}\n\`\`\`\n\n`
+  if (tag === 'ul' || tag === 'ol') return `${inner}\n`
+  if (tag === 'li') return `- ${inner}\n`
+  if (tag === 'br') return '\n'
+  if (tag === 'hr') return '\n---\n\n'
+  if (tag === 'code') return `\`${inner}\``
+  if (tag === 'strong' || tag === 'b') return `**${inner}**`
+  if (tag === 'em' || tag === 'i') return `*${inner}*`
+  if (tag === 'a') {
+    const href = element.getAttribute('href')
+    return href ? `[${inner}](${href})` : inner
+  }
 
-    return inner
-  }).join('')
+  return inner
 }
 
-export function getSlotPromptText(children: any): string {
-  if (!Array.isArray(children)) return ''
-  return walkPromptNodes(children).replace(/\n{3,}/g, '\n\n')
+export function extractPromptText(el: Element | null | undefined): string {
+  if (!el) return ''
+  return walkPromptElement(el)
+    .replace(/[ \t]+\n/g, '\n')
+    .replace(/\n{3,}/g, '\n\n')
+    .trim()
 }
 
 export function transformUI(ui: any, uiProp?: any) {

--- a/test/utils/index.spec.ts
+++ b/test/utils/index.spec.ts
@@ -1,96 +1,79 @@
 import { describe, it, expect } from 'vitest'
-import { h, Fragment } from 'vue'
-import { getSlotPromptText } from '../../src/runtime/utils'
+import { extractPromptText } from '../../src/runtime/utils'
 
-describe('getSlotPromptText', () => {
-  it('returns empty string for non-array input', () => {
-    expect(getSlotPromptText(undefined)).toBe('')
-    expect(getSlotPromptText(null)).toBe('')
+function el(html: string): HTMLElement {
+  const div = document.createElement('div')
+  div.innerHTML = html
+  return div
+}
+
+describe('extractPromptText', () => {
+  it('returns empty string for null/undefined', () => {
+    expect(extractPromptText(null)).toBe('')
+    expect(extractPromptText(undefined)).toBe('')
   })
 
   it('extracts plain text from a single text node', () => {
-    const nodes = [{ type: Symbol('Text'), children: 'Hello world' }]
-    expect(getSlotPromptText(nodes)).toBe('Hello world')
+    expect(extractPromptText(el('Hello world'))).toBe('Hello world')
   })
 
   it('inserts a paragraph break between <p> blocks', () => {
-    const nodes = [
-      h('p', null, 'First paragraph.'),
-      h('p', null, 'Second paragraph.')
-    ]
-    expect(getSlotPromptText(nodes).trim()).toBe('First paragraph.\n\nSecond paragraph.')
+    expect(extractPromptText(el('<p>First paragraph.</p><p>Second paragraph.</p>')))
+      .toBe('First paragraph.\n\nSecond paragraph.')
   })
 
   it('preserves bullet structure for unordered lists', () => {
-    const nodes = [
-      h('p', null, 'Intro:'),
-      h('ul', null, [
-        h('li', null, 'First item'),
-        h('li', null, 'Second item')
-      ])
-    ]
-    expect(getSlotPromptText(nodes).trim()).toBe('Intro:\n\n- First item\n- Second item')
+    expect(extractPromptText(el('<p>Intro:</p><ul><li>First item</li><li>Second item</li></ul>')))
+      .toBe('Intro:\n\n- First item\n- Second item')
   })
 
   it('preserves inline code with backticks', () => {
-    const nodes = [
-      h('p', null, ['Use the ', h('code', null, 'b24-ui-nuxt'), ' skill.'])
-    ]
-    expect(getSlotPromptText(nodes).trim()).toBe('Use the `b24-ui-nuxt` skill.')
+    expect(extractPromptText(el('<p>Use the <code>b24-ui-nuxt</code> skill.</p>')))
+      .toBe('Use the `b24-ui-nuxt` skill.')
   })
 
   it('preserves links as markdown', () => {
-    const nodes = [
-      h('p', null, [
-        'See ',
-        h('a', { href: 'https://example.com' }, 'docs'),
-        ' for details.'
-      ])
-    ]
-    expect(getSlotPromptText(nodes).trim()).toBe('See [docs](https://example.com) for details.')
+    expect(extractPromptText(el('<p>See <a href="https://example.com">docs</a> for details.</p>')))
+      .toBe('See [docs](https://example.com) for details.')
   })
 
   it('treats <br> as a single newline', () => {
-    const nodes = [
-      h('p', null, ['Line 1', h('br'), 'Line 2'])
-    ]
-    expect(getSlotPromptText(nodes).trim()).toBe('Line 1\nLine 2')
+    expect(extractPromptText(el('<p>Line 1<br>Line 2</p>')))
+      .toBe('Line 1\nLine 2')
   })
 
-  it('collapses 3+ consecutive newlines into a paragraph break', () => {
-    const nodes = [
-      h('blockquote', null, h('p', null, 'Quoted.')),
-      h('p', null, 'Next.')
-    ]
-    expect(getSlotPromptText(nodes).trim()).toBe('Quoted.\n\nNext.')
-  })
-
-  it('walks Fragment children', () => {
-    const nodes = [
-      h(Fragment, null, [
-        h('p', null, 'A'),
-        h('p', null, 'B')
-      ])
-    ]
-    expect(getSlotPromptText(nodes).trim()).toBe('A\n\nB')
+  it('collapses runaway newlines from nested blocks', () => {
+    expect(extractPromptText(el('<blockquote><p>Quoted.</p></blockquote><p>Next.</p>')))
+      .toBe('Quoted.\n\nNext.')
   })
 
   it('handles a realistic prompt with paragraphs and a list', () => {
-    const nodes = [
-      h('p', null, ['Lean on the ', h('code', null, 'b24-ui-nuxt'), ' skill.']),
-      h('p', null, 'Before writing any code:'),
-      h('ul', null, [
-        h('li', null, 'Which entity?'),
-        h('li', null, 'What trigger?')
-      ]),
-      h('p', null, 'Then assemble the popover.')
-    ]
-    expect(getSlotPromptText(nodes).trim()).toBe(
+    const root = el(`
+      <p>Lean on the <code>b24-ui-nuxt</code> skill.</p>
+      <p>Before writing any code:</p>
+      <ul>
+        <li>Which entity?</li>
+        <li>What trigger?</li>
+      </ul>
+      <p>Then assemble the popover.</p>
+    `)
+    expect(extractPromptText(root)).toBe(
       'Lean on the `b24-ui-nuxt` skill.\n\n'
       + 'Before writing any code:\n\n'
       + '- Which entity?\n'
       + '- What trigger?\n\n'
       + 'Then assemble the popover.'
     )
+  })
+
+  it('walks through prose-style wrapper components rendered as plain tags', () => {
+    const root = el('<div data-slot="base"><p data-slot="base">A</p><ul data-slot="base"><li data-slot="base">B</li></ul></div>')
+    expect(extractPromptText(root)).toBe('A\n\n- B')
+  })
+
+  it('reads from a hidden host element', () => {
+    const host = el('<p>One.</p><p>Two.</p>')
+    host.hidden = true
+    expect(extractPromptText(host)).toBe('One.\n\nTwo.')
   })
 })


### PR DESCRIPTION
## Summary

Reopens #19, which **did not actually fix the problem in production** — pasting a `::prompt` block (e.g. the entity-info popover example in `docs/content/docs/2.components/popover.md`) still copied as a single run-on line.

### Why the previous attempt missed

`getSlotPromptText` walked the VNodes returned by `slots.default()` and matched `node.type` against HTML tag strings (`'p'`, `'ul'`, ...). But MDC rewires standard tags to Prose-prefixed components via its `proseComponentMap` (`"p" -> "prose-p" -> ProseP`), so `node.type` ends up as a component object, never the string `'p'`. Every block-level branch fell through to the default `return inner`, and the output was still flat.

### What this PR does instead

- Render the slot into a hidden `<div ref="bodyRef" hidden>` inside `ProsePrompt`. The Prose components ultimately produce real `<p>`, `<ul>`, `<li>`, etc. in the DOM, so `tagName` is always a string regardless of how the VNode was authored.
- Replace `getSlotPromptText(children)` with `extractPromptText(el: Element)` that walks the live DOM and rebuilds a markdown-shaped string (paragraphs, lists, headings, inline code, links, `<br>`, `<hr>`, `<pre>` code blocks, bold/italic).
- Drop pure-whitespace text nodes that span a newline (HTML-formatting artifacts between block elements), and tighten the newline normalization so nested blocks (`<blockquote><p>...</p></blockquote>`) don't leave runaway gaps.
- Tests rewritten against real `Element` instances under happy-dom.

`getSlotChildrenText` (used by `PageCard`/`PageFeature`/`Header` for aria-label generation) is untouched.

## Test plan

- [x] `pnpm lint` clean
- [x] `pnpm typecheck` clean
- [x] `pnpm test:nuxt` — 108 files / 2409 tests pass (10 new DOM-based extraction cases incl. realistic-prompt and `hidden`-host fixtures)
- [ ] Open `/docs/components/popover` in the running docs site and copy the `::prompt` block — paragraphs, list items and inline code land on separate lines

https://claude.ai/code/session_017sVpofYXPFQsRzyJXpejS1

---
_Generated by [Claude Code](https://claude.ai/code/session_017sVpofYXPFQsRzyJXpejS1)_