### PR TITLE
feat(Checkbox/RadioGroup/Switch): add `highlight` prop for error ring styling

### DIFF
--- a/.sync/log/a0deee4d85ddde5f8c59ab908cb21001a77f39a7.md
+++ b/.sync/log/a0deee4d85ddde5f8c59ab908cb21001a77f39a7.md
@@ -1,0 +1,37 @@
+# port — nuxt/ui@a0deee4d85ddde5f8c59ab908cb21001a77f39a7
+
+**Upstream:** feat(Checkbox/RadioGroup/Switch): add `highlight` prop for error ring styling
+
+**Decision:** port (functional feat; theme adapted to b24ui).
+
+**Rationale:** `useFormField` in b24ui already exposes a `highlight` computed
+(`error ? true : props.highlight`), but Checkbox / CheckboxGroup / RadioGroup /
+Switch did **not** consume it — so a control inside an errored `FormField` showed
+no ring. This commit closes that gap, matching upstream:
+
+- **Components:** added `highlight?: boolean` prop (JSDoc), destructured
+  `highlight` from `useFormField`, passed `highlight: highlight.value ?? props.highlight`
+  into the theme `tv()` call. CheckboxGroup adds `highlight` to its `Pick<CheckboxProps>`
+  and forwards `:highlight="highlight"` to each child checkbox.
+- **Themes (checkbox / radio-group / switch):** added a `highlight` variant.
+
+**b24ui divergence (theme):** upstream uses `compoundVariants` generating
+`ring-${color}` per `options.theme.colors` + `ring-inverted` for `neutral`.
+b24ui themes are plain objects with the `air-*` color system and `--b24ui-*`
+tokens (no `options.theme.colors`, no `neutral`). So the highlight ring uses the
+**active color token**, mirroring the existing `Input` precedent
+(`src/theme/input.ts`):
+
+```
+highlight: { true: { base: 'ring ring-inset ring-(--b24ui-border-color)' } }
+```
+
+(`--b24ui-border-color` is set by the active color's `style-*` class — the b24ui
+analog of upstream's per-color ring.) Switch `base` had `ring-0`, so `ring`
+restores width.
+
+**Note:** upstream's follow-up `73daec1a` adds `highlight` test coverage — that is
+the *next* commit in the queue and will be ported separately.
+
+**Validation:** `dev:prepare` · `eslint` · `typecheck` · full `vitest run -u`
+then full `vitest run` (per #74 discipline) — snapshot deltas reviewed.

--- a/.sync/nuxt-ui.json
+++ b/.sync/nuxt-ui.json
@@ -2,7 +2,7 @@
   "upstream": "nuxt/ui",
   "branch": "v4",
   "sync_enabled": false,
-  "cursor": "507640490f5d01ff2c9d84d19421cc06a2b2aaec",
+  "cursor": "a0deee4d85ddde5f8c59ab908cb21001a77f39a7",
   "_cursor_note": "cursor = last upstream commit ported into b24ui (oldest-first, manual cadence). sync_enabled stays false until Phase 2 (porter workflow #67 + CLAUDE_CODE_OAUTH_TOKEN) is wired and trusted. `processed` is maintained per port from now on (backfilled #68-#72 on 2026-06-09).",
   "stats": {
     "queue_depth": 0,
@@ -53,10 +53,16 @@
       "summary": "feat(ChatPrompt): add `submitOnEnter` prop to control Enter behavior"
     },
     "507640490f5d01ff2c9d84d19421cc06a2b2aaec": {
+      "pr": 78,
+      "b24ui_sha": "a27ff2d4",
+      "decision": "port",
+      "summary": "docs(app): extract playground button into shared component"
+    },
+    "a0deee4d85ddde5f8c59ab908cb21001a77f39a7": {
       "pr": null,
       "b24ui_sha": "pending-merge",
       "decision": "port",
-      "summary": "docs(app): extract playground button into shared component"
+      "summary": "feat(Checkbox/RadioGroup/Switch): add `highlight` prop for error ring styling"
     }
   }
 }

--- a/src/runtime/components/Checkbox.vue
+++ b/src/runtime/components/Checkbox.vue
@@ -33,6 +33,8 @@ export interface CheckboxProps<T = boolean> extends Pick<CheckboxRootProps<T>, '
    * @defaultValue 'start'
    */
   indicator?: Checkbox['variants']['indicator']
+  /** Highlight the ring color like a focus state. */
+  highlight?: boolean
   class?: any
   b24ui?: Checkbox['slots']
 }
@@ -71,7 +73,7 @@ const appConfig = useAppConfig() as Checkbox['AppConfig']
 
 const rootProps = useForwardProps(reactivePick(props, 'required', 'value', 'defaultValue', 'modelValue', 'trueValue', 'falseValue'), emits)
 
