### PR TITLE
feat(Error): add avatar and color props alongside icon

### DIFF
--- a/docs/content/docs/2.components/error.md
+++ b/docs/content/docs/2.components/error.md
@@ -67,6 +67,57 @@ props:
 ---
 ::
 
+### Avatar :badge{label="Soon" class="align-text-top"}
+
+Use the `avatar` prop to display an [Avatar](/docs/components/avatar/) above the status code (used only when `icon` is not set).
+
+::component-code
+---
+prettier: true
+hide:
+  - class
+ignore:
+  - avatar.src
+  - error.statusCode
+  - error.statusMessage
+  - error.message
+props:
+  avatar:
+    src: 'https://github.com/bitrix24.png'
+  error:
+    statusCode: 404
+    statusMessage: 'Page not found'
+    message: 'The page you are looking for does not exist.'
+  class: '!min-h-96'
+---
+::
+
+### Color :badge{label="Soon" class="align-text-top"}
+
+Use the `color` prop to tint the inner [Avatar](/docs/components/avatar/). An explicit `avatar.color` overrides this default.
+
+::component-code
+---
+prettier: true
+hide:
+  - class
+ignore:
+  - avatar.src
+  - error.statusCode
+  - error.statusMessage
+  - error.message
+props:
+  color: 'air-primary-alert'
+  avatar:
+    src: 'https://github.com/bitrix24.png'
+  error:
+    statusCode: 404
+    statusMessage: 'Page not found'
+    message: 'The page you are looking for does not exist.'
+  class: '!min-h-96'
+---
+::
+
 Use the `#leading` slot to display a custom element, such as a logo.
 
 ::component-code

--- a/docs/content/docs/2.components/error.md
+++ b/docs/content/docs/2.components/error.md
@@ -106,6 +106,25 @@ ignore:
   - error.statusCode
   - error.statusMessage
   - error.message
+items:
+  color:
+    - air-primary
+    - air-primary-success
+    - air-primary-alert
+    - air-primary-copilot
+    - air-primary-warning
+    - air-primary-no-accent
+    - air-secondary
+    - air-secondary-alert
+    - air-secondary-accent
+    - air-secondary-accent-1
+    - air-secondary-accent-2
+    - air-secondary-no-accent
+    - air-tertiary
+    - air-tertiary-accent
+    - air-tertiary-no-accent
+    - air-selection
+    - air-boost
 props:
   color: 'air-primary-alert'
   avatar:

--- a/src/runtime/components/Error.vue
+++ b/src/runtime/components/Error.vue
@@ -3,7 +3,7 @@ import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import type { NuxtError } from '#app'
 import theme from '#build/b24ui/error'
-import type { ButtonProps, IconComponent } from '../types'
+import type { AvatarProps, ButtonProps, IconComponent } from '../types'
 import type { ComponentConfig } from '../types/tv'
 
 type Error = ComponentConfig<typeof theme, AppConfig, 'error'>
