### PR TITLE
docs(design-system): mention Tailwind CSS v4 cursor change on buttons

### DIFF
--- a/docs/content/docs/1.getting-started/5.theme/1.design-system.md
+++ b/docs/content/docs/1.getting-started/5.theme/1.design-system.md
@@ -24,6 +24,20 @@ Tailwind CSS uses a CSS-first configuration, letting you define your design toke
 Check the Tailwind CSS documentation for all available theme variable customization options.
 ::
 
+::tip
+Tailwind CSS v4 changed its [Preflight](https://tailwindcss.com/docs/upgrade-guide#buttons-use-the-default-cursor) so that buttons use `cursor: default` instead of `cursor: pointer` to match browser defaults. If you'd like to restore the pointer cursor globally, add these base styles to your CSS:
+
+```css [app/assets/css/main.css]
+@layer base {
+  button:not(:disabled),
+  [role="button"]:not(:disabled) {
+    cursor: pointer;
+  }
+}
+```
+
+::
+
 ### Breakpoints
 
 Use the `--breakpoint-*` theme variables to [customize your breakpoints](https://tailwindcss.com/docs/responsive-design#customizing-your-theme).


### PR DESCRIPTION
## Live sync — commit 3/76 (docs)

**Upstream:** [`6102a87b`](https://github.com/nuxt/ui/commit/6102a87b) — docs(design-system): mention Tailwind CSS v4 cursor change on buttons

First commit after the corrected baseline `e6ea707b` (your last manual port: feat(Error) icon/leading slot). Adds the upstream `::tip` to b24ui's **design-system** page: Tailwind v4 Preflight uses `cursor: default` on buttons; documents how to restore the pointer cursor globally.

- Ported near-verbatim; same `app/assets/css/main.css` convention b24ui already uses on that page.
- Placed after the Tailwind theme note, before "Breakpoints" (matching upstream's relative position).
- Docs-only; CI validates the docs build.

<!-- upstream-sha: 6102a87b -->

---

### ⚠️ Important re-baseline note
The real sync cursor is **`e6ea707b`** (12.05), not v4.8.0 — so there are **76** upstream commits to work through (not 46). Already done out-of-order earlier: `2799fa6f` (#68 autocomplete→mode), `d50c121` (#69), `631f5dc` (#70). From here I proceed **strictly oldest-first** from `e6ea707b`, including docs, skipping those three.

https://claude.ai/code/session_01Qz7EXMncvEGiCj4WbmYgJo

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qz7EXMncvEGiCj4WbmYgJo)_