### PR TITLE
feat(ChatPrompt): add `submitOnEnter` prop to control Enter behavior

### DIFF
--- a/.sync/log/b597f909aa9f4b12f3c732ec75f52226bcf88c2e.md
+++ b/.sync/log/b597f909aa9f4b12f3c732ec75f52226bcf88c2e.md
@@ -1,0 +1,23 @@
+# port — nuxt/ui@b597f909aa9f4b12f3c732ec75f52226bcf88c2e
+
+**Upstream:** feat(ChatPrompt): add `submitOnEnter` prop to control Enter behavior (resolves nuxt/ui#6177)
+
+**Decision:** port (applied 1:1).
+
+**Rationale:** b24ui's `ChatPrompt.vue` mirrors upstream — same `useIMEGuard`
+(`onEnter` / `onCompositionEnd`) and the `@keydown.enter` handler on the inner
+textarea. Added the new prop and gating handler identically:
+
+- `submitOnEnter?: boolean` prop (JSDoc), default `true` in `withDefaults`.
+- `handleEnter(event)`: when `submitOnEnter` → ignore if any modifier held;
+  when `false` → submit only on Ctrl/Cmd+Enter (Enter inserts a newline).
+- template: `@keydown.enter.exact="onEnter"` → `@keydown.enter="handleEnter"`.
+- docs note + 3 behavioral specs (Enter no-submit / Ctrl+Enter / Meta+Enter).
+
+**b24ui divergence:** only the prop name on the slots type stays `b24ui` (vs
+upstream `ui`) — that is the existing library-wide rename, not introduced here.
+No icon/color adaptation needed.
+
+**Validation:** eslint · typecheck · full `vitest run` (no `-u`). New tests are
+behavioral (event emission), not snapshots; existing snapshots unchanged
+(no template class/structure change beyond the event binding).

--- a/.sync/nuxt-ui.json
+++ b/.sync/nuxt-ui.json
@@ -2,7 +2,7 @@
   "upstream": "nuxt/ui",
   "branch": "v4",
   "sync_enabled": false,
-  "cursor": "efd7b8ecc9fdbc75077c3ee6076f94fa4fa753f1",
+  "cursor": "b597f909aa9f4b12f3c732ec75f52226bcf88c2e",
   "_cursor_note": "cursor = last upstream commit ported into b24ui (oldest-first, manual cadence). sync_enabled stays false until Phase 2 (porter workflow #67 + CLAUDE_CODE_OAUTH_TOKEN) is wired and trusted. `processed` is maintained per port from now on (backfilled #68-#72 on 2026-06-09).",
   "stats": {
     "queue_depth": 0,
@@ -41,10 +41,16 @@
       "summary": "fix(components)!: constrain popper content to available viewport height"
     },
     "efd7b8ecc9fdbc75077c3ee6076f94fa4fa753f1": {
+      "pr": 76,
+      "b24ui_sha": "d9debe3e",
+      "decision": "port",
+      "summary": "fix(CommandPalette): re-highlight first item after debounced results render"
+    },
+    "b597f909aa9f4b12f3c732ec75f52226bcf88c2e": {
       "pr": null,
       "b24ui_sha": "pending-merge",
       "decision": "port",
-      "summary": "fix(CommandPalette): re-highlight first item after debounced results render"
+      "summary": "feat(ChatPrompt): add `submitOnEnter` prop to control Enter behavior"
     }
   }
 }

--- a/docs/content/docs/2.components/chat-prompt.md
+++ b/docs/content/docs/2.components/chat-prompt.md
@@ -60,7 +60,7 @@ items:
 ::note
 The ChatPrompt handles the following events:
 
-- The form is submitted when the user presses :kbd{value="enter"} or when the user clicks on the submit button.
+- The form is submitted when the user presses :kbd{value="enter"} or when the user clicks on the submit button. Set the `submit-on-enter` prop to `false` to submit with :kbd{value="ctrl"} + :kbd{value="enter"} (or :kbd{value="cmd"} + :kbd{value="enter"} on macOS) instead, allowing :kbd{value="enter"} to insert a newline.
 - The textarea is blurred when :kbd{value="escape"} is pressed and emits a `close` event.
 ::
 

--- a/src/runtime/components/ChatPrompt.vue
+++ b/src/runtime/components/ChatPrompt.vue
@@ -22,6 +22,12 @@ export interface ChatPromptProps extends Pick<TextareaProps, 'rows' | 'autofocus
    * @defaultValue 'outline'
    */
   variant?: ChatPrompt['variants']['variant']
+  /**
+   * When `true`, pressing `Enter` submits and `Shift+Enter` inserts a newline.
+   * When `false`, pressing `Enter` inserts a newline and `Ctrl+Enter` / `Cmd+Enter` submits.
+   * @defaultValue true
+   */
+  submitOnEnter?: boolean
   error?: Error
   class?: any
   b24ui?: ChatPrompt['slots'] & TextareaProps['b24ui']
@@ -59,7 +65,8 @@ const _props = withDefaults(defineProps<ChatPromptProps>(), {
   as: 'form',
   autofocus: true,
   autoresize: true,
-  rows: 1
+  rows: 1,
+  submitOnEnter: true
 })
 const emits = defineEmits<ChatPromptEmits>()
 const slots = defineSlots<ChatPromptSlots>()
@@ -100,6 +107,16 @@ const { onKeydown: onEnter, onCompositionEnd } = useIMEGuard((event) => {
   submit(event)
 })
 
+function handleEnter(event: KeyboardEvent) {
+  if (props.submitOnEnter) {
+    if (event.shiftKey || event.ctrlKey || event.metaKey || event.altKey) return
+  } else {
+    if (!event.ctrlKey && !event.metaKey) return
+  }
+
+  onEnter(event)
+}
+
 defineExpose({
   textareaRef: toRef(() => textareaRef.value?.textareaRef)
 })
@@ -122,7 +139,7 @@ defineExpose({
       :b24ui="transformUI(omit(b24ui, ['root', 'body', 'header', 'footer']), props.b24ui)"
       data-slot="body"
       :class="b24ui.body({ class: props.b24ui?.body })"
-      @keydown.enter.exact="onEnter"
+      @keydown.enter="handleEnter"
       @compositionend="onCompositionEnd"
       @keydown.esc="blur"
     >

--- a/test/components/ChatPrompt.spec.ts
+++ b/test/components/ChatPrompt.spec.ts
@@ -72,6 +72,39 @@ describe('ChatPrompt', () => {
     vi.useRealTimers()
   })
 
+  it('does not emit submit on Enter when submitOnEnter is false', async () => {
+    const wrapper = await mountSuspended(ChatPrompt, {
+      props: { modelValue: 'Hello', submitOnEnter: false }
+    })
+
+    const textarea = wrapper.find('textarea')
+    await textarea.trigger('keydown', { key: 'Enter' })
+
+    expect(wrapper.emitted('submit')).toBeUndefined()
+  })
+
+  it('emits submit on Ctrl+Enter when submitOnEnter is false', async () => {
+    const wrapper = await mountSuspended(ChatPrompt, {
+      props: { modelValue: 'Hello', submitOnEnter: false }
+    })
+
+    const textarea = wrapper.find('textarea')
+    await textarea.trigger('keydown', { key: 'Enter', ctrlKey: true })
+
+    expect(wrapper.emitted('submit')).toHaveLength(1)
+  })
+
+  it('emits submit on Meta+Enter when submitOnEnter is false', async () => {
+    const wrapper = await mountSuspended(ChatPrompt, {
+      props: { modelValue: 'Hello', submitOnEnter: false }
+    })
+
+    const textarea = wrapper.find('textarea')
+    await textarea.trigger('keydown', { key: 'Enter', metaKey: true })
+
+    expect(wrapper.emitted('submit')).toHaveLength(1)
+  })
+
   it('passes accessibility tests', async () => {
     const wrapper = await mountSuspended(ChatPrompt, {
       props: {


### PR DESCRIPTION
## Live sync — next commit in queue

**Upstream:** [`b597f909`](https://github.com/nuxt/ui/commit/b597f909aa9f4b12f3c732ec75f52226bcf88c2e) — feat(ChatPrompt): add `submitOnEnter` prop to control Enter behavior _(resolves nuxt/ui#6177)_

Immediate next commit after `efd7b8ec` (#76) in the oldest-first queue.

### What & why
Adds a `submitOnEnter` prop (default `true`) to `ChatPrompt`:
- **`true`** — `Enter` submits, `Shift+Enter` inserts a newline (current behavior).
- **`false`** — `Enter` inserts a newline, `Ctrl+Enter` / `Cmd+Enter` submits.

Applied **1:1** with upstream:
```diff
+  submitOnEnter?: boolean        // default true
+
+function handleEnter(event: KeyboardEvent) {
+  if (props.submitOnEnter) {
+    if (event.shiftKey || event.ctrlKey || event.metaKey || event.altKey) return
+  } else {
+    if (!event.ctrlKey && !event.metaKey) return
+  }
+  onEnter(event)
+}
-      @keydown.enter.exact="onEnter"
+      @keydown.enter="handleEnter"
```
The existing IME-guard (`useIMEGuard` → `onEnter` / `onCompositionEnd`) is preserved. Docs note + 3 behavioral specs added.

**b24ui divergence:** none functional — only the slots-type prop stays `b24ui` (vs upstream `ui`), which is the pre-existing library-wide rename. Not a breaking change (new optional prop, default keeps old behavior).

### Ledger (per-port maintenance, #75 §1)
- `.sync/nuxt-ui.json`: `cursor` → `b597f909`; previous `efd7b8ec` entry finalized (`pr: 76`, `b24ui_sha: d9debe3e`) — the rolling-correction pattern.
- `.sync/log/b597f909….md`: decision record.

### Validation (linux verify script; windows .ps1 below in chat)
- ✅ `dev:prepare` · ✅ `eslint` · ✅ `typecheck`
- ✅ ChatPrompt spec **38 passed** (+3) · ✅ full `pnpm exec vitest run` (no `-u`) **4892 passed | 6 skipped**

https://claude.ai/code/session_01Qz7EXMncvEGiCj4WbmYgJo

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qz7EXMncvEGiCj4WbmYgJo)_