### PR TITLE
docs(contributing): note when items.color is required

### DIFF
--- a/.github/contributing/documentation.md
+++ b/.github/contributing/documentation.md
@@ -276,6 +276,18 @@ slots:
 ::
 ```
 
+::note
+**Required when the prop type is referenced from another component**
+(e.g. `color?: AvatarProps['color']`). The docs generator resolves the
+palette from the host theme's own `variants.color`, so a prop typed via
+another component cannot auto-fill the dropdown. Spell the items out
+under `items.color` to render the selector.
+
+See [`docs/content/docs/2.components/user.md`](../../docs/content/docs/2.components/user.md) and
+[`docs/content/docs/2.components/error.md`](../../docs/content/docs/2.components/error.md) for
+canonical usage in their `### Color` sections.
+::
+
 ## Component Examples
 
 For complex examples with setup code:


### PR DESCRIPTION
## Summary

Documents the edge case discovered while landing #36 (Error) and applied to #27 (User): when a component prop is typed via another component (e.g. `color?: AvatarProps['color']`), the docs generator cannot resolve the palette from the host theme's `variants.color`, and the dropdown ends up empty. The fix is to declare `items.color` explicitly in the `::component-code` block.

Adds a `::note` block right after the existing `### Dropdown Items` example in `.github/contributing/documentation.md`, with pointers to the canonical fixes already in `docs/content/docs/2.components/user.md` and `docs/content/docs/2.components/error.md`.

## Test plan

- [ ] Skim the rendered contributing page — the note appears under `### Dropdown Items`
- [ ] No code / theme / test changes; lint / typecheck / test are no-ops

🤖 Generated with [Claude Code](https://claude.com/claude-code)