@@ -19,6 +19,15 @@ export interface ErrorProps {
    * @IconComponent
    */
   icon?: IconComponent
+  /**
+   * The avatar displayed above the status code.
+   * Used only when `icon` is not set.
+   */
+  avatar?: AvatarProps
+  /**
+   * Default `color` for the inner `B24Avatar`. Overridden by `avatar.color` when set.
+   */
+  color?: AvatarProps['color']
   error?: Partial<NuxtError & { message: string }>
   /**
    * The URL to redirect to when the error is cleared.
@@ -52,6 +61,7 @@ import { clearError, useAppConfig } from '#imports'
 import { useComponentProps } from '../composables/useComponentProps'
 import { useLocale } from '../composables/useLocale'
 import { tv } from '../utils/tv'
+import B24Avatar from './Avatar.vue'
 import B24Button from './Button.vue'
 
 const _props = withDefaults(defineProps<ErrorProps>(), {
@@ -76,9 +86,17 @@ function handleError() {
 
 <template>
   <Primitive :as="props.as" data-slot="root" :class="b24ui.root({ class: [props.b24ui?.root, props.class] })">
-    <div v-if="props.icon || !!slots.leading" data-slot="leading" :class="b24ui.leading({ class: props.b24ui?.leading })">
+    <div v-if="props.icon || props.avatar || !!slots.leading" data-slot="leading" :class="b24ui.leading({ class: props.b24ui?.leading })">
       <slot name="leading" :b24ui="b24ui">
         <Component :is="props.icon" v-if="props.icon" data-slot="leadingIcon" :class="b24ui.leadingIcon({ class: props.b24ui?.leadingIcon })" />
+        <B24Avatar
+          v-else-if="!!props.avatar"
+          :size="((props.b24ui?.leadingAvatarSize || b24ui.leadingAvatarSize()) as AvatarProps['size'])"
+          :color="props.color"
+          v-bind="props.avatar"
+          data-slot="leadingAvatar"
+          :class="b24ui.leadingAvatar({ class: props.b24ui?.leadingAvatar })"
+        />
       </slot>
     </div>
     <p v-if="!!props.error?.statusCode || !!props.error?.status || !!slots.statusCode" data-slot="statusCode" :class="b24ui.statusCode({ class: props.b24ui?.statusCode })">

--- a/src/theme/error.ts
+++ b/src/theme/error.ts
@@ -8,6 +8,8 @@ export default {
     root: 'min-h-[calc(100vh-var(--topbar-height))] flex flex-col items-center justify-center text-center',
     leading: 'mb-4 flex items-center justify-center',
     leadingIcon: 'size-10 shrink-0 text-legend',
+    leadingAvatar: 'shrink-0',
+    leadingAvatarSize: 'lg',
     statusCode: 'text-(length:--ui-font-size-sm) font-(--ui-font-weight-semi-bold) text-legend',
     statusMessage: 'mt-2 text-(length:--ui-font-size-4xl)/(--ui-font-line-height-md) sm:text-(length:--ui-font-size-5xl)/(--ui-font-line-height-md) font-(--ui-font-weight-bold) text-label text-balance',
     message: 'mt-4 text-(length:--ui-font-size-2xl)/(--ui-font-line-height-md) text-description text-balance',

--- a/test/components/Error.spec.ts
+++ b/test/components/Error.spec.ts
@@ -25,6 +25,8 @@ describe('Error', () => {
     ['with error', { props }],
     ['with error using status/statusText', { props: { error: errorWithStatus } }],
     ['with icon', { props: { ...props, icon: Search2Icon } }],
+    ['with avatar', { props: { ...props, avatar: { src: 'https://github.com/bitrix24.png' } } }],
+    ['with color and avatar', { props: { ...props, color: 'air-primary-alert' as const, avatar: { src: 'https://github.com/bitrix24.png' } } }],
     ['with redirect', { props: { ...props, redirect: '/blog' } }],
     ['with clear', { props: { ...props, clear: { label: 'Home' } } }],
     ['with as', { props: { ...props, as: 'section' } }],

--- a/test/components/__snapshots__/Error-vue.spec.ts.snap
+++ b/test/components/__snapshots__/Error-vue.spec.ts.snap
@@ -16,6 +16,22 @@ exports[`Error > renders with as correctly 1`] = `
 </section>"
 `;
 
+exports[`Error > renders with avatar correctly 1`] = `
+"<main data-slot="root" class="min-h-[calc(100vh-var(--topbar-height))] flex flex-col items-center justify-center text-center">
+  <div data-slot="leading" class="mb-4 flex items-center justify-center"><span data-slot="root" class="air-secondary-accent inline-flex items-center justify-center select-none rounded-full align-middle bg-(--b24ui-background) ring ring-(--b24ui-border-color) style-outline-no-accent size-10.5 text-(length:--ui-font-size-2xl)/(--ui-font-line-height-reset) shrink-0"><img src="https://github.com/bitrix24.png" data-slot="image" class="h-full w-full rounded-[inherit] object-cover"></span></div>
+  <p data-slot="statusCode" class="text-(length:--ui-font-size-sm) font-(--ui-font-weight-semi-bold) text-legend">404</p>
+  <h1 data-slot="statusMessage" class="mt-2 text-(length:--ui-font-size-4xl)/(--ui-font-line-height-md) sm:text-(length:--ui-font-size-5xl)/(--ui-font-line-height-md) font-(--ui-font-weight-bold) text-label text-balance">Not Found</h1>
+  <p data-slot="message" class="mt-4 text-(length:--ui-font-size-2xl)/(--ui-font-line-height-md) text-description text-balance">The page you are looking for does not exist.</p>
+  <div data-slot="links" class="mt-8 flex items-center justify-center gap-6"><button type="button" data-slot="base" class="ui-btn font-[family-name:var(--ui-font-family-primary)] select-none cursor-pointer inline-flex items-center relative outline-transparent focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed aria-disabled:cursor-not-allowed disabled:opacity-30 aria-disabled:opacity-30 transition duration-0 ease-linear border-(length:--ui-btn-border-width) text-(--ui-btn-color) bg-(--ui-btn-background) border-(--ui-btn-border-color) hover:text-(--ui-btn-color-hover) hover:bg-(--ui-btn-background-hover) hover:border-(--ui-btn-border-color-hover) focus:text-(--ui-btn-color-hover) focus:bg-(--ui-btn-background-hover) focus:border-(--ui-btn-border-color-hover) active:text-(--ui-btn-color-active) active:bg-(--ui-btn-background-active) active:border-(--ui-btn-border-color-active) disabled:bg-(--ui-btn-background) disabled:border-(--ui-btn-border-color) aria-disabled:bg-(--ui-btn-background) aria-disabled:border-(--ui-btn-border-color) focus-visible:outline-(--ui-btn-background) ring-(--ui-btn-background-hover) focus:outline-none focus-visible:ring-(--ui-btn-background-hover) h-(--ui-btn-height) text-(length:--ui-btn-font-size) leading-(--ui-btn-height) font-(--ui-btn-font-weight) --style-filled ui-btn-lg rounded-(--ui-btn-radius) normal-case --air">
+      <!--v-if-->
+      <div data-slot="baseLine" class="w-full inline-flex items-center justify-center gap-(--ui-btn-icon-space) ps-(--ui-btn-padding-left) pe-(--ui-btn-padding-right) h-(--ui-btn-height)">
+        <!--v-if--><span data-slot="label" class="h-(--ui-btn-height) max-w-full inline-flex flex-row items-center tracking-(--ui-btn-letter-spacing) overflow-visible text-clip"><span data-slot="labelInner" class="truncate inline-block max-w-full mt-(--ui-btn-title-compensation)">Try again</span></span>
+        <!--v-if-->
+      </div>
+    </button></div>
+</main>"
+`;
+
 exports[`Error > renders with b24ui correctly 1`] = `
 "<main data-slot="root" class="min-h-[calc(100vh-var(--topbar-height))] flex flex-col items-center justify-center text-center">
   <!--v-if-->
@@ -58,6 +74,22 @@ exports[`Error > renders with clear correctly 1`] = `
       <!--v-if-->
       <div data-slot="baseLine" class="w-full inline-flex items-center justify-center gap-(--ui-btn-icon-space) ps-(--ui-btn-padding-left) pe-(--ui-btn-padding-right) h-(--ui-btn-height)">
         <!--v-if--><span data-slot="label" class="h-(--ui-btn-height) max-w-full inline-flex flex-row items-center tracking-(--ui-btn-letter-spacing) overflow-visible text-clip"><span data-slot="labelInner" class="truncate inline-block max-w-full mt-(--ui-btn-title-compensation)">Home</span></span>
+        <!--v-if-->
+      </div>
+    </button></div>
+</main>"
+`;
+
+exports[`Error > renders with color and avatar correctly 1`] = `
+"<main data-slot="root" class="min-h-[calc(100vh-var(--topbar-height))] flex flex-col items-center justify-center text-center">
+  <div data-slot="leading" class="mb-4 flex items-center justify-center"><span data-slot="root" class="air-secondary-accent inline-flex items-center justify-center select-none rounded-full align-middle bg-(--b24ui-background) ring ring-(--b24ui-border-color) style-filled-alert size-10.5 text-(length:--ui-font-size-2xl)/(--ui-font-line-height-reset) shrink-0"><img src="https://github.com/bitrix24.png" data-slot="image" class="h-full w-full rounded-[inherit] object-cover"></span></div>
+  <p data-slot="statusCode" class="text-(length:--ui-font-size-sm) font-(--ui-font-weight-semi-bold) text-legend">404</p>
+  <h1 data-slot="statusMessage" class="mt-2 text-(length:--ui-font-size-4xl)/(--ui-font-line-height-md) sm:text-(length:--ui-font-size-5xl)/(--ui-font-line-height-md) font-(--ui-font-weight-bold) text-label text-balance">Not Found</h1>
+  <p data-slot="message" class="mt-4 text-(length:--ui-font-size-2xl)/(--ui-font-line-height-md) text-description text-balance">The page you are looking for does not exist.</p>
+  <div data-slot="links" class="mt-8 flex items-center justify-center gap-6"><button type="button" data-slot="base" class="ui-btn font-[family-name:var(--ui-font-family-primary)] select-none cursor-pointer inline-flex items-center relative outline-transparent focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed aria-disabled:cursor-not-allowed disabled:opacity-30 aria-disabled:opacity-30 transition duration-0 ease-linear border-(length:--ui-btn-border-width) text-(--ui-btn-color) bg-(--ui-btn-background) border-(--ui-btn-border-color) hover:text-(--ui-btn-color-hover) hover:bg-(--ui-btn-background-hover) hover:border-(--ui-btn-border-color-hover) focus:text-(--ui-btn-color-hover) focus:bg-(--ui-btn-background-hover) focus:border-(--ui-btn-border-color-hover) active:text-(--ui-btn-color-active) active:bg-(--ui-btn-background-active) active:border-(--ui-btn-border-color-active) disabled:bg-(--ui-btn-background) disabled:border-(--ui-btn-border-color) aria-disabled:bg-(--ui-btn-background) aria-disabled:border-(--ui-btn-border-color) focus-visible:outline-(--ui-btn-background) ring-(--ui-btn-background-hover) focus:outline-none focus-visible:ring-(--ui-btn-background-hover) h-(--ui-btn-height) text-(length:--ui-btn-font-size) leading-(--ui-btn-height) font-(--ui-btn-font-weight) --style-filled ui-btn-lg rounded-(--ui-btn-radius) normal-case --air">
+      <!--v-if-->
+      <div data-slot="baseLine" class="w-full inline-flex items-center justify-center gap-(--ui-btn-icon-space) ps-(--ui-btn-padding-left) pe-(--ui-btn-padding-right) h-(--ui-btn-height)">
+        <!--v-if--><span data-slot="label" class="h-(--ui-btn-height) max-w-full inline-flex flex-row items-center tracking-(--ui-btn-letter-spacing) overflow-visible text-clip"><span data-slot="labelInner" class="truncate inline-block max-w-full mt-(--ui-btn-title-compensation)">Try again</span></span>
         <!--v-if-->
       </div>
     </button></div>

--- a/test/components/__snapshots__/Error.spec.ts.snap
+++ b/test/components/__snapshots__/Error.spec.ts.snap
@@ -16,6 +16,22 @@ exports[`Error > renders with as correctly 1`] = `
 </section>"
 `;
 
+exports[`Error > renders with avatar correctly 1`] = `
+"<main data-slot="root" class="min-h-[calc(100vh-var(--topbar-height))] flex flex-col items-center justify-center text-center">
+  <div data-slot="leading" class="mb-4 flex items-center justify-center"><span data-slot="root" class="air-secondary-accent inline-flex items-center justify-center select-none rounded-full align-middle bg-(--b24ui-background) ring ring-(--b24ui-border-color) style-outline-no-accent size-10.5 text-(length:--ui-font-size-2xl)/(--ui-font-line-height-reset) shrink-0"><img src="https://github.com/bitrix24.png" data-slot="image" class="h-full w-full rounded-[inherit] object-cover"></span></div>
+  <p data-slot="statusCode" class="text-(length:--ui-font-size-sm) font-(--ui-font-weight-semi-bold) text-legend">404</p>
+  <h1 data-slot="statusMessage" class="mt-2 text-(length:--ui-font-size-4xl)/(--ui-font-line-height-md) sm:text-(length:--ui-font-size-5xl)/(--ui-font-line-height-md) font-(--ui-font-weight-bold) text-label text-balance">Not Found</h1>
+  <p data-slot="message" class="mt-4 text-(length:--ui-font-size-2xl)/(--ui-font-line-height-md) text-description text-balance">The page you are looking for does not exist.</p>
+  <div data-slot="links" class="mt-8 flex items-center justify-center gap-6"><button type="button" data-slot="base" class="ui-btn font-[family-name:var(--ui-font-family-primary)] select-none cursor-pointer inline-flex items-center relative outline-transparent focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed aria-disabled:cursor-not-allowed disabled:opacity-30 aria-disabled:opacity-30 transition duration-0 ease-linear border-(length:--ui-btn-border-width) text-(--ui-btn-color) bg-(--ui-btn-background) border-(--ui-btn-border-color) hover:text-(--ui-btn-color-hover) hover:bg-(--ui-btn-background-hover) hover:border-(--ui-btn-border-color-hover) focus:text-(--ui-btn-color-hover) focus:bg-(--ui-btn-background-hover) focus:border-(--ui-btn-border-color-hover) active:text-(--ui-btn-color-active) active:bg-(--ui-btn-background-active) active:border-(--ui-btn-border-color-active) disabled:bg-(--ui-btn-background) disabled:border-(--ui-btn-border-color) aria-disabled:bg-(--ui-btn-background) aria-disabled:border-(--ui-btn-border-color) focus-visible:outline-(--ui-btn-background) ring-(--ui-btn-background-hover) focus:outline-none focus-visible:ring-(--ui-btn-background-hover) h-(--ui-btn-height) text-(length:--ui-btn-font-size) leading-(--ui-btn-height) font-(--ui-btn-font-weight) --style-filled ui-btn-lg rounded-(--ui-btn-radius) normal-case --air">
+      <!--v-if-->
+      <div data-slot="baseLine" class="w-full inline-flex items-center justify-center gap-(--ui-btn-icon-space) ps-(--ui-btn-padding-left) pe-(--ui-btn-padding-right) h-(--ui-btn-height)">
+        <!--v-if--><span data-slot="label" class="h-(--ui-btn-height) max-w-full inline-flex flex-row items-center tracking-(--ui-btn-letter-spacing) overflow-visible text-clip"><span data-slot="labelInner" class="truncate inline-block max-w-full mt-(--ui-btn-title-compensation)">Try again</span></span>
+        <!--v-if-->
+      </div>
+    </button></div>
+</main>"
+`;
+
 exports[`Error > renders with b24ui correctly 1`] = `
 "<main data-slot="root" class="min-h-[calc(100vh-var(--topbar-height))] flex flex-col items-center justify-center text-center">
   <!--v-if-->
@@ -58,6 +74,22 @@ exports[`Error > renders with clear correctly 1`] = `
       <!--v-if-->
       <div data-slot="baseLine" class="w-full inline-flex items-center justify-center gap-(--ui-btn-icon-space) ps-(--ui-btn-padding-left) pe-(--ui-btn-padding-right) h-(--ui-btn-height)">
         <!--v-if--><span data-slot="label" class="h-(--ui-btn-height) max-w-full inline-flex flex-row items-center tracking-(--ui-btn-letter-spacing) overflow-visible text-clip"><span data-slot="labelInner" class="truncate inline-block max-w-full mt-(--ui-btn-title-compensation)">Home</span></span>
+        <!--v-if-->
+      </div>
+    </button></div>
+</main>"
+`;
+
+exports[`Error > renders with color and avatar correctly 1`] = `
+"<main data-slot="root" class="min-h-[calc(100vh-var(--topbar-height))] flex flex-col items-center justify-center text-center">
+  <div data-slot="leading" class="mb-4 flex items-center justify-center"><span data-slot="root" class="air-secondary-accent inline-flex items-center justify-center select-none rounded-full align-middle bg-(--b24ui-background) ring ring-(--b24ui-border-color) style-filled-alert size-10.5 text-(length:--ui-font-size-2xl)/(--ui-font-line-height-reset) shrink-0"><img src="https://github.com/bitrix24.png" data-slot="image" class="h-full w-full rounded-[inherit] object-cover"></span></div>
+  <p data-slot="statusCode" class="text-(length:--ui-font-size-sm) font-(--ui-font-weight-semi-bold) text-legend">404</p>
+  <h1 data-slot="statusMessage" class="mt-2 text-(length:--ui-font-size-4xl)/(--ui-font-line-height-md) sm:text-(length:--ui-font-size-5xl)/(--ui-font-line-height-md) font-(--ui-font-weight-bold) text-label text-balance">Not Found</h1>
+  <p data-slot="message" class="mt-4 text-(length:--ui-font-size-2xl)/(--ui-font-line-height-md) text-description text-balance">The page you are looking for does not exist.</p>
+  <div data-slot="links" class="mt-8 flex items-center justify-center gap-6"><button type="button" data-slot="base" class="ui-btn font-[family-name:var(--ui-font-family-primary)] select-none cursor-pointer inline-flex items-center relative outline-transparent focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed aria-disabled:cursor-not-allowed disabled:opacity-30 aria-disabled:opacity-30 transition duration-0 ease-linear border-(length:--ui-btn-border-width) text-(--ui-btn-color) bg-(--ui-btn-background) border-(--ui-btn-border-color) hover:text-(--ui-btn-color-hover) hover:bg-(--ui-btn-background-hover) hover:border-(--ui-btn-border-color-hover) focus:text-(--ui-btn-color-hover) focus:bg-(--ui-btn-background-hover) focus:border-(--ui-btn-border-color-hover) active:text-(--ui-btn-color-active) active:bg-(--ui-btn-background-active) active:border-(--ui-btn-border-color-active) disabled:bg-(--ui-btn-background) disabled:border-(--ui-btn-border-color) aria-disabled:bg-(--ui-btn-background) aria-disabled:border-(--ui-btn-border-color) focus-visible:outline-(--ui-btn-background) ring-(--ui-btn-background-hover) focus:outline-none focus-visible:ring-(--ui-btn-background-hover) h-(--ui-btn-height) text-(length:--ui-btn-font-size) leading-(--ui-btn-height) font-(--ui-btn-font-weight) --style-filled ui-btn-lg rounded-(--ui-btn-radius) normal-case --air">
+      <!--v-if-->
+      <div data-slot="baseLine" class="w-full inline-flex items-center justify-center gap-(--ui-btn-icon-space) ps-(--ui-btn-padding-left) pe-(--ui-btn-padding-right) h-(--ui-btn-height)">
+        <!--v-if--><span data-slot="label" class="h-(--ui-btn-height) max-w-full inline-flex flex-row items-center tracking-(--ui-btn-letter-spacing) overflow-visible text-clip"><span data-slot="labelInner" class="truncate inline-block max-w-full mt-(--ui-btn-title-compensation)">Try again</span></span>
         <!--v-if-->
       </div>
     </button></div>


### PR DESCRIPTION
## Summary

Aligns `B24Error` with the canonical **Embedded Avatar** pattern documented in `.github/contributing/component-structure.md` (§Components with Embedded Avatar). The plain `icon` keeps precedence — `avatar` is the `v-else-if` fallback, same as `Button`, `ChatMessage`, `Badge`, `Input`, `Select`, `Tabs`, `Countdown`, `PageCard`, `PageCardGroup`.

- Adds `avatar?: AvatarProps` (rendered only when `icon` is not set).
- Adds `color?: AvatarProps['color']` that tints the inner `B24Avatar` by default. Explicit `avatar.color` still wins, since `v-bind="props.avatar"` is applied after `:color="props.color"`.
- Theme exposes two new slots:
  - `leadingAvatar` (CSS classes)
  - `leadingAvatarSize` (value slot, base `'lg'`). Error has no `size` variant, so the value lives in the slot base per the value-slot rule in `.github/contributing/theme-structure.md`.

Follow-up to #24 (Avatar/AvatarGroup `color`) and #40bdf842 (`feat(Error): add icon prop and leading slot`).

## Test plan

- [ ] `pnpm run lint` / `pnpm run typecheck` / `pnpm run test` pass
- [ ] New `renders with avatar correctly` and `renders with color and avatar correctly` snapshots witness the cascade (default → `style-outline-no-accent`, `air-primary-alert` → `style-filled-alert`)
- [ ] Verify in docs page → Error → Avatar / Color sections that the cascade renders correctly
- [ ] Verify explicit `avatar.color` overrides the cascade

🤖 Generated with [Claude Code](https://claude.com/claude-code)