### PR TITLE
fix(FileUpload): pass `disabled` attribute to button variant

### DIFF
--- a/.sync/log/2890c8334b35b0b6f528c64f56e80950e5b7409b.md
+++ b/.sync/log/2890c8334b35b0b6f528c64f56e80950e5b7409b.md
@@ -1,0 +1,24 @@
+# port — nuxt/ui@2890c8334b35b0b6f528c64f56e80950e5b7409b
+
+**Upstream:** fix(FileUpload): pass `disabled` attribute to button variant (resolves nuxt/ui#6420)
+
+**Decision:** port (applied 1:1).
+
+**Rationale:** b24ui's `FileUpload.vue` mirrors upstream — the dropzone renders
+as a `<button>` when `variant === 'button'`, and `disabled` is already in scope
+(from `useFormField`). Added the same native-`disabled` binding so the button
+variant is actually disabled (not just styled):
+
+```vue
+:disabled="variant === 'button' ? disabled : undefined"
+```
+
+placed right after the `:role` binding. Added the matching spec case
+`['with disabled variant button', { props: { disabled: true, variant: 'button' } }]`
+and regenerated snapshots.
+
+**b24ui divergence:** none — identical logic; only surrounding markup is the
+existing b24ui flavor.
+
+**Validation:** `eslint` · `vue-tsc --noEmit` · full `vitest run -u` then
+`vitest run` (per #74) — one new FileUpload snapshot pair expected.

--- a/.sync/nuxt-ui.json
+++ b/.sync/nuxt-ui.json
@@ -2,7 +2,7 @@
   "upstream": "nuxt/ui",
   "branch": "v4",
   "sync_enabled": false,
-  "cursor": "8dbddf938713ed9ed76d85f7076220f52a57d1f0",
+  "cursor": "2890c8334b35b0b6f528c64f56e80950e5b7409b",
   "_cursor_note": "cursor = last upstream commit ported into b24ui (oldest-first, manual cadence). sync_enabled stays false until Phase 2 (porter workflow #67 + CLAUDE_CODE_OAUTH_TOKEN) is wired and trusted. `processed` is maintained per port from now on (backfilled #68-#72 on 2026-06-09).",
   "stats": {
     "queue_depth": 0,
@@ -71,10 +71,16 @@
       "summary": "test(components): add highlight coverage across all form controls"
     },
     "8dbddf938713ed9ed76d85f7076220f52a57d1f0": {
+      "pr": 103,
+      "b24ui_sha": "fab9b432",
+      "decision": "port",
+      "summary": "chore(playground): add share button to repl"
+    },
+    "2890c8334b35b0b6f528c64f56e80950e5b7409b": {
       "pr": null,
       "b24ui_sha": "pending-merge",
       "decision": "port",
-      "summary": "chore(playground): add share button to repl"
+      "summary": "fix(FileUpload): pass `disabled` attribute to button variant"
     }
   }
 }

--- a/src/runtime/components/FileUpload.vue
+++ b/src/runtime/components/FileUpload.vue
@@ -366,6 +366,7 @@ defineExpose({
         ref="dropzoneRef"
         :type="variant === 'button' ? 'button' : undefined"
         :role="variant === 'button' ? undefined : 'button'"
+        :disabled="variant === 'button' ? disabled : undefined"
         :data-dragging="isDragging"
         data-slot="base"
         :class="b24ui.base({ class: props.b24ui?.base })"

--- a/test/components/FileUpload.spec.ts
+++ b/test/components/FileUpload.spec.ts
@@ -60,6 +60,7 @@ describe('FileUpload', () => {
     ...sizes.map((size: string) => [`with size ${size} variant button`, { props: { ...props, size, variant: 'button' } }]),
     ['with required', { props: { required: true } }],
     ['with disabled', { props: { disabled: true } }],
+    ['with disabled variant button', { props: { disabled: true, variant: 'button' } }],
     ['with accept', { props: { accept: 'image/*' } }],
     ['with multiple', { props: { ...props, multiple: true } }],
     ['without dropzone', { props: { dropzone: false } }],

--- a/test/components/__snapshots__/FileUpload-vue.spec.ts.snap
+++ b/test/components/__snapshots__/FileUpload-vue.spec.ts.snap
@@ -180,6 +180,22 @@ exports[`FileUpload > renders with disabled correctly 2`] = `
 </div>"
 `;
 
+exports[`FileUpload > renders with disabled variant button correctly 1`] = `
+"<div data-slot="root" class="relative flex flex-col style-outline-no-accent"><button type="button" disabled="" data-dragging="false" data-slot="base" class="w-full flex-1 bg-(--b24ui-background)/90 border-(--b24ui-border-color) border-(length:--b24ui-border-width) text-(--b24ui-color) flex flex-col gap-2 items-stretch justify-center rounded-(--ui-border-radius-md) focus-visible:outline-2 transition-[background] text-(length:--ui-font-size-sm) border-dashed data-[dragging=true]:bg-(--ui-color-accent-soft-grey-1)/90 cursor-not-allowed opacity-75 focus-visible:outline-inverted p-1.5" tabindex="-1">
+    <!--v-if-->
+    <div data-slot="wrapper" class="flex flex-col items-center justify-center text-center"><svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" aria-hidden="true" data-slot="icon" class="shrink-0 size-5">
+        <path fill="currentColor" fill-rule="evenodd" d="M17.1 9.028a1.3 1.3 0 0 0-.368-.906l-2.325-2.356a1.24 1.24 0 0 0-.868-.366H8.132c-.648 0-1.232.575-1.232 1.267v10.666c0 .692.584 1.267 1.232 1.267h7.736c.648 0 1.232-.575 1.232-1.267zM13.535 4H8.132C6.684 4 5.5 5.23 5.5 6.667v10.666C5.5 18.771 6.684 20 8.132 20h7.736c1.449 0 2.632-1.23 2.632-2.667V9.031a2.7 2.7 0 0 0-.772-1.893l-2.325-2.356A2.64 2.64 0 0 0 13.535 4" clip-rule="evenodd"></path>
+        <path fill="currentColor" fill-rule="evenodd" d="M9.25 15.831a.7.7 0 0 1 .7-.7h4.1a.7.7 0 1 1 0 1.4h-4.1a.7.7 0 0 1-.7-.7M12 7.929a.7.7 0 0 1 .7.7v5a.7.7 0 1 1-1.4 0v-5a.7.7 0 0 1 .7-.7" clip-rule="evenodd"></path>
+        <path fill="currentColor" fill-rule="evenodd" d="M12.495 8.134a.7.7 0 0 1 0 .99l-2.05 2.05a.7.7 0 1 1-.99-.99l2.05-2.05a.7.7 0 0 1 .99 0" clip-rule="evenodd"></path>
+        <path fill="currentColor" fill-rule="evenodd" d="M11.505 8.134a.7.7 0 0 1 .99 0l2.05 2.05a.7.7 0 1 1-.99.99l-2.05-2.05a.7.7 0 0 1 0-.99" clip-rule="evenodd"></path>
+      </svg>
+      <!--v-if-->
+    </div>
+  </button>
+  <!--v-if--><input data-hidden="" tabindex="-1" style="position: absolute; border: 0px; width: 1px; height: 1px; padding: 0px; margin: -1px; overflow: hidden; clip: rect(0, 0, 0, 0); clip-path: inset(50%); white-space: nowrap; word-wrap: normal; top: -1px; left: -1px;" type="file" accept="*" disabled="">
+</div>"
+`;
+
 exports[`FileUpload > renders with file slot correctly 1`] = `
 "<div data-slot="root" class="relative flex flex-col style-outline-no-accent">
   <div role="button" data-dragging="false" data-slot="base" class="w-full flex-1 bg-(--b24ui-background)/90 border-(--b24ui-border-color) border-(length:--b24ui-border-width) text-(--b24ui-color) flex flex-col gap-2 items-stretch justify-center rounded-(--ui-border-radius-md) focus-visible:outline-2 transition-[background] p-4 text-(length:--ui-font-size-sm) border-dashed data-[dragging=true]:bg-(--ui-color-accent-soft-grey-1)/90 focus-visible:outline-inverted hover:bg-elevated/25" tabindex="0">

--- a/test/components/__snapshots__/FileUpload.spec.ts.snap
+++ b/test/components/__snapshots__/FileUpload.spec.ts.snap
@@ -180,6 +180,22 @@ exports[`FileUpload > renders with disabled correctly 2`] = `
 </div>"
 `;
 
+exports[`FileUpload > renders with disabled variant button correctly 1`] = `
+"<div data-slot="root" class="relative flex flex-col style-outline-no-accent"><button type="button" disabled="" data-dragging="false" data-slot="base" class="w-full flex-1 bg-(--b24ui-background)/90 border-(--b24ui-border-color) border-(length:--b24ui-border-width) text-(--b24ui-color) flex flex-col gap-2 items-stretch justify-center rounded-(--ui-border-radius-md) focus-visible:outline-2 transition-[background] text-(length:--ui-font-size-sm) border-dashed data-[dragging=true]:bg-(--ui-color-accent-soft-grey-1)/90 cursor-not-allowed opacity-75 focus-visible:outline-inverted p-1.5" tabindex="-1">
+    <!--v-if-->
+    <div data-slot="wrapper" class="flex flex-col items-center justify-center text-center"><svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" aria-hidden="true" data-slot="icon" class="shrink-0 size-5">
+        <path fill="currentColor" fill-rule="evenodd" d="M17.1 9.028a1.3 1.3 0 0 0-.368-.906l-2.325-2.356a1.24 1.24 0 0 0-.868-.366H8.132c-.648 0-1.232.575-1.232 1.267v10.666c0 .692.584 1.267 1.232 1.267h7.736c.648 0 1.232-.575 1.232-1.267zM13.535 4H8.132C6.684 4 5.5 5.23 5.5 6.667v10.666C5.5 18.771 6.684 20 8.132 20h7.736c1.449 0 2.632-1.23 2.632-2.667V9.031a2.7 2.7 0 0 0-.772-1.893l-2.325-2.356A2.64 2.64 0 0 0 13.535 4" clip-rule="evenodd"></path>
+        <path fill="currentColor" fill-rule="evenodd" d="M9.25 15.831a.7.7 0 0 1 .7-.7h4.1a.7.7 0 1 1 0 1.4h-4.1a.7.7 0 0 1-.7-.7M12 7.929a.7.7 0 0 1 .7.7v5a.7.7 0 1 1-1.4 0v-5a.7.7 0 0 1 .7-.7" clip-rule="evenodd"></path>
+        <path fill="currentColor" fill-rule="evenodd" d="M12.495 8.134a.7.7 0 0 1 0 .99l-2.05 2.05a.7.7 0 1 1-.99-.99l2.05-2.05a.7.7 0 0 1 .99 0" clip-rule="evenodd"></path>
+        <path fill="currentColor" fill-rule="evenodd" d="M11.505 8.134a.7.7 0 0 1 .99 0l2.05 2.05a.7.7 0 1 1-.99.99l-2.05-2.05a.7.7 0 0 1 0-.99" clip-rule="evenodd"></path>
+      </svg>
+      <!--v-if-->
+    </div>
+  </button>
+  <!--v-if--><input data-hidden="" tabindex="-1" style="position: absolute; border: 0px; width: 1px; height: 1px; padding: 0px; margin: -1px; overflow: hidden; clip: rect(0, 0, 0, 0); clip-path: inset(50%); white-space: nowrap; word-wrap: normal; top: -1px; left: -1px;" type="file" accept="*" disabled="">
+</div>"
+`;
+
 exports[`FileUpload > renders with file slot correctly 1`] = `
 "<div data-slot="root" class="relative flex flex-col style-outline-no-accent">
   <div role="button" data-dragging="false" data-slot="base" class="w-full flex-1 bg-(--b24ui-background)/90 border-(--b24ui-border-color) border-(length:--b24ui-border-width) text-(--b24ui-color) flex flex-col gap-2 items-stretch justify-center rounded-(--ui-border-radius-md) focus-visible:outline-2 transition-[background] p-4 text-(length:--ui-font-size-sm) border-dashed data-[dragging=true]:bg-(--ui-color-accent-soft-grey-1)/90 focus-visible:outline-inverted hover:bg-elevated/25" tabindex="0">


### PR DESCRIPTION
## Live sync — next commit in queue

**Upstream:** [`2890c833`](https://github.com/nuxt/ui/commit/2890c8334b35b0b6f528c64f56e80950e5b7409b) — fix(FileUpload): pass `disabled` attribute to button variant _(resolves nuxt/ui#6420)_

Immediate next commit after `8dbddf93` (#103) in the oldest-first queue.

### What & why
When `variant="button"`, the FileUpload dropzone renders as a native `<button>`. Previously `disabled` only drove styling/`tabindex`, not the element's native `disabled`. Bind it directly:
```vue
:disabled="variant === 'button' ? disabled : undefined"
```
(placed after the `:role` binding). `disabled` was already in scope via `useFormField`. Added the matching spec case + regenerated snapshots.

**b24ui divergence:** none — identical logic.

### Validation (linux verify script; windows .ps1 below in chat)
- ✅ `dev:prepare` · ✅ `eslint` · ✅ `vue-tsc --noEmit`
- ✅ full `vitest run -u` then `vitest run` (no `-u`) — **4950 passed | 6 skipped** (+2)
- Snapshots: FileUpload pair only, **+32** (one new `disabled variant button` case).

### Ledger (per-port maintenance, #75 §1)
- `.sync/nuxt-ui.json`: `cursor` → `2890c833`; `8dbddf93` finalized (`pr: 103`, `b24ui_sha: fab9b432`).
- `.sync/log/2890c833….md`: decision record.

https://claude.ai/code/session_01Qz7EXMncvEGiCj4WbmYgJo

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qz7EXMncvEGiCj4WbmYgJo)_