### PR TITLE
feat(PageCard/PageCardGroup): add `avatar` prop with Button.vue pattern

### DIFF
--- a/docs/app/components/content/examples/page/PageCardGroupAvatarExample.vue
+++ b/docs/app/components/content/examples/page/PageCardGroupAvatarExample.vue
@@ -1,0 +1,39 @@
+<script setup lang="ts">
+import TelephonyHandset1Icon from '@bitrix24/b24icons-vue/main/TelephonyHandset1Icon'
+import MailIcon from '@bitrix24/b24icons-vue/main/MailIcon'
+import FeedbackIcon from '@bitrix24/b24icons-vue/main/FeedbackIcon'
+import type { PageCardGroupItem } from '@bitrix24/b24ui-nuxt'
+
+const items: PageCardGroupItem[] = [
+  {
+    value: 'callback',
+    avatar: { color: 'air-primary-success', icon: TelephonyHandset1Icon },
+    label: 'Callback',
+    description: 'Capture the phone number and start a callback'
+  },
+  {
+    value: 'contacts',
+    avatar: { color: 'air-primary-copilot', icon: MailIcon },
+    label: 'Contact details',
+    description: 'Collect phone, email and client name'
+  },
+  {
+    value: 'feedback',
+    avatar: { color: 'air-primary-warning', icon: FeedbackIcon },
+    label: 'Feedback',
+    description: 'Gather customer reviews'
+  }
+]
+
+const value = ref('contacts')
+</script>
+
+<template>
+  <B24PageCardGroup
+    v-model="value"
+    :items="items"
+    color="air-primary-copilot"
+    columns="3"
+    category-key=""
+  />
+</template>

--- a/docs/content/docs/2.components/page-card-group.md
+++ b/docs/content/docs/2.components/page-card-group.md
@@ -70,6 +70,35 @@ Override the umbrella `color` for the corner [Badge](/docs/components/badge/) on
 
 Override the badge size derived from `size` with `badge-size`.
 
+### Icon vs Avatar
+
+Each item picks one of two leading visuals:
+
+- `icon` field — plain icon, no circle. Theme controls size via `leadingIcon`. Use this for compact, non-decorated lists.
+- `avatar` field — [B24Avatar](/docs/components/avatar/) with full color control (`color`, `src`, `chip`, `icon`). Avatar size is derived from the group `size` (`sm` → `lg`, `md` → `xl`, `lg` → `2xl`) and the avatar's `alt` falls back to the item's `label`.
+
+`icon` wins when both are set on the same item — the plain icon renders and `avatar` is ignored. Pick one per item:
+
+```ts
+// shows the icon via B24Avatar (color circle around the icon)
+{ avatar: { color: 'air-primary-warning', icon: FeedbackIcon }, label: 'Feedback' }
+
+// shows the plain icon only — `icon` at the top level takes precedence
+{ icon: FeedbackIcon, avatar: { color: 'air-primary-warning' }, label: 'Feedback' }
+```
+
+Set a group-level Avatar default that every avatar-mode item inherits:
+
+```vue
+<B24PageCardGroup v-model="value" :items="items" :avatar="{ color: 'air-secondary' }" />
+```
+
+Per-item `avatar` config merges on top of the group default:
+
+:component-example{name="page-card-group-avatar-example"}
+
+The `avatar` field accepts the full [B24Avatar](/docs/components/avatar/) API — same hook drives `src` (photo), `chip`, or a different `icon` per item.
+
 ### Category grouping
 
 When items contain a `category` field (or another field set via `category-key`), the group renders one section per category with a heading above each grid. Pass `category-key=""` to disable grouping.
@@ -139,12 +168,16 @@ Override the corner badge through the `badge` slot. Receives `{ item, selected }
 
 ### Custom leading icon
 
-Override the icon-in-circle through the `leading` slot. Receives `{ item, selected }`.
+The leading slot is an escape hatch for cases where the built-in [B24Avatar](/docs/components/avatar/) (driven by the `avatar` prop / item `avatar` field) isn't flexible enough. Override the icon circle through the `leading` slot — receives `{ item, selected }`.
 
 ```vue
 <B24PageCardGroup v-model="value" :items="items">