-const { id: _id, emitFormChange, emitFormInput, size, color, name, disabled, ariaAttrs } = useFormField<CheckboxProps<T>>(_props)
+const { id: _id, emitFormChange, emitFormInput, size, color, highlight, name, disabled, ariaAttrs } = useFormField<CheckboxProps<T>>(_props)
 const id = _id.value ?? useId()
 
 const attrs = useAttrs()
@@ -87,6 +89,7 @@ const b24ui = computed(() => tv({ extend: tv(theme), ...(appConfig.b24ui?.checkb
   color: color.value ?? props.color,
   variant: props.variant,
   indicator: props.indicator,
+  highlight: highlight.value ?? props.highlight,
   required: props.required,
   disabled: disabled.value
 }))

--- a/src/runtime/components/CheckboxGroup.vue
+++ b/src/runtime/components/CheckboxGroup.vue
@@ -21,7 +21,7 @@ export type CheckboxGroupItem = CheckboxGroupValue | {
   [key: string]: any
 }
 
-export interface CheckboxGroupProps<T extends CheckboxGroupItem[] = CheckboxGroupItem[], VK extends GetItemKeys<T> = 'value'> extends Pick<CheckboxGroupRootProps, 'disabled' | 'loop' | 'name' | 'required'>, Pick<CheckboxProps, 'color' | 'indicator'> {
+export interface CheckboxGroupProps<T extends CheckboxGroupItem[] = CheckboxGroupItem[], VK extends GetItemKeys<T> = 'value'> extends Pick<CheckboxGroupRootProps, 'disabled' | 'loop' | 'name' | 'required'>, Pick<CheckboxProps, 'color' | 'highlight' | 'indicator'> {
   /**
    * The element or component this component should render as.
    * @defaultValue 'div'
@@ -110,7 +110,7 @@ const rootProps = useForwardProps(reactivePick(props, 'as', 'modelValue', 'defau
 const checkboxProps = useForwardProps(reactivePick(props, 'variant', 'indicator'))
 const getProxySlots = () => omit(slots, ['legend'])
 
-const { emitFormChange, emitFormInput, color, name, size, id: _id, disabled, ariaAttrs } = useFormField<CheckboxGroupProps<T>>(_props, { bind: false })
+const { emitFormChange, emitFormInput, color, highlight, name, size, id: _id, disabled, ariaAttrs } = useFormField<CheckboxGroupProps<T>>(_props, { bind: false })
 const id = _id.value ?? useId()
 
 // @ts-expect-error We skip test Checkbox.variant
@@ -192,6 +192,7 @@ function onUpdate(value: any) {
         :key="item.value"
         v-bind="{ ...item, ...checkboxProps }"
         :color="color"
+        :highlight="highlight"
         :size="size"
         :name="name"
         :disabled="item.disabled || disabled"

--- a/src/runtime/components/RadioGroup.vue
+++ b/src/runtime/components/RadioGroup.vue
@@ -59,6 +59,8 @@ export interface RadioGroupProps<T extends RadioGroupItem[] = RadioGroupItem[], 
    * @defaultValue 'air-primary'
    */
   color?: RadioGroup['variants']['color']
+  /** Highlight the ring color like a focus state. */
+  highlight?: boolean
   /**
    * The orientation the radio buttons are laid out.
    * @defaultValue 'vertical'
@@ -114,13 +116,14 @@ const appConfig = useAppConfig() as RadioGroup['AppConfig']
 
 const rootProps = useForwardProps(reactivePick(props, 'as', 'loop', 'required'), emits)
 
-const { emitFormChange, emitFormInput, color, name, size, id: _id, disabled, ariaAttrs } = useFormField<RadioGroupProps<T>>(_props, { bind: false })
+const { emitFormChange, emitFormInput, color, name, size, highlight, id: _id, disabled, ariaAttrs } = useFormField<RadioGroupProps<T>>(_props, { bind: false })
 const id = _id.value ?? useId()
 
 // eslint-disable-next-line vue/no-dupe-keys
 const b24ui = computed(() => tv({ extend: tv(theme), ...(appConfig.b24ui?.radioGroup || {}) })({
   size: size.value ?? props.size,
   color: color.value ?? props.color,
+  highlight: highlight.value ?? props.highlight,
   disabled: disabled.value,
   required: props.required,
   orientation: props.orientation,

--- a/src/runtime/components/Switch.vue
+++ b/src/runtime/components/Switch.vue
@@ -23,6 +23,8 @@ export interface SwitchProps<T = boolean> extends Pick<SwitchRootProps<T>, 'disa
    * @defaultValue 'md'
    */
   size?: Switch['variants']['size']
+  /** Highlight the ring color like a focus state. */
+  highlight?: boolean
   /**
    * When `true`, the loading icon will be displayed
    * @defaultValue false
@@ -83,7 +85,7 @@ const appConfig = useAppConfig() as Switch['AppConfig']
 
 const rootProps = useForwardProps(reactivePick(props, 'required', 'value', 'defaultValue', 'modelValue', 'trueValue', 'falseValue'), emits)
 
-const { id: _id, emitFormChange, emitFormInput, size, color, name, disabled, ariaAttrs } = useFormField<SwitchProps<T>>(_props)
+const { id: _id, emitFormChange, emitFormInput, size, color, highlight, name, disabled, ariaAttrs } = useFormField<SwitchProps<T>>(_props)
 const id = _id.value ?? useId()
 
 const attrs = useAttrs()
@@ -97,6 +99,7 @@ const forwardedAttrs = computed(() => {
 const b24ui = computed(() => tv({ extend: tv(theme), ...(appConfig.b24ui?.switch || {}) })({
   size: size.value ?? props.size,
   color: color.value ?? props.color,
+  highlight: highlight.value ?? props.highlight,
   required: props.required,
   loading: props.loading,
   disabled: disabled.value || props.loading

--- a/src/theme/checkbox.ts
+++ b/src/theme/checkbox.ts
@@ -116,6 +116,11 @@ export default {
         description: 'cursor-not-allowed'
       }
     },
+    highlight: {
+      true: {
+        base: 'ring ring-inset ring-(--b24ui-border-color)'
+      }
+    },
     checked: {
       true: ''
     }

--- a/src/theme/radio-group.ts
+++ b/src/theme/radio-group.ts
@@ -155,6 +155,11 @@ export default {
       true: {
         label: 'after:content-[\'*\'] after:ms-0.5 after:text-(--ui-color-accent-main-alert)'
       }
+    },
+    highlight: {
+      true: {
+        base: 'ring ring-inset ring-(--b24ui-border-color)'
+      }
     }
   },
   compoundVariants: [

--- a/src/theme/switch.ts
+++ b/src/theme/switch.ts
@@ -128,6 +128,11 @@ export default {
         label: 'cursor-not-allowed',
         description: 'cursor-not-allowed'
       }
+    },
+    highlight: {
+      true: {
+        base: 'ring ring-inset ring-(--b24ui-border-color)'
+      }
     }
   },
   defaultVariants: {


### PR DESCRIPTION
## Live sync — next commit in queue

**Upstream:** [`a0deee4d`](https://github.com/nuxt/ui/commit/a0deee4d85ddde5f8c59ab908cb21001a77f39a7) — feat(Checkbox/RadioGroup/Switch): add `highlight` prop for error ring styling

Immediate next commit after `50764049` (#78) in the oldest-first queue.

### What & why
Adds `highlight?: boolean` to **Checkbox, CheckboxGroup, RadioGroup, Switch**. `useFormField` already exposed a `highlight` computed (`error ? true : props.highlight`), but these four controls didn't consume it — so a control inside an **errored `FormField` showed no ring**. Now they forward `highlight: highlight.value ?? props.highlight` into the theme. CheckboxGroup adds `highlight` to its `Pick<CheckboxProps>` and passes `:highlight` to each child.

### ⚠️ Theme divergence — needs your visual review
Upstream generates per-color rings:
```ts
...(options.theme.colors).map(color => ({ color, highlight: true, class: { base: `ring-${color}` } })),
{ color: 'neutral', highlight: true, class: { base: 'ring-inverted' } }
```
b24ui themes are **plain objects** with the `air-*` color system + `--b24ui-*` tokens — there's no `options.theme.colors` and no `neutral`. So I used the **active color token**, matching the existing `Input` precedent (`src/theme/input.ts`):
```ts
highlight: { true: { base: 'ring ring-inset ring-(--b24ui-border-color)' } }
```
`--b24ui-border-color` is set by the active color's `style-*` class (the b24ui analog of upstream's per-color ring). Switch `base` had `ring-0`, so `ring` restores width.

**👁 Please eyeball:** Checkbox / RadioGroup / Switch inside an errored `B24FormField` (and with explicit `highlight`) across colors + `card` variant — confirm the ring reads as an error highlight and the width/inset looks right. If you'd prefer the alert color specifically (e.g. `ring-(--ui-color-accent-main-alert)`) instead of the active color token, say so and I'll adjust.

### Validation (linux verify script; windows .ps1 below in chat)
- ✅ `dev:prepare` · ✅ `eslint` (7 files) · ✅ `vue-tsc --noEmit`
- ✅ full `vitest run -u` **then** `vitest run` (no `-u`) — **4892 passed | 6 skipped**, **no snapshot changes** (highlight render cases arrive in the next commit `73daec1a`).

### Ledger (per-port maintenance, #75 §1)
- `.sync/nuxt-ui.json`: `cursor` → `a0deee4d`; `50764049` finalized (`pr: 78`, `b24ui_sha: a27ff2d4`).
- `.sync/log/a0deee4d….md`: decision record (incl. the theme divergence).

https://claude.ai/code/session_01Qz7EXMncvEGiCj4WbmYgJo

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qz7EXMncvEGiCj4WbmYgJo)_