### PR TITLE
fix(CommandPalette): re-highlight first item after debounced results render

### DIFF
--- a/.sync/log/efd7b8ecc9fdbc75077c3ee6076f94fa4fa753f1.md
+++ b/.sync/log/efd7b8ecc9fdbc75077c3ee6076f94fa4fa753f1.md
@@ -1,0 +1,22 @@
+# port — nuxt/ui@efd7b8ecc9fdbc75077c3ee6076f94fa4fa753f1
+
+**Upstream:** fix(CommandPalette): re-highlight first item after debounced results render
+
+**Decision:** port (applied 1:1).
+
+**Rationale:** b24ui's `CommandPalette.vue` mirrors upstream structure — it already
+has `filteredGroups`, `filteredItems`, `rootRef` (`useTemplateRef`) and calls
+`rootRef.value?.highlightFirstItem()` from `navigate` / `navigateBack`. The only
+gap was the reactive re-highlight after the debounced (`refDebounced`) results
+re-render. Applied the identical fix:
+
+- add `watch, nextTick` to the `vue` import;
+- `watch(filteredGroups, () => nextTick(() => rootRef.value?.highlightFirstItem()))`
+  placed right after `const rootRef = useTemplateRef('rootRef')`.
+
+**b24ui divergence:** none — the change is framework-level (reka-ui Listbox), no
+icon / color / `b24ui`-prop adaptation needed.
+
+**Validation:** eslint (CommandPalette) · typecheck · full `vitest run` (no `-u`).
+The watch is non-immediate, so it does not fire on initial mount → render
+snapshots unchanged.

--- a/.sync/nuxt-ui.json
+++ b/.sync/nuxt-ui.json
@@ -2,12 +2,49 @@
   "upstream": "nuxt/ui",
   "branch": "v4",
   "sync_enabled": false,
-  "cursor": null,
-  "_cursor_note": "Bootstrap: set to the nuxt/ui v4 SHA matching current b24ui state (~tag v4.8.0) before enabling. sync_enabled stays false until Phase 2 is wired.",
+  "cursor": "efd7b8ecc9fdbc75077c3ee6076f94fa4fa753f1",
+  "_cursor_note": "cursor = last upstream commit ported into b24ui (oldest-first, manual cadence). sync_enabled stays false until Phase 2 (porter workflow #67 + CLAUDE_CODE_OAUTH_TOKEN) is wired and trusted. `processed` is maintained per port from now on (backfilled #68-#72 on 2026-06-09).",
   "stats": {
     "queue_depth": 0,
     "noop_ratio": 0,
     "avg_pr_age_hours": 0
   },
-  "processed": {}
+  "processed": {
+    "2799fa6f2b25ce3eb15e050f3ef7c57d0d9a2fdb": {
+      "pr": 68,
+      "b24ui_sha": "081a9799",
+      "decision": "port",
+      "summary": "fix(InputMenu)!: rename `autocomplete` prop to `mode`"
+    },
+    "d50c121c05372082a7414d205d612513e89d3af7": {
+      "pr": 69,
+      "b24ui_sha": "1044c945",
+      "decision": "no-op",
+      "summary": "fix(Icon): avoid recursive icon resolution — n/a (b24ui has no Icon.vue/iconify resolver)"
+    },
+    "631f5dc543fecaa36d5090a10a3db3223e9671b5": {
+      "pr": 70,
+      "b24ui_sha": "e92fdc35",
+      "decision": "port",
+      "summary": "fix(ContentSearch/DashboardSearch): proxy missing CommandPalette props"
+    },
+    "6102a87b93233c9ddef2b7706efd803babac2fe1": {
+      "pr": 71,
+      "b24ui_sha": "77314c8e",
+      "decision": "port",
+      "summary": "docs(design-system): mention Tailwind CSS v4 cursor change on buttons"
+    },
+    "007b136a257d03270dff7f7aaf8ab884827ea045": {
+      "pr": 72,
+      "b24ui_sha": "5da53b6b",
+      "decision": "port",
+      "summary": "fix(components)!: constrain popper content to available viewport height"
+    },
+    "efd7b8ecc9fdbc75077c3ee6076f94fa4fa753f1": {
+      "pr": null,
+      "b24ui_sha": "pending-merge",
+      "decision": "port",
+      "summary": "fix(CommandPalette): re-highlight first item after debounced results render"
+    }
+  }
 }

