### PR TITLE
chore(release): v2.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,44 @@
 # Changelog
 
+## [2.8.0](https://github.com/bitrix24/b24ui/compare/v2.7.1...v2.8.0) (2026-05-20)
+
+### Features
+
+* **Avatar/AvatarGroup:** add `color` prop
+* **Breadcrumb:** add `color` prop
+* **ChatMessage:** add `color` prop and `header` slot
+* **Error:** add `icon` prop and `leading` slot
+* **Error:** add `avatar` and `color` props alongside icon
+* **CommandPalette:** search and highlight `description` field
+* **ContentSearch/DashboardSearch:** enable Fuse.js token search by default
+* **DashboardGroup:** add `storageOptions` prop
+* **PageCard/PageCardGroup:** add `avatar` prop with Button.vue pattern
+
+### Bug Fixes
+
+* **ProsePrompt:** type `icon` prop as `IconComponent`
+* **ProsePrompt:** preserve copy formatting and centralize icon registry
+* **ProsePrompt:** preserve line breaks and lists when copying prompt
+* **CommandPalette:** preserve relative order of `ignoreFilter` groups
+* **CommandPalette:** only split tokens in highlight when `useTokenSearch` is enabled
+* **CommandPalette:** update default fuse keys in docs and search components
+* **defineShortcuts:** use `e.code` for alt shortcuts to handle macOS key remapping
+* **useComponentProps:** treat array-typed theme values as `ClassValue` leaves
+* **module:** don't require `@nuxtjs/mdc` when using `content` option
+
+### Docs
+
+* **Modal:** host the Sales dynamics widget in a Modal; add marketing/promo composition example
+* **Card/Popover:** add Sales dynamics widget recipe and entity-info popover example
+* **contributing:** note when `items.color` is required; document embedded-Avatar pattern and value slots
+* remove stale "Soon" badges and coming-soon notes
+
+### Chore
+
+* **ci:** add CI workflow and gate npm publish on it
+* **deps:** update all non-major dependencies (tailwindcss `^4.3.0`, reka-ui `2.9.7`, vue-tsc `^3.2.8`)
+* **tests:** update snapshots
+
 ## [2.7.1](https://github.com/bitrix24/b24ui/compare/v2.7.0...v2.7.1) (2026-05-08)
 
 ### Features

--- a/docs/content/docs/2.components/avatar-group.md
+++ b/docs/content/docs/2.components/avatar-group.md
@@ -75,7 +75,7 @@ slots:
 :b24-avatar{src="/b24ui/avatar/assistant.png" alt="Assistant Name" loading="lazy"}
 ::
 
-### Color :badge{label="Soon" class="align-text-top"}
+### Color
 
 Use the `color` prop to change the color of all the avatars.
 

--- a/docs/content/docs/2.components/avatar.md
+++ b/docs/content/docs/2.components/avatar.md
@@ -125,7 +125,7 @@ props:
 The `alt` prop is passed to the `img` element as the `alt` attribute.
 ::
 
-### Color :badge{label="Soon" class="align-text-top"}
+### Color
 
 Use the `color` prop to change the color of the Avatar.
 

--- a/docs/content/docs/2.components/breadcrumb.md
+++ b/docs/content/docs/2.components/breadcrumb.md
@@ -101,7 +101,7 @@ props:
 ---
 ::
 
-### Color :badge{label="Soon" class="align-text-top"}
+### Color
 
 Use the `color` prop to change the color of the active Breadcrumb.
 

--- a/docs/content/docs/2.components/chat-message.md
+++ b/docs/content/docs/2.components/chat-message.md
@@ -119,7 +119,7 @@ props:
 When using the [`ChatMessages`](/docs/components/chat-messages/) component, the `variant` prop is set to `message` for `assistant` messages and `message` for `user` messages.
 ::
 
-### Color :badge{label="Soon" class="align-text-top"}
+### Color
 
 Use the `color` prop to change the color of the message.
 

--- a/docs/content/docs/2.components/error.md
+++ b/docs/content/docs/2.components/error.md
@@ -40,7 +40,7 @@ props:
 ---
 ::
 
-### Icon :badge{label="Soon" class="align-text-top"}
+### Icon
 
 Use the `icon` prop to display an icon above the status code.
 
@@ -67,7 +67,7 @@ props:
 ---
 ::
 
-### Avatar :badge{label="Soon" class="align-text-top"}
+### Avatar
 
 Use the `avatar` prop to display an [Avatar](/docs/components/avatar/) above the status code (used only when `icon` is not set).
 
@@ -92,7 +92,7 @@ props:
 ---
 ::
 
-### Color :badge{label="Soon" class="align-text-top"}
+### Color
 
 Use the `color` prop to tint the inner [Avatar](/docs/components/avatar/). An explicit `avatar.color` overrides this default.
 