-  <template #leading="{ item }">
-    <B24Avatar :alt="item.label" :icon="item.icon" />
+  <template #leading="{ item, selected }">
+    <B24Avatar
+      :alt="item.label"
+      :icon="item.icon"
+      :color="selected ? 'air-primary' : 'air-secondary-no-accent'"
+    />
   </template>
 </B24PageCardGroup>
 ```

--- a/playgrounds/demo/app/pages/components/page-card-group.vue
+++ b/playgrounds/demo/app/pages/components/page-card-group.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import theme from '#build/b24ui/page-card-group'
 import pageCardTheme from '#build/b24ui/page-card'
+import avatarTheme from '#build/b24ui/avatar'
 import TelephonyHandset1Icon from '@bitrix24/b24icons-vue/main/TelephonyHandset1Icon'
 import MailIcon from '@bitrix24/b24icons-vue/main/MailIcon'
 import FeedbackIcon from '@bitrix24/b24icons-vue/main/FeedbackIcon'
@@ -8,8 +9,22 @@ import DocumentStreamIcon from '@bitrix24/b24icons-vue/main/DocumentStreamIcon'
 import CartWithCursorIcon from '@bitrix24/b24icons-vue/main/CartWithCursorIcon'
 import CreditDebitCardIcon from '@bitrix24/b24icons-vue/main/CreditDebitCardIcon'
 import PictureIcon from '@bitrix24/b24icons-vue/main/PictureIcon'
+import type { PageCardGroupItem, AvatarProps } from '@bitrix24/b24ui-nuxt'
 
-const items = [
+type AvatarColor = keyof typeof avatarTheme.variants.color
+
+// Per-item accent palette used when `Per-item palette` is on.
+const accentPalette: AvatarColor[] = [
+  'air-primary-success',
+  'air-primary-copilot',
+  'air-primary-warning',
+  'air-primary-alert',
+  'air-secondary-accent-1',
+  'air-secondary-accent-2',
+  'air-tertiary-accent'
+]
+
+const baseItems = [
   { value: 'callback', category: 'Customer communications', icon: TelephonyHandset1Icon, label: 'Callback', description: 'Capture the phone number and start a callback' },
   { value: 'contacts', category: 'Customer communications', icon: MailIcon, label: 'Contact details', description: 'Collect phone, email and client name' },
   { value: 'feedback', category: 'Customer communications', icon: FeedbackIcon, label: 'Feedback', description: 'Gather customer reviews' },
@@ -36,14 +51,41 @@ const sizes = Object.keys(theme.variants.size)
 const columns = Object.keys(theme.variants.columns)
 const variants = Object.keys(pageCardTheme.variants.variant)
 const colors = Object.keys(pageCardTheme.variants.highlightColor)
+const avatarColors = Object.keys(avatarTheme.variants.color) as AvatarColor[]
 
 const attrs = reactive({
   size: 'md' as keyof typeof theme.variants.size,
   variant: 'outline' as keyof typeof pageCardTheme.variants.variant,
   color: 'air-primary-success' as keyof typeof pageCardTheme.variants.highlightColor,
   columns: '3' as keyof typeof theme.variants.columns,
-  multiple: false
+  multiple: false,
+  // Avatar mode: when off, items keep top-level `icon` (plain icon, no circle).
+  // When on, the icon is moved into `avatar.icon` so PageCard renders B24Avatar.
+  avatarMode: true,
+  // Per-item palette: when on, each item gets its own `avatar.color` from the palette.
+  // When off, items expose `avatar.icon` only — the group `:avatar.color` drives them.
+  itemPalette: false,
+  // Group-level umbrella avatar color forwarded to `:avatar`. Per-item `avatar.color`
+  // wins on merge, so this is visible only when `itemPalette` is off.
+  avatarColor: 'air-secondary-accent-1' as AvatarColor | undefined
 })
+
+const items = computed<PageCardGroupItem[]>(() => {
+  if (!attrs.avatarMode) return baseItems as PageCardGroupItem[]
+
+  return baseItems.map((item, idx) => {
+    const { icon, ...rest } = item
+    const avatar: Partial<AvatarProps> = { icon }
+    if (attrs.itemPalette) {
+      avatar.color = accentPalette[idx % accentPalette.length]
+    }
+    return { ...rest, avatar } as PageCardGroupItem
+  })
+})
+
+const groupAvatar = computed<Partial<AvatarProps> | undefined>(() =>
+  attrs.avatarColor ? { color: attrs.avatarColor } : undefined
+)
 </script>
 
 <template>
@@ -54,6 +96,16 @@ const attrs = reactive({
       <B24Select v-model="attrs.color" class="w-44" :items="colors" placeholder="Color" size="xs" />
       <B24Select v-model="attrs.columns" class="w-24" :items="columns" placeholder="Columns" size="xs" />
       <B24Switch v-model="attrs.multiple" label="Multiple" size="xs" />
+      <B24Switch v-model="attrs.avatarMode" label="Avatar mode" size="xs" />
+      <B24Switch v-model="attrs.itemPalette" label="Item palette" size="xs" :disabled="!attrs.avatarMode" />
+      <B24Select
+        v-model="attrs.avatarColor"
+        class="w-52"
+        :items="avatarColors"
+        placeholder="Group avatar color"
+        size="xs"
+        :disabled="!attrs.avatarMode || attrs.itemPalette"
+      />
     </template>
 
     <B24PageCardGroup
@@ -64,6 +116,7 @@ const attrs = reactive({
       :variant="attrs.variant"
       :color="attrs.color"
       :columns="attrs.columns"
+      :avatar="groupAvatar"
     />
     <B24PageCardGroup
       v-else
@@ -74,7 +127,69 @@ const attrs = reactive({
       :variant="attrs.variant"
       :color="attrs.color"
       :columns="attrs.columns"
+      :avatar="groupAvatar"
     />
+
+    <hr class="my-8 border-(--ui-color-design-outline-stroke)">
+
+    <div class="flex flex-col gap-4">
+      <h3 class="font-(--ui-font-weight-semi-bold) text-(length:--ui-font-size-lg)/[normal]">
+        Per-item palette — each item brings its own avatar color
+      </h3>
+      <p class="text-(--ui-color-design-outline-content-secondary) text-(length:--ui-font-size-sm)/[normal]">
+        Items expose <code>avatar: {{ '{ color, icon }' }}</code> — per-item <code>color</code> wins over the group <code>:avatar.color</code>.
+      </p>
+      <B24PageCardGroup
+        v-model="single"
+        :items="baseItems.map((it, idx) => ({ ...it, icon: undefined, avatar: { icon: it.icon, color: accentPalette[idx % accentPalette.length] } }))"
+        :size="attrs.size"
+        :variant="attrs.variant"
+        :color="attrs.color"
+        :columns="attrs.columns"
+        category-key=""
+      />
+    </div>
+
+    <hr class="my-8 border-(--ui-color-design-outline-stroke)">
+
+    <div class="flex flex-col gap-4">
+      <h3 class="font-(--ui-font-weight-semi-bold) text-(length:--ui-font-size-lg)/[normal]">
+        Group avatar color — uniform branding via <code>:avatar</code>
+      </h3>
+      <p class="text-(--ui-color-design-outline-content-secondary) text-(length:--ui-font-size-sm)/[normal]">
+        Items expose only <code>avatar: {{ '{ icon }' }}</code> — color comes from the group prop.
+      </p>
+      <B24PageCardGroup
+        v-model="single"
+        :items="baseItems.map(it => ({ ...it, icon: undefined, avatar: { icon: it.icon } }))"
+        :size="attrs.size"
+        :variant="attrs.variant"
+        :color="attrs.color"
+        :columns="attrs.columns"
+        :avatar="{ color: 'air-primary-copilot' }"
+        category-key=""
+      />
+    </div>
+
+    <hr class="my-8 border-(--ui-color-design-outline-stroke)">
+
+    <div class="flex flex-col gap-4">
+      <h3 class="font-(--ui-font-weight-semi-bold) text-(length:--ui-font-size-lg)/[normal]">
+        Plain icon — no circle
+      </h3>
+      <p class="text-(--ui-color-design-outline-content-secondary) text-(length:--ui-font-size-sm)/[normal]">
+        Items use top-level <code>icon</code>. <code>icon</code> wins over <code>avatar</code>, so the leading visual is a flat icon (size scales with the group <code>size</code> prop).
+      </p>
+      <B24PageCardGroup
+        v-model="single"
+        :items="baseItems"
+        :size="attrs.size"
+        :variant="attrs.variant"
+        :color="attrs.color"
+        :columns="attrs.columns"
+        category-key=""
+      />
+    </div>
 
     <hr class="my-8 border-(--ui-color-design-outline-stroke)">
 

--- a/playgrounds/nuxt/app/pages/components/page-card-group.vue
+++ b/playgrounds/nuxt/app/pages/components/page-card-group.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import theme from '#build/b24ui/page-card-group'
 import pageCardTheme from '#build/b24ui/page-card'
+import avatarTheme from '#build/b24ui/avatar'
 import TelephonyHandset1Icon from '@bitrix24/b24icons-vue/main/TelephonyHandset1Icon'
 import MailIcon from '@bitrix24/b24icons-vue/main/MailIcon'
 import FeedbackIcon from '@bitrix24/b24icons-vue/main/FeedbackIcon'
@@ -8,8 +9,22 @@ import DocumentStreamIcon from '@bitrix24/b24icons-vue/main/DocumentStreamIcon'
 import CartWithCursorIcon from '@bitrix24/b24icons-vue/main/CartWithCursorIcon'
 import CreditDebitCardIcon from '@bitrix24/b24icons-vue/main/CreditDebitCardIcon'
 import PictureIcon from '@bitrix24/b24icons-vue/main/PictureIcon'
+import type { PageCardGroupItem, AvatarProps } from '@bitrix24/b24ui-nuxt'
 
-const items = [
+type AvatarColor = keyof typeof avatarTheme.variants.color
+
+// Per-item accent palette used when `Per-item palette` is on.
+const accentPalette: AvatarColor[] = [
+  'air-primary-success',
+  'air-primary-copilot',
+  'air-primary-warning',
+  'air-primary-alert',
+  'air-secondary-accent-1',
+  'air-secondary-accent-2',
+  'air-tertiary-accent'
+]
+
+const baseItems = [
   { value: 'callback', category: 'Customer communications', icon: TelephonyHandset1Icon, label: 'Callback', description: 'Capture the phone number and start a callback' },
   { value: 'contacts', category: 'Customer communications', icon: MailIcon, label: 'Contact details', description: 'Collect phone, email and client name' },
   { value: 'feedback', category: 'Customer communications', icon: FeedbackIcon, label: 'Feedback', description: 'Gather customer reviews' },
@@ -36,14 +51,41 @@ const sizes = Object.keys(theme.variants.size)
 const columns = Object.keys(theme.variants.columns)
 const variants = Object.keys(pageCardTheme.variants.variant)
 const colors = Object.keys(pageCardTheme.variants.highlightColor)
+const avatarColors = Object.keys(avatarTheme.variants.color) as AvatarColor[]
 
 const attrs = reactive({
   size: 'md' as keyof typeof theme.variants.size,
   variant: 'outline' as keyof typeof pageCardTheme.variants.variant,
   color: 'air-primary-success' as keyof typeof pageCardTheme.variants.highlightColor,
   columns: '3' as keyof typeof theme.variants.columns,
-  multiple: false
+  multiple: false,
+  // Avatar mode: when off, items keep top-level `icon` (plain icon, no circle).
+  // When on, the icon is moved into `avatar.icon` so PageCard renders B24Avatar.
+  avatarMode: true,
+  // Per-item palette: when on, each item gets its own `avatar.color` from the palette.
+  // When off, items expose `avatar.icon` only — the group `:avatar.color` drives them.
+  itemPalette: false,
+  // Group-level umbrella avatar color forwarded to `:avatar`. Per-item `avatar.color`
+  // wins on merge, so this is visible only when `itemPalette` is off.
+  avatarColor: 'air-secondary-accent-1' as AvatarColor | undefined
 })
+
+const items = computed<PageCardGroupItem[]>(() => {
+  if (!attrs.avatarMode) return baseItems as PageCardGroupItem[]
+
+  return baseItems.map((item, idx) => {
+    const { icon, ...rest } = item
+    const avatar: Partial<AvatarProps> = { icon }
+    if (attrs.itemPalette) {
+      avatar.color = accentPalette[idx % accentPalette.length]
+    }
+    return { ...rest, avatar } as PageCardGroupItem
+  })
+})
+
+const groupAvatar = computed<Partial<AvatarProps> | undefined>(() =>
+  attrs.avatarColor ? { color: attrs.avatarColor } : undefined
+)
 </script>
 
 <template>
@@ -54,6 +96,16 @@ const attrs = reactive({
       <B24Select v-model="attrs.color" class="w-44" :items="colors" placeholder="Color" size="xs" />
       <B24Select v-model="attrs.columns" class="w-24" :items="columns" placeholder="Columns" size="xs" />
       <B24Switch v-model="attrs.multiple" label="Multiple" size="xs" />
+      <B24Switch v-model="attrs.avatarMode" label="Avatar mode" size="xs" />
+      <B24Switch v-model="attrs.itemPalette" label="Item palette" size="xs" :disabled="!attrs.avatarMode" />
+      <B24Select
+        v-model="attrs.avatarColor"
+        class="w-52"
+        :items="avatarColors"
+        placeholder="Group avatar color"
+        size="xs"
+        :disabled="!attrs.avatarMode || attrs.itemPalette"
+      />
     </template>
 
     <B24PageCardGroup
@@ -64,6 +116,7 @@ const attrs = reactive({
       :variant="attrs.variant"
       :color="attrs.color"
       :columns="attrs.columns"
+      :avatar="groupAvatar"
     />
     <B24PageCardGroup
       v-else
@@ -74,7 +127,69 @@ const attrs = reactive({
       :variant="attrs.variant"
       :color="attrs.color"
       :columns="attrs.columns"
+      :avatar="groupAvatar"
     />
+
+    <hr class="my-8 border-(--ui-color-design-outline-stroke)">
+
+    <div class="flex flex-col gap-4">
+      <h3 class="font-(--ui-font-weight-semi-bold) text-(length:--ui-font-size-lg)/[normal]">
+        Per-item palette — each item brings its own avatar color
+      </h3>
+      <p class="text-(--ui-color-design-outline-content-secondary) text-(length:--ui-font-size-sm)/[normal]">
+        Items expose <code>avatar: {{ '{ color, icon }' }}</code> — per-item <code>color</code> wins over the group <code>:avatar.color</code>.
+      </p>
+      <B24PageCardGroup
+        v-model="single"
+        :items="baseItems.map((it, idx) => ({ ...it, icon: undefined, avatar: { icon: it.icon, color: accentPalette[idx % accentPalette.length] } }))"
+        :size="attrs.size"
+        :variant="attrs.variant"
+        :color="attrs.color"
+        :columns="attrs.columns"
+        category-key=""
+      />
+    </div>
+
+    <hr class="my-8 border-(--ui-color-design-outline-stroke)">
+
+    <div class="flex flex-col gap-4">
+      <h3 class="font-(--ui-font-weight-semi-bold) text-(length:--ui-font-size-lg)/[normal]">
+        Group avatar color — uniform branding via <code>:avatar</code>
+      </h3>
+      <p class="text-(--ui-color-design-outline-content-secondary) text-(length:--ui-font-size-sm)/[normal]">
+        Items expose only <code>avatar: {{ '{ icon }' }}</code> — color comes from the group prop.
+      </p>
+      <B24PageCardGroup
+        v-model="single"
+        :items="baseItems.map(it => ({ ...it, icon: undefined, avatar: { icon: it.icon } }))"
+        :size="attrs.size"
+        :variant="attrs.variant"
+        :color="attrs.color"
+        :columns="attrs.columns"
+        :avatar="{ color: 'air-primary-copilot' }"
+        category-key=""
+      />
+    </div>
+
+    <hr class="my-8 border-(--ui-color-design-outline-stroke)">
+
+    <div class="flex flex-col gap-4">
+      <h3 class="font-(--ui-font-weight-semi-bold) text-(length:--ui-font-size-lg)/[normal]">
+        Plain icon — no circle
+      </h3>
+      <p class="text-(--ui-color-design-outline-content-secondary) text-(length:--ui-font-size-sm)/[normal]">
+        Items use top-level <code>icon</code>. <code>icon</code> wins over <code>avatar</code>, so the leading visual is a flat icon (size scales with the group <code>size</code> prop).
+      </p>
+      <B24PageCardGroup
+        v-model="single"
+        :items="baseItems"
+        :size="attrs.size"
+        :variant="attrs.variant"
+        :color="attrs.color"
+        :columns="attrs.columns"
+        category-key=""
+      />
+    </div>
 
     <hr class="my-8 border-(--ui-color-design-outline-stroke)">
 

--- a/skills/b24-ui-nuxt/references/recipes/card-pickers.md
+++ b/skills/b24-ui-nuxt/references/recipes/card-pickers.md
@@ -85,8 +85,9 @@ The wrapping `<B24FormField>` keeps precedence over `<B24Theme :props>` defaults
 
 ## Sizing, color, and hover shadow
 
-- `size` (`sm` | `md` | `lg`) scales the icon circle, inner gap, and title/description font size. Default `md`.
+- `size` (`sm` | `md` | `lg`) scales the inner avatar, inner gap, and title/description font size. Default `md`.
 - `color` is the umbrella accent that drives both the highlighted card border and the corner badge — keep them in sync by setting `color` instead of `highlight-color` / `badge-color` separately.
+- Each item picks one leading visual: top-level `icon` field (plain icon, no circle) or `avatar` field (full `B24Avatar` — color, src, chip). `icon` wins when both are set, so move the icon into `avatar.icon` when you want the colored circle. Brand defaults group-wide with the `avatar` prop or per option via the item's `avatar` field — both accept the full Avatar API.
 - The card lifts with a subtle shadow on hover, unless the item or the whole group is `disabled`.
 
 ```vue
