### PR TITLE
feat(EditorMentionMenu): add item.color forwarded to leading Avatar

### DIFF
--- a/docs/content/docs/2.components/editor-mention-menu.md
+++ b/docs/content/docs/2.components/editor-mention-menu.md
@@ -45,6 +45,7 @@ Use the `items` prop as an array of objects with the following properties:
 
 - `label: string`{lang="ts-type"}
 - `avatar?: AvatarProps`{lang="ts-type"}
+- `color?: AvatarProps['color']`{lang="ts-type"}
 - `icon?: IconComponent`{lang="ts-type"}
 - `description?: string`{lang="ts-type"}
 - `disabled?: boolean`{lang="ts-type"}

--- a/src/runtime/components/EditorMentionMenu.vue
+++ b/src/runtime/components/EditorMentionMenu.vue
@@ -15,6 +15,10 @@ export interface EditorMentionMenuItem {
    */
   icon?: IconComponent
   avatar?: AvatarProps
+  /**
+   * Default `color` for the item's leading `B24Avatar`. Overridden by `avatar.color` when set.
+   */
+  color?: AvatarProps['color']
   disabled?: boolean
   class?: any
   [key: string]: any
@@ -93,7 +97,7 @@ onMounted(async () => {
       item.icon
         ? h(item.icon, { class: styles.value.itemLeadingIcon() })
         : item.avatar
-          ? h(B24Avatar, { ...item.avatar, size: styles.value.itemLeadingAvatarSize(), class: styles.value.itemLeadingAvatar() })
+          ? h(B24Avatar, { color: item.color, ...item.avatar, size: styles.value.itemLeadingAvatarSize(), class: styles.value.itemLeadingAvatar() })
           : null,
       h('span', { class: styles.value.itemWrapper() }, [
         h('span', { class: styles.value.itemLabel() }, item.label),


### PR DESCRIPTION
## Summary

- Adds `color?: AvatarProps['color']` to `EditorMentionMenuItem`.
- Forwards it as the default `color` to the item's leading `B24Avatar`. Explicit `item.avatar.color` still wins, since the avatar object is spread after `color` in the `h(B24Avatar, ...)` call.
- No host-level color is introduced — `src/theme/editor-mention-menu.ts` is untouched. The new prop only tints the inner Avatar.
- Particularly useful for @mention UX where roles, statuses, or other per-user signals are conveyed by avatar tint.

Follow-up to #24 (Avatar/AvatarGroup `color`), #27 (User), #28 (ChatMessage), #29 (Alert), #30 (Toast), #31 (Timeline), #32 (NavigationMenu), #33 (Tabs), #34 (CommandPalette).

## Test plan

- [ ] `pnpm run lint` / `pnpm run typecheck` pass (no test file exists for `EditorMentionMenu` — it renders inside the editor only)
- [ ] Verify in editor playground that per-item `color` tints the mention-menu avatar
- [ ] Verify explicit `item.avatar.color` overrides the cascade

🤖 Generated with [Claude Code](https://claude.com/claude-code)