--- a/docs/content/docs/2.components/modal.md
+++ b/docs/content/docs/2.components/modal.md
@@ -472,7 +472,7 @@ name: 'modal-footer-slot-example'
 ---
 ::
 
-### Marketing / promo composition :badge{label="Soon" class="align-text-top"}
+### Marketing / promo composition
 
 Compose a promo/upgrade modal from existing components — no new component needed. The body uses a responsive 2-column flex (heading + description on the left, a feature card on the right), the footer pairs a primary CTA with a tertiary "remind me later" action. The decorative background is a Tailwind gradient utility passed through `b24ui.body`.
 

--- a/docs/content/docs/2.components/separator.md
+++ b/docs/content/docs/2.components/separator.md
@@ -60,7 +60,7 @@ props:
 ---
 ::
 
-### Position :badge{label="Soon" class="align-text-top"}
+### Position
 
 Use the `position` prop to change the position of the content of the Separator. Defaults to `center`.
 

--- a/docs/content/docs/2.components/theme.md
+++ b/docs/content/docs/2.components/theme.md
@@ -32,7 +32,7 @@ name: 'theme-ui-example'
 ---
 ::
 
-### Prop defaults :badge{label="Soon" class="align-text-top"}
+### Prop defaults
 
 Use the `props` prop to override the default value of any prop on descendant components. Each key maps to a partial of that component's props.
 

--- a/docs/content/docs/4.typography/field-group.md
+++ b/docs/content/docs/4.typography/field-group.md
@@ -20,7 +20,7 @@ Group fields together in a list.
 ::field-group{class="my-0"}
 
   ::field{name="analytics" type="boolean"}
-  Default to `false` - Enables analytics for your project (coming soon).
+  Default to `false` - Enables analytics for your project.
   ::
 
   ::field{name="blob" type="boolean"}
@@ -42,7 +42,7 @@ Group fields together in a list.
 ```mdc
 ::field-group
   ::field{name="analytics" type="boolean"}
-    Default to `false` - Enables analytics for your project (coming soon).
+    Default to `false` - Enables analytics for your project.
   ::
 
   ::field{name="blob" type="boolean"}

--- a/docs/content/docs/4.typography/prompt.md
+++ b/docs/content/docs/4.typography/prompt.md
@@ -9,7 +9,6 @@ links:
   - label: Nuxt UI
     iconName: NuxtIcon
     to: https://ui.nuxt.com/docs/typography/prompt
-navigation.badge: Soon
 ---
 
 ## Usage

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bitrix24/b24ui-nuxt",
   "description": "Bitrix24 UI-Kit for developing web applications REST API for NUXT & VUE",
-  "version": "2.7.1",
+  "version": "2.8.0",
   "packageManager": "pnpm@10.33.4",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

Minor release **v2.8.0** — bumps `package.json` to `2.8.0` and documents everything landed since `v2.7.1`.

Includes the docs cleanup commit (`docs: remove stale "Soon" badges and coming-soon notes`), since those badges marked features that now ship in this release.

### Features
- **Avatar/AvatarGroup**, **Breadcrumb**, **ChatMessage** — `color` prop (+ `header` slot on ChatMessage)
- **Error** — `icon`/`avatar`/`color` props and `leading` slot
- **CommandPalette** — search & highlight `description` field
- **ContentSearch/DashboardSearch** — Fuse.js token search on by default
- **DashboardGroup** — `storageOptions` prop
- **PageCard/PageCardGroup** — `avatar` prop

### Bug Fixes
- **ProsePrompt** — `icon` typed as `IconComponent`; preserve copy formatting / line breaks / lists; centralized icon registry
- **CommandPalette** — preserve `ignoreFilter` group order; token-split only with `useTokenSearch`; default fuse keys
- **defineShortcuts** — use `e.code` for alt shortcuts (macOS remapping)
- **useComponentProps** — array-typed theme values treated as `ClassValue` leaves
- **module** — `@nuxtjs/mdc` no longer required when using `content` option

### Docs / Chore
- Modal / Card / Popover — Sales dynamics widget recipes & examples
- contributing notes; removed stale "Soon" badges
- CI workflow gating npm publish; dependency updates (tailwindcss `^4.3.0`, reka-ui `2.9.7`, vue-tsc `^3.2.8`); snapshot updates

## Test plan
- [ ] CI green (lint / typecheck / test / build)
- [ ] `CHANGELOG.md` 2.8.0 section reads correctly
- [ ] `package.json` version is `2.8.0`

https://claude.ai/code/session_01ReWfWJcdNVZNYH5p5VpoJa

---
_Generated by [Claude Code](https://claude.ai/code/session_01ReWfWJcdNVZNYH5p5VpoJa)_