@@ -95,17 +96,32 @@ The wrapping `<B24FormField>` keeps precedence over `<B24Theme :props>` defaults
   :items="items"
   size="lg"
   color="air-primary-copilot"
+  :avatar="{ color: 'air-secondary' }"
   :columns="2"
 />
+```
+
+```ts
+// Avatar mode (colored circle around the icon) — keep the icon inside `avatar.icon`
+const items = [
+  { value: 'grid', avatar: { color: 'air-primary-success', icon: GridIcon }, label: 'Grid', description: '...' },
+  { value: 'list', avatar: { color: 'air-primary-warning', icon: ListIcon }, label: 'List', description: '...' }
+]
+
+// Plain-icon mode (no circle) — top-level `icon` wins, `avatar` (if any) is ignored
+const compact = [
+  { value: 'grid', icon: GridIcon, label: 'Grid', description: '...' },
+  { value: 'list', icon: ListIcon, label: 'List', description: '...' }
+]
 ```
 
 ## Custom slots
 
 `B24PageCardGroup` exposes overrides for the cases where the defaults are too rigid:
 
-- `#leading="{ item, selected }"` — replace the icon-in-circle (e.g. swap to `B24Avatar`).
+- `#leading="{ item, selected }"` — escape hatch for the leading visual. The default already renders a `B24Avatar`; reach for the slot only when the built-in avatar config (`avatar` prop / item `avatar` field) isn't enough.
 - `#badge="{ item, selected }"` — replace the corner check badge (e.g. show the price tag of the selected plan).
 - `#categoryLabel="{ category, items }"` — custom heading per section (counters, secondary text).
 - `#legend` — heading above the entire group.
 