--- a/src/runtime/components/CommandPalette.vue
+++ b/src/runtime/components/CommandPalette.vue
@@ -226,7 +226,7 @@ export type CommandPaletteSlots<T extends CommandPaletteItem = CommandPaletteIte
 </script>
 
 <script setup lang="ts" generic="G extends CommandPaletteGroup<T>, T extends CommandPaletteItem">
-import { computed, ref, useTemplateRef, toRef } from 'vue'
+import { computed, ref, useTemplateRef, toRef, watch, nextTick } from 'vue'
 import { ListboxRoot, ListboxFilter, ListboxContent, ListboxGroup, ListboxGroupLabel, ListboxVirtualizer, ListboxItem, ListboxItemIndicator } from 'reka-ui'
 import { defu } from 'defu'
 import { reactivePick, createReusableTemplate, refDebounced, refThrottled } from '@vueuse/core'
@@ -447,6 +447,12 @@ const filteredGroups = computed(() => {
 const filteredItems = computed(() => filteredGroups.value.flatMap(group => group.items || []))
 
 const rootRef = useTemplateRef('rootRef')
+
+watch(filteredGroups, () => {
+  nextTick(() => {
+    rootRef.value?.highlightFirstItem()
+  })
+})
 
 function navigate(item: T) {
   if (!item.children?.length) {


### PR DESCRIPTION
## Live sync — next commit in queue

**Upstream:** [`efd7b8ec`](https://github.com/nuxt/ui/commit/efd7b8ecc9fdbc75077c3ee6076f94fa4fa753f1) — fix(CommandPalette): re-highlight first item after debounced results render

Immediate next commit after `007b136a` (#72) in the oldest-first queue.

### What & why
b24ui's `CommandPalette.vue` already mirrors the upstream structure — `filteredGroups`, `filteredItems`, `rootRef` (`useTemplateRef`), and `rootRef.value?.highlightFirstItem()` calls in `navigate` / `navigateBack`. The only gap was re-highlighting the first item **after the debounced (`refDebounced`) results re-render**. Applied the fix **1:1** with upstream:

```diff
-import { computed, ref, useTemplateRef, toRef } from 'vue'
+import { computed, ref, useTemplateRef, toRef, watch, nextTick } from 'vue'
 ...
 const rootRef = useTemplateRef('rootRef')
+
+watch(filteredGroups, () => {
+  nextTick(() => {
+    rootRef.value?.highlightFirstItem()
+  })
+})
```

**b24ui divergence:** none — framework-level (reka-ui Listbox), no icon/color/`b24ui`-prop adaptation. Not a breaking change.

### Ledger maintenance (resolves drift from #75 §1)
Now that ports advance per-commit, this PR also starts maintaining `.sync/`:
- `.sync/nuxt-ui.json`: `cursor` → `efd7b8ec`, `processed` backfilled for #68–#72.
- `.sync/log/efd7b8ec….md`: decision record for this port.

`sync_enabled` stays `false` (automation Phase 2 / #67 not live yet).

### Validation (linux verify script; windows .ps1 below in chat)
- ✅ `dev:prepare` · ✅ `eslint` · ✅ `typecheck`
- ✅ CommandPalette spec (86 passed) · ✅ full `pnpm exec vitest run` (no `-u`) **4886 passed | 6 skipped**
- Snapshots unchanged by construction: the `watch` is non-immediate, so it does not fire on initial mount.

https://claude.ai/code/session_01Qz7EXMncvEGiCj4WbmYgJo

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qz7EXMncvEGiCj4WbmYgJo)_