### PR TITLE
chore(playground): add share button to repl

### DIFF
--- a/.sync/log/8dbddf938713ed9ed76d85f7076220f52a57d1f0.md
+++ b/.sync/log/8dbddf938713ed9ed76d85f7076220f52a57d1f0.md
@@ -1,0 +1,28 @@
+# port — nuxt/ui@8dbddf938713ed9ed76d85f7076220f52a57d1f0
+
+**Upstream:** chore(playground): add share button to repl
+
+**Decision:** port (REPL playground; adapted to b24ui).
+
+**Rationale:** b24ui has the same `@vue/repl`-based playground at
+`playgrounds/repl/src/App.vue` (the URL-hash serialization + `#right` header
+toolbar match upstream). Added the share button identically:
+
+- `import { useClipboard } from '@vueuse/core'`.
+- `const hasChanged = ref(hasInitialHash)`; the existing `watchEffect` now sets
+  `hasChanged.value = !isDefault`.
+- `const { copy, copied } = useClipboard()` + `share()` copying `location.href`.
+- A share `B24Tooltip` + `B24Button` in the header `#right` slot
+  (`:disabled="!hasChanged"`, label toggles `Share` / `Copied!`).
+
+**b24ui divergence:** `B24Tooltip`/`B24Button` instead of `UTooltip`/`UButton`;
+icons `ShareIcon` / `CircleCheckIcon` from `@bitrix24/b24icons-vue/outline`
+instead of `i-lucide-share` / `i-lucide-circle-check`; button color
+`air-tertiary-no-accent` + `size="sm"` to match the existing header buttons
+(b24ui has no `variant="ghost"` / `color="neutral"`).
+
+**Scope note:** only `playgrounds/repl` — the `playgrounds/nuxt` ↔
+`playgrounds/demo` mirror (per AGENTS.md) is unrelated to this commit.
+
+**Validation:** `eslint` (file) · `repl:prepare` + `repl:build` (the repl is not
+covered by the repo `typecheck`/`vitest`). Library suite unaffected.

--- a/.sync/nuxt-ui.json
+++ b/.sync/nuxt-ui.json
@@ -2,7 +2,7 @@
   "upstream": "nuxt/ui",
   "branch": "v4",
   "sync_enabled": false,
-  "cursor": "73daec1af120a52102be4ecd1b6dbe0245ed5291",
+  "cursor": "8dbddf938713ed9ed76d85f7076220f52a57d1f0",
   "_cursor_note": "cursor = last upstream commit ported into b24ui (oldest-first, manual cadence). sync_enabled stays false until Phase 2 (porter workflow #67 + CLAUDE_CODE_OAUTH_TOKEN) is wired and trusted. `processed` is maintained per port from now on (backfilled #68-#72 on 2026-06-09).",
   "stats": {
     "queue_depth": 0,
@@ -65,10 +65,16 @@
       "summary": "feat(Checkbox/RadioGroup/Switch): add `highlight` prop for error ring styling"
     },
     "73daec1af120a52102be4ecd1b6dbe0245ed5291": {
+      "pr": 102,
+      "b24ui_sha": "e3c107c5",
+      "decision": "port",
+      "summary": "test(components): add highlight coverage across all form controls"
+    },
+    "8dbddf938713ed9ed76d85f7076220f52a57d1f0": {
       "pr": null,
       "b24ui_sha": "pending-merge",
       "decision": "port",
-      "summary": "test(components): add highlight coverage across all form controls"
+      "summary": "chore(playground): add share button to repl"
     }
   }
 }

--- a/playgrounds/repl/src/App.vue
+++ b/playgrounds/repl/src/App.vue
@@ -2,9 +2,12 @@
 <script setup lang="ts">
 import { ref, computed, watchEffect } from 'vue'
 import { Repl, useStore, useVueImportMap } from '@vue/repl'
+import { useClipboard } from '@vueuse/core'
 import CodeMirror from '@vue/repl/codemirror-editor'
 import GraduationCapIcon from '@bitrix24/b24icons-vue/outline/GraduationCapIcon'
 import GitHubIcon from '@bitrix24/b24icons-vue/social/GitHubIcon'
+import ShareIcon from '@bitrix24/b24icons-vue/outline/ShareIcon'
+import CircleCheckIcon from '@bitrix24/b24icons-vue/outline/CircleCheckIcon'
 
 // const colorMode = useColorMode()
 // const theme = computed(() => colorMode.preference === 'dark' ? 'dark' : 'light')
@@ -147,9 +150,14 @@ if (!hasInitialHash) {
   }, 'src/App.vue')
 }
 
+const hasChanged = ref(hasInitialHash)
+
 watchEffect(() => {
   const serialized = store.serialize()
-  if (!hasInitialHash && store.getFiles()['App.vue']?.trimEnd() === defaultCode.trimEnd()) {
+  const isDefault = !hasInitialHash && store.getFiles()['App.vue']?.trimEnd() === defaultCode.trimEnd()
+
+  hasChanged.value = !isDefault
+  if (isDefault) {
     if (location.hash) {
       history.replaceState({}, '', location.pathname)
     }
@@ -157,6 +165,11 @@ watchEffect(() => {
   }
   history.replaceState({}, '', serialized)
 })
+
+const { copy, copied } = useClipboard()
+function share() {
+  copy(location.href)
+}
 
 const previewOptions = {
   headHTML: [
@@ -182,6 +195,17 @@ const previewOptions = {
         </template>
 
         <template #right>
+          <B24Tooltip :text="copied ? 'Copied!' : 'Share'" :disabled="!hasChanged">
+            <B24Button
+              aria-label="Share"
+              color="air-tertiary-no-accent"
+              :icon="copied ? CircleCheckIcon : ShareIcon"
+              :disabled="!hasChanged"
+              size="sm"
+              @click="share"
+            />
+          </B24Tooltip>
+
           <B24Button
             aria-label="Bitrix24 UI on GitHub"
             color="air-tertiary-no-accent"


### PR DESCRIPTION
## Live sync — next commit in queue

**Upstream:** [`8dbddf93`](https://github.com/nuxt/ui/commit/8dbddf938713ed9ed76d85f7076220f52a57d1f0) — chore(playground): add share button to repl

Immediate next commit after `73daec1a` (#102) in the oldest-first queue.

### What & why
Adds a **Share** button to the `@vue/repl` playground header (`playgrounds/repl/src/App.vue`). It copies the current hash-serialized URL (`useClipboard` → `location.href`), is enabled only once the code differs from the default (`hasChanged`, tracked in the existing `watchEffect`), and toggles its label/icon `Share` → `Copied!`. Applied as upstream.

### b24ui divergence
- `B24Tooltip` / `B24Button` instead of `UTooltip` / `UButton`.
- Icons `ShareIcon` / `CircleCheckIcon` from `@bitrix24/b24icons-vue/outline` (vs `i-lucide-share` / `i-lucide-circle-check`).
- `color="air-tertiary-no-accent"` + `size="sm"` to match the existing header buttons (b24ui has no `variant="ghost"`/`color="neutral"`).

Only `playgrounds/repl` — unrelated to the `playgrounds/nuxt` ↔ `playgrounds/demo` mirror.

### Validation (linux verify script; windows .ps1 below in chat)
- ✅ `eslint` (file) — CI's `lint` (`eslint .`) covers it.
- ✅ `repl:build` — **✓ built in 31.65s, 1336 modules** (the repl isn't in the repo `typecheck`/`vitest`/CI-`build`, so built explicitly to validate).
- ⚠️ Heads-up (pre-existing, **not** from this PR): `pnpm run repl:prepare` writes `.nuxt/tsconfig.json` via `echo {\"compilerOptions\":{}}`, which in some shells yields invalid JSON (`{compilerOptions:{}}`) and breaks `repl:build`'s config load. Worked around locally by writing valid JSON. Not in CI's path. Can file a small fix issue if you want.

### Ledger (per-port maintenance, #75 §1)
- `.sync/nuxt-ui.json`: `cursor` → `8dbddf93`; `73daec1a` finalized (`pr: 102`, `b24ui_sha: e3c107c5`).
- `.sync/log/8dbddf93….md`: decision record.

https://claude.ai/code/session_01Qz7EXMncvEGiCj4WbmYgJo

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qz7EXMncvEGiCj4WbmYgJo)_