-Theme slot overrides (`:b24ui="{ card: '...', cardWrapper: '...', iconWrap: '...' }"`) apply on top of the size/columns variants and are deep-merged automatically — see the proxy notes in [conventions](../guidelines/conventions.md).
+Theme slot overrides (`:b24ui="{ card: '...', cardWrapper: '...', avatar: '...' }"`) apply on top of the size/columns variants and are deep-merged automatically — see the proxy notes in [conventions](../guidelines/conventions.md).

--- a/src/runtime/components/PageCard.vue
+++ b/src/runtime/components/PageCard.vue
@@ -2,7 +2,7 @@
 import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/b24ui/page-card'
-import type { IconComponent, LinkProps } from '../types'
+import type { IconComponent, LinkProps, AvatarProps } from '../types'
 import type { ComponentConfig } from '../types/tv'
 
 type PageCard = ComponentConfig<typeof theme, AppConfig, 'pageCard'>
@@ -18,10 +18,16 @@ export interface PageCardProps {
    */
   as?: any
   /**
-   * The icon displayed above the title.
+   * The icon displayed above the title. Takes precedence over `avatar` — when both
+   * are set, only the plain icon is rendered.
    * @IconComponent
    */
   icon?: IconComponent
+  /**
+   * Render a `B24Avatar` in the leading position. Ignored when `icon` is set.
+   * Avatar size falls back to the theme's `leadingAvatarSize` slot.
+   */
+  avatar?: AvatarProps
   title?: string
   description?: string
   /**
@@ -71,6 +77,7 @@ import { useAppConfig } from '#imports'
 import { useComponentProps } from '../composables/useComponentProps'
 import { getSlotChildrenText } from '../utils'
 import { tv } from '../utils/tv'
+import B24Avatar from './Avatar.vue'
 import B24Link from './Link.vue'
 
 defineOptions({ inheritAttrs: false })
@@ -114,14 +121,26 @@ const ariaLabel = computed(() => {
     @click="props.onClick"
   >
     <div data-slot="container" :class="b24ui.container({ class: props.b24ui?.container })">
-      <div v-if="!!slots.header || (props.icon || !!slots.leading) || !!slots.body || (props.title || !!slots.title) || (props.description || !!slots.description) || !!slots.footer" data-slot="wrapper" :class="b24ui.wrapper({ class: props.b24ui?.wrapper })">
+      <div v-if="!!slots.header || (props.icon || props.avatar || !!slots.leading) || !!slots.body || (props.title || !!slots.title) || (props.description || !!slots.description) || !!slots.footer" data-slot="wrapper" :class="b24ui.wrapper({ class: props.b24ui?.wrapper })">
         <div v-if="!!slots.header" data-slot="header" :class="b24ui.header({ class: props.b24ui?.header })">
           <slot name="header" />
         </div>
 
-        <div v-if="props.icon || !!slots.leading" data-slot="leading" :class="b24ui.leading({ class: props.b24ui?.leading })">
+        <div v-if="props.icon || props.avatar || !!slots.leading" data-slot="leading" :class="b24ui.leading({ class: props.b24ui?.leading })">
           <slot name="leading" :b24ui="b24ui">
-            <Component :is="props.icon" v-if="props.icon" data-slot="leadingIcon" :class="b24ui.leadingIcon({ class: props.b24ui?.leadingIcon })" />
+            <Component
+              :is="props.icon"
+              v-if="props.icon"
+              data-slot="leadingIcon"
+              :class="b24ui.leadingIcon({ class: props.b24ui?.leadingIcon })"
+            />
+            <B24Avatar
+              v-else-if="!!props.avatar"
+              :size="((props.b24ui?.leadingAvatarSize || b24ui.leadingAvatarSize()) as AvatarProps['size'])"
+              v-bind="props.avatar"
+              data-slot="leadingAvatar"
+              :class="b24ui.leadingAvatar({ class: props.b24ui?.leadingAvatar })"
+            />
           </slot>
         </div>
 

--- a/src/runtime/components/PageCardGroup.vue
+++ b/src/runtime/components/PageCardGroup.vue
@@ -2,7 +2,7 @@
 import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/b24ui/page-card-group'
-import type { IconComponent, BadgeProps, PageCardProps } from '../types'
+import type { IconComponent, AvatarProps, BadgeProps, PageCardProps } from '../types'
 import type { AcceptableValue } from '../types/utils'
 import type { ComponentConfig } from '../types/tv'
 
@@ -13,7 +13,17 @@ export type PageCardGroupValue = AcceptableValue
 export interface PageCardGroupItem {
   label?: string
   description?: string
+  /**
+   * Plain icon shown in the leading position. Takes precedence over `avatar` —
+   * when both are set, the plain icon wins and Avatar is not rendered.
+   * @IconComponent
+   */
   icon?: IconComponent
+  /**
+   * Avatar config for the leading position. Used only when `icon` is not set.
+   * Merged on top of the group-level `avatar` prop.
+   */
+  avatar?: Partial<AvatarProps>
   value?: PageCardGroupValue
   disabled?: boolean
   category?: string
@@ -63,7 +73,7 @@ export interface PageCardGroupProps {
   required?: boolean
   name?: string
   /**
-   * Card size — drives the icon-circle, icon, gap and inner title/description text size.
+   * Card size — drives the inner avatar size, inner gap and title/description text size.
    * @defaultValue 'md'
    */
   size?: PageCardGroup['variants']['size']
@@ -91,6 +101,11 @@ export interface PageCardGroupProps {
    * from the group `size` when not set.
    */
   badgeSize?: BadgeProps['size']
+  /**
+   * Group-level Avatar defaults forwarded to every card whose item opts into avatar mode
+   * (`item.avatar` set or this prop set). Per-item `avatar` field merges on top.
+   */
+  avatar?: Partial<AvatarProps>
   /**
    * Max columns on desktop.
    * @defaultValue 3
@@ -180,14 +195,18 @@ const effectiveBadgeSize = computed<BadgeProps['size']>(() =>
 )
 
 // Slot-class overrides forwarded to the inner `B24PageCard` via its `b24ui` prop.
-// Layered over user-provided overrides (`props.b24ui?.cardX`).
+// Layered over user-provided overrides (`props.b24ui?.cardX`). `leadingAvatarSize`
+// is forwarded as a raw string (an `AvatarProps['size']` value, not a class).
 const innerCardUI = computed(() => ({
   container: b24ui.value.cardContainer({ class: props.b24ui?.cardContainer }),
   wrapper: b24ui.value.cardWrapper({ class: props.b24ui?.cardWrapper }),
   leading: b24ui.value.cardLeading({ class: props.b24ui?.cardLeading }),
   body: b24ui.value.cardBody({ class: props.b24ui?.cardBody }),
   title: b24ui.value.cardTitle({ class: props.b24ui?.cardTitle }),
-  description: b24ui.value.cardDescription({ class: props.b24ui?.cardDescription })
+  description: b24ui.value.cardDescription({ class: props.b24ui?.cardDescription }),
+  leadingIcon: b24ui.value.leadingIcon({ class: props.b24ui?.leadingIcon }),
+  leadingAvatar: b24ui.value.leadingAvatar({ class: props.b24ui?.leadingAvatar }),
+  leadingAvatarSize: (props.b24ui?.leadingAvatarSize as string) || b24ui.value.leadingAvatarSize()
 }))
 
 function getItemValue(item: PageCardGroupItem): PageCardGroupValue {
@@ -203,6 +222,24 @@ function isSelected(item: PageCardGroupItem): boolean {
     return Array.isArray(cur) && cur.includes(v)
   }
   return cur === v
+}
+
+function getItemIcon(item: PageCardGroupItem): IconComponent | undefined {
+  return get(item, props.iconKey!) as IconComponent | undefined
+}
+
+function getItemAvatar(item: PageCardGroupItem): AvatarProps | undefined {
+  // Plain `item.icon` wins — Avatar mode disabled when both are set.
+  if (getItemIcon(item)) return undefined
+
+  const itemAvatar = item.avatar
+  if (!itemAvatar && !props.avatar) return undefined
+
+  return {
+    ...props.avatar,
+    ...itemAvatar,
+    alt: (itemAvatar?.alt ?? (get(item, props.labelKey!) as string | undefined))
+  } as AvatarProps
 }
 
 function setValue(next: PageCardGroupValue | PageCardGroupValue[] | undefined, event: Event) {
@@ -299,6 +336,8 @@ const groupedItems = computed<{ category?: string, items: PageCardGroupItem[] }[
             <B24PageCard
               :title="get(item, props.labelKey!)"
               :description="get(item, props.descriptionKey!)"
+              :icon="getItemIcon(item)"
+              :avatar="getItemAvatar(item)"
               :variant="props.variant"
               orientation="vertical"
               :highlight="isSelected(item)"
@@ -306,12 +345,8 @@ const groupedItems = computed<{ category?: string, items: PageCardGroupItem[] }[
               :class="b24ui.card({ class: props.b24ui?.card })"
               :b24ui="innerCardUI"
             >
-              <template v-if="get(item, props.iconKey!) || !!slots.leading" #leading>
-                <slot name="leading" :item="item" :selected="isSelected(item)" :b24ui="b24ui">
-                  <span data-slot="iconWrap" :class="b24ui.iconWrap({ class: props.b24ui?.iconWrap })">
-                    <component :is="get(item, props.iconKey!)" data-slot="icon" :class="b24ui.icon({ class: props.b24ui?.icon })" />
-                  </span>
-                </slot>
+              <template v-if="!!slots.leading" #leading>
+                <slot name="leading" :item="item" :selected="isSelected(item)" :b24ui="b24ui" />
               </template>
 
               <template v-if="isSelected(item)">

--- a/src/theme/page-card-group.ts
+++ b/src/theme/page-card-group.ts
@@ -3,11 +3,18 @@
  * A selectable group of PageCard items. Supports single (radio) and multi (checkbox) selection,
  * optional grouping by category, responsive grid layout, and a corner badge for the selected state.
  *
+ * The leading visual of every card is rendered by the inner `B24PageCard`:
+ *  - If the item has a plain `icon` field — it wins, rendered as-is (legacy path).
+ *  - Otherwise the inner card renders a `B24Avatar` (group `avatar` prop merged with the item's
+ *    `avatar` field). Avatar size is driven by `leadingAvatarSize` (a value, not a CSS class)
+ *    which the size variant forwards into `PageCard`'s `b24ui` slot.
+ *
  * The `card*` slots are forwarded to the inner `B24PageCard` via its `b24ui` prop and override
  * PageCard's own slot classes — this is what produces the icon-on-the-left layout (PageCard
  * defaults to a vertical wrapper).
  * ---
  * @see src/theme/page-card.ts
+ * @see src/theme/avatar.ts
  */
 export default {
   slots: {
@@ -26,33 +33,37 @@ export default {
     cardBody: 'flex-1 min-w-0',
     cardTitle: '',
     cardDescription: '',
-    iconWrap: 'inline-flex items-center justify-center rounded-full bg-(--ui-color-design-tinted-a1-bg) shrink-0',
-    icon: 'text-(--ui-color-design-tinted-a1-content-icon)',
+    leadingIcon: '',
+    leadingAvatar: '',
+    // Avatar size **value** (not a class). Size variant supplies it — keep base empty
+    // so `b24ui.leadingAvatarSize()` returns the variant value verbatim (e.g. `lg`),
+    // not the concatenated `'lg lg'` which would miss the Avatar size variant lookup.
+    leadingAvatarSize: '',
     badge: 'absolute -top-2 -end-2 z-10',
     badgeIcon: 'rounded-full'
   },
   variants: {
     size: {
       sm: {
-        iconWrap: 'size-10',
-        icon: 'size-5',
         cardWrapper: 'gap-2.5',
         cardTitle: 'text-(length:--ui-font-size-base)/[normal]',
-        cardDescription: 'text-(length:--ui-font-size-sm)/[normal]'
+        cardDescription: 'text-(length:--ui-font-size-sm)/[normal]',
+        leadingIcon: 'size-7 shrink-0',
+        leadingAvatarSize: 'sm'
       },
       md: {
-        iconWrap: 'size-12',
-        icon: 'size-6',
         cardWrapper: 'gap-3',
         cardTitle: 'text-(length:--ui-font-size-lg)/[normal]',
-        cardDescription: 'text-(length:--ui-font-size-base)/[normal]'
+        cardDescription: 'text-(length:--ui-font-size-base)/[normal]',
+        leadingIcon: 'size-8 shrink-0',
+        leadingAvatarSize: 'md'
       },
       lg: {
-        iconWrap: 'size-14',
-        icon: 'size-7',
         cardWrapper: 'gap-4',
         cardTitle: 'text-(length:--ui-font-size-xl)/[normal]',
-        cardDescription: 'text-(length:--ui-font-size-base)/[normal]'
+        cardDescription: 'text-(length:--ui-font-size-base)/[normal]',
+        leadingIcon: 'size-10 shrink-0',
+        leadingAvatarSize: 'lg'
       }
     },
     columns: {

--- a/src/theme/page-card.ts
+++ b/src/theme/page-card.ts
@@ -14,6 +14,8 @@ export default {
     footer: 'pt-4 mt-auto',
     leading: 'inline-flex items-center mb-2.5',
     leadingIcon: 'size-5 shrink-0',
+    leadingAvatar: 'shrink-0',
+    leadingAvatarSize: 'xl',
     title: 'text-(length:--ui-font-size-2xl)/[normal] text-pretty font-(--ui-font-weight-semi-bold)',
     description: 'text-(length:--ui-font-size-lg)/[normal] text-pretty'
   },


### PR DESCRIPTION
## Summary

- `PageCard` gains an `avatar` prop — renders `B24Avatar` in the leading slot; top-level `icon` keeps precedence (mirrors `Button.vue`). Theme adds `leadingAvatar` + `leadingAvatarSize` slots.
- `PageCardGroup` items accept a full `avatar` config (color, src, chip, icon) plus a group-level `:avatar` umbrella default; per-item `avatar.color` merges over the group default. Plain top-level `icon` still works and now scales with `size` via new `leadingIcon` size variants.
- Avatar/icon sizing per `size`: `sm` → 28px, `md` → 32px, `lg` → 42px. Bug fix: previous `'xl'` base for `leadingAvatarSize` concatenated with size-variant value into an invalid `'xl xl'` Avatar size and collapsed the avatar to 0×0.
- Docs: new "Icon vs Avatar" section, dedicated `PageCardGroupAvatarExample` per-item palette demo, "Custom leading icon" repositioned as the escape hatch.
- Playgrounds (demo + nuxt): split per-item-palette and group-avatar-color controls so toggling either actually re-renders (per-item color wins on merge — disables the group picker when the palette is on); static showcases for per-item palette, group-level avatar color, plain-icon mode.
- Skill recipe (card-pickers) updated for icon-vs-avatar choice and merge rules.

## Test plan

- [x] `vitest run` — 212 files / 4852 tests pass
- [x] `nuxt typecheck` clean for `docs`, `playgrounds/demo`, `playgrounds/nuxt`
- [x] `eslint` clean on changed files
- [x] Inline snapshot test verified avatar renders with correct size class (`size-7`/`size-8`/`size-10.5`) per group `size`
- [x] Inline snapshot test verified plain-icon path renders with synced size (`size-7`/`size-8`/`size-10`) per group `size`
- [ ] Visual smoke in playgrounds — toggle `Avatar mode`, `Item palette`, `Group avatar color`; verify both the palette and group-color paths actually update the rendered grid

🤖 Generated with [Claude Code](https://claude.com/claude-code)