### PR TITLE
docs(app): extract playground button into shared component

### DIFF
--- a/.sync/log/507640490f5d01ff2c9d84d19421cc06a2b2aaec.md
+++ b/.sync/log/507640490f5d01ff2c9d84d19421cc06a2b2aaec.md
@@ -1,0 +1,24 @@
+# port — nuxt/ui@507640490f5d01ff2c9d84d19421cc06a2b2aaec
+
+**Upstream:** docs(app): extract playground button into shared component
+
+**Decision:** port (docs-app refactor; adapted to b24ui).
+
+**Rationale:** b24ui's doc site carries the same "Open in playground" button,
+duplicated in `ComponentCode.vue` and `ComponentExample.vue` (b24ui flavor:
+`B24Tooltip` + `B24Button` + `PlayLIcon`, `useAnalytics().track`). Mirrored the
+upstream DRY refactor: extracted a shared
+`docs/app/components/content/ComponentPlaygroundButton.vue` (auto-imported) and
+replaced both inline blocks with `<ComponentPlaygroundButton :to :component source />`.
+Removed the now-unused `PlayLIcon` import and `const { track } = useAnalytics()`
+from both files.
+
+**b24ui divergences:**
+- Components/icon: `B24Tooltip`/`B24Button`/`PlayLIcon` (vs upstream `UTooltip`/`UButton`/`i-lucide-play`).
+- Kept the `source` field (`'code'` / `'example'`) in the analytics event via a
+  `source` prop — b24ui tracked it before this commit, so dropping it (as upstream
+  did) would have regressed analytics granularity.
+- Adopted upstream's new `tabindex="-1"` on the button.
+
+**Validation:** `dev:prepare` · `eslint` · `typecheck` (incl. `nuxt typecheck docs`).
+No `src/` change → library `vitest` suite unaffected (run anyway for the record).

--- a/.sync/nuxt-ui.json
+++ b/.sync/nuxt-ui.json
@@ -2,7 +2,7 @@
   "upstream": "nuxt/ui",
   "branch": "v4",
   "sync_enabled": false,
-  "cursor": "b597f909aa9f4b12f3c732ec75f52226bcf88c2e",
+  "cursor": "507640490f5d01ff2c9d84d19421cc06a2b2aaec",
   "_cursor_note": "cursor = last upstream commit ported into b24ui (oldest-first, manual cadence). sync_enabled stays false until Phase 2 (porter workflow #67 + CLAUDE_CODE_OAUTH_TOKEN) is wired and trusted. `processed` is maintained per port from now on (backfilled #68-#72 on 2026-06-09).",
   "stats": {
     "queue_depth": 0,
@@ -47,10 +47,16 @@
       "summary": "fix(CommandPalette): re-highlight first item after debounced results render"
     },
     "b597f909aa9f4b12f3c732ec75f52226bcf88c2e": {
+      "pr": 77,
+      "b24ui_sha": "91c397fd",
+      "decision": "port",
+      "summary": "feat(ChatPrompt): add `submitOnEnter` prop to control Enter behavior"
+    },
+    "507640490f5d01ff2c9d84d19421cc06a2b2aaec": {
       "pr": null,
       "b24ui_sha": "pending-merge",
       "decision": "port",
-      "summary": "feat(ChatPrompt): add `submitOnEnter` prop to control Enter behavior"
+      "summary": "docs(app): extract playground button into shared component"
     }
   }
 }

--- a/docs/app/components/content/ComponentCode.vue
+++ b/docs/app/components/content/ComponentCode.vue
@@ -8,12 +8,9 @@ import { CalendarDate, Time } from '@internationalized/date'
 import * as theme from '#build/b24ui'
 import { get, set } from '#b24ui/utils'
 import RocketIcon from '@bitrix24/b24icons-vue/main/RocketIcon'
-import PlayLIcon from '@bitrix24/b24icons-vue/outline/PlayLIcon'
 // import SignIcon from '@bitrix24/b24icons-vue/main/SignIcon'
 // import MoreMIcon from '@bitrix24/b24icons-vue/outline/MoreMIcon'
 // import InfoIcon from '@bitrix24/b24icons-vue/button/InfoIcon'
-
-const { track } = useAnalytics()
 
 interface CastImport {
   name: string
@@ -609,17 +606,7 @@ const { data: ast } = useAsyncData(codeKey, async () => {
       </div>
 
       <ClientOnly>
-        <B24Tooltip v-if="playgroundUrl" text="Open in playground" :content="{ side: 'right' }">
-          <B24Button
-            :to="playgroundUrl"
-            target="_blank"
-            :icon="PlayLIcon"
-            size="sm"
-            class="absolute -bottom-[13px] -right-[13px] z-1 rounded-full lg:opacity-0 lg:group-hover/component:opacity-100 ring-muted transition-opacity duration-200"
-            aria-label="Open in playground"
-            @click="track('Playground Opened', { component: camelName, source: 'code' })"
-          />
-        </B24Tooltip>
+        <ComponentPlaygroundButton v-if="playgroundUrl" :to="playgroundUrl" :component="camelName" source="code" />
 
         <LazyComponentThemeVisualizer
           :container="componentContainer"

--- a/docs/app/components/content/ComponentExample.vue
+++ b/docs/app/components/content/ComponentExample.vue
@@ -3,9 +3,6 @@ import { camelCase, upperFirst } from 'scule'
 import { hash } from 'ohash'
 import { useElementSize } from '@vueuse/core'
 import { get, set } from '#b24ui/utils'
-import PlayLIcon from '@bitrix24/b24icons-vue/outline/PlayLIcon'
-
-const { track } = useAnalytics()
 
 const props = withDefaults(defineProps<{
   name: string
@@ -259,17 +256,7 @@ const urlSearchParams = computed(() => {
         </div>
 
         <ClientOnly>
-          <B24Tooltip v-if="playgroundUrl" text="Open in playground" :content="{ side: 'right' }">
-            <B24Button
-              :to="playgroundUrl"
-              target="_blank"
-              :icon="PlayLIcon"
-              size="sm"
-              class="absolute -bottom-[13px] -right-[13px] z-1 rounded-full lg:opacity-0 lg:group-hover/component:opacity-100 ring-muted transition-opacity duration-200"
-              aria-label="Open in playground"
-              @click="track('Playground Opened', { component: camelName, source: 'example' })"
-            />
-          </B24Tooltip>
+          <ComponentPlaygroundButton v-if="playgroundUrl" :to="playgroundUrl" :component="camelName" source="example" />
 
           <LazyComponentThemeVisualizer
             :container="componentContainer"

--- a/docs/app/components/content/ComponentPlaygroundButton.vue
+++ b/docs/app/components/content/ComponentPlaygroundButton.vue
@@ -1,0 +1,26 @@
+<script setup lang="ts">
+import PlayLIcon from '@bitrix24/b24icons-vue/outline/PlayLIcon'
+
+const { track } = useAnalytics()
+
+const props = defineProps<{
+  to: string
+  component: string
+  source: string
+}>()
+</script>
+
+<template>
+  <B24Tooltip text="Open in playground" :content="{ side: 'right' }">
+    <B24Button
+      :to="props.to"
+      target="_blank"
+      :icon="PlayLIcon"
+      size="sm"
+      class="absolute -bottom-[13px] -right-[13px] z-1 rounded-full lg:opacity-0 lg:group-hover/component:opacity-100 ring-muted transition-opacity duration-200"
+      aria-label="Open in playground"
+      tabindex="-1"
+      @click="track('Playground Opened', { component: props.component, source: props.source })"
+    />
+  </B24Tooltip>
+</template>


### PR DESCRIPTION
## Live sync — next commit in queue

**Upstream:** [`50764049`](https://github.com/nuxt/ui/commit/507640490f5d01ff2c9d84d19421cc06a2b2aaec) — docs(app): extract playground button into shared component

Immediate next commit after `b597f909` (#77) in the oldest-first queue.

### What & why
Docs-site DRY refactor. The "Open in playground" button was duplicated in `ComponentCode.vue` and `ComponentExample.vue`. Extracted it into a shared, auto-imported **`docs/app/components/content/ComponentPlaygroundButton.vue`** and replaced both inline blocks with:
```vue
<ComponentPlaygroundButton v-if="playgroundUrl" :to="playgroundUrl" :component="camelName" source="code|example" />
```
Removed the now-unused `PlayLIcon` import and `const { track } = useAnalytics()` from both files.

### b24ui divergences (vs upstream)
- Components/icon: `B24Tooltip` / `B24Button` / `PlayLIcon` (upstream uses `UTooltip` / `UButton` / `i-lucide-play`).
- **Kept the `source` field** (`'code'` / `'example'`) in the `track('Playground Opened', …)` event via a `source` prop. b24ui tracked it before this commit, so dropping it (as upstream did) would have regressed analytics granularity.
- Adopted upstream's new `tabindex="-1"` on the button.

Docs-app only — no `src/` (library) change.

### Ledger (per-port maintenance, #75 §1)
- `.sync/nuxt-ui.json`: `cursor` → `50764049`; previous `b597f909` entry finalized (`pr: 77`, `b24ui_sha: 91c397fd`).
- `.sync/log/50764049….md`: decision record.

### Validation (linux verify script; windows .ps1 below in chat)
- ✅ `dev:prepare` · ✅ `eslint` (3 files) · ✅ `nuxt typecheck docs`
- ✅ full `pnpm exec vitest run` (no `-u`) **4892 passed | 6 skipped** (library suite unaffected by docs change — run for the record)

https://claude.ai/code/session_01Qz7EXMncvEGiCj4WbmYgJo

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qz7EXMncvEGiCj4WbmYgJo)_