### PR TITLE
chore(sync): no-op — nuxt/ui@d50c121 (Icon recursion fix)

### DIFF
--- a/.sync/log/d50c121c05372082a7414d205d612513e89d3af7.md
+++ b/.sync/log/d50c121c05372082a7414d205d612513e89d3af7.md
@@ -1,0 +1,11 @@
+# no-op — nuxt/ui@d50c121c05372082a7414d205d612513e89d3af7
+
+**Upstream:** fix(Icon): avoid recursive icon resolution (#6495)
+
+**Decision:** no-op (not applicable to b24ui).
+
+**Rationale:** The upstream fix swaps `<Icon>` for `<NuxtIcon>` inside nuxt/ui's
+`src/runtime/components/Icon.vue`, which wraps `@nuxt/icon` (iconify name
+resolution). b24ui has no `Icon.vue` and no iconify-name resolver — icons are
+imported as Vue components from `@bitrix24/b24icons-vue`. There is no equivalent
+recursion to fix.


### PR DESCRIPTION
## Live sync — commit 1/20 (oldest first)

First commit in the live port of nuxt/ui v4 commits since v4.8.0. This one is a **no-op** (ledger entry only — no code change).

**Upstream:** [`d50c121c05`](https://github.com/nuxt/ui/commit/d50c121c05372082a7414d205d612513e89d3af7) — fix(Icon): avoid recursive icon resolution (#6495)

**Why no-op:** the upstream fix swaps `<Icon>` → `<NuxtIcon>` inside nuxt/ui's `Icon.vue` (a wrapper over `@nuxt/icon`'s iconify name resolver). **b24ui has no `Icon.vue` and no iconify resolver** — icons are imported as Vue components from `@bitrix24/b24icons-vue`. Nothing to port.

Adds only `.sync/log/<sha>.md` recording the decision (per `.sync/PLAN.md` no-op handling). Quick approve to advance.

<!-- upstream-sha: d50c121c05372082a7414d205d612513e89d3af7 -->

https://claude.ai/code/session_01Qz7EXMncvEGiCj4WbmYgJo

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qz7EXMncvEGiCj4WbmYgJo)_