### PR TITLE
fix(ContentToc): apply `b24ui.trigger` prop to trigger elements

### DIFF
--- a/.sync/log/252b90659ce93f3795d97c4c056c14f027e02e1d.md
+++ b/.sync/log/252b90659ce93f3795d97c4c056c14f027e02e1d.md
@@ -1,0 +1,24 @@
+# port — nuxt/ui@252b90659ce93f3795d97c4c056c14f027e02e1d
+
+**Upstream:** fix(ContentToc): apply `ui.trigger` prop to trigger elements (resolves nuxt/ui#6428)
+
+**Decision:** port (applied 1:1, b24ui prop name).
+
+**Rationale:** b24ui's `content/ContentToc.vue` has the same two trigger
+elements (mobile `CollapsibleTrigger` + desktop `<p>`), and previously their
+class was only the hardcoded responsive utility — the user's `trigger` slot
+override was ignored. Merged it in, mirroring upstream:
+
+```diff
+- b24ui.trigger({ class: 'lg:hidden' })
++ b24ui.trigger({ class: [props.b24ui?.trigger, 'lg:hidden'] })
+- b24ui.trigger({ class: 'hidden lg:flex' })
++ b24ui.trigger({ class: [props.b24ui?.trigger, 'hidden lg:flex'] })
+```
+
+**b24ui divergence:** only the prop name — `props.b24ui?.trigger` (vs upstream
+`props.ui?.trigger`).
+
+**Validation:** `dev:prepare` · `eslint` · `vue-tsc --noEmit` · full `vitest run`
+(template-only change; ContentToc has no component snapshot spec → suite
+unaffected, run for the record).

--- a/.sync/nuxt-ui.json
+++ b/.sync/nuxt-ui.json
@@ -2,7 +2,7 @@
   "upstream": "nuxt/ui",
   "branch": "v4",
   "sync_enabled": false,
-  "cursor": "2890c8334b35b0b6f528c64f56e80950e5b7409b",
+  "cursor": "252b90659ce93f3795d97c4c056c14f027e02e1d",
   "_cursor_note": "cursor = last upstream commit ported into b24ui (oldest-first, manual cadence). sync_enabled stays false until Phase 2 (porter workflow #67 + CLAUDE_CODE_OAUTH_TOKEN) is wired and trusted. `processed` is maintained per port from now on (backfilled #68-#72 on 2026-06-09).",
   "stats": {
     "queue_depth": 0,
@@ -77,10 +77,16 @@
       "summary": "chore(playground): add share button to repl"
     },
     "2890c8334b35b0b6f528c64f56e80950e5b7409b": {
+      "pr": 104,
+      "b24ui_sha": "d08ad977",
+      "decision": "port",
+      "summary": "fix(FileUpload): pass `disabled` attribute to button variant"
+    },
+    "252b90659ce93f3795d97c4c056c14f027e02e1d": {
       "pr": null,
       "b24ui_sha": "pending-merge",
       "decision": "port",
-      "summary": "fix(FileUpload): pass `disabled` attribute to button variant"
+      "summary": "fix(ContentToc): apply `ui.trigger` prop to trigger elements"
     }
   }
 }

--- a/src/runtime/components/content/ContentToc.vue
+++ b/src/runtime/components/content/ContentToc.vue
@@ -193,7 +193,7 @@ onUnmounted(() => {
       </div>
 
       <template v-if="props.links?.length">
-        <CollapsibleTrigger data-slot="trigger" :class="b24ui.trigger({ class: 'lg:hidden' })">
+        <CollapsibleTrigger data-slot="trigger" :class="b24ui.trigger({ class: [props.b24ui?.trigger, 'lg:hidden'] })">
           <ReuseTriggerTemplate :open="open" />
         </CollapsibleTrigger>
 
@@ -203,7 +203,7 @@ onUnmounted(() => {
           </slot>
         </CollapsibleContent>
 
-        <p data-slot="trigger" :class="b24ui.trigger({ class: 'hidden lg:flex' })">
+        <p data-slot="trigger" :class="b24ui.trigger({ class: [props.b24ui?.trigger, 'hidden lg:flex'] })">
           <ReuseTriggerTemplate :open="open" />
         </p>
 


### PR DESCRIPTION
## Live sync — next commit in queue

**Upstream:** [`252b9065`](https://github.com/nuxt/ui/commit/252b90659ce93f3795d97c4c056c14f027e02e1d) — fix(ContentToc): apply `ui.trigger` prop to trigger elements _(resolves nuxt/ui#6428)_

Immediate next commit after `2890c833` (#104) in the oldest-first queue.

### What & why
The ContentToc's two trigger elements (mobile `CollapsibleTrigger` + desktop `<p>`) hardcoded only the responsive utility class, so a user's `trigger` override was ignored. Merge it in:
```diff
- b24ui.trigger({ class: 'lg:hidden' })
+ b24ui.trigger({ class: [props.b24ui?.trigger, 'lg:hidden'] })
- b24ui.trigger({ class: 'hidden lg:flex' })
+ b24ui.trigger({ class: [props.b24ui?.trigger, 'hidden lg:flex'] })
```

**b24ui divergence:** prop name only — `props.b24ui?.trigger` (vs upstream `props.ui?.trigger`).

### Validation (linux verify script; windows .ps1 below in chat)
- ✅ `dev:prepare` · ✅ `eslint` · ✅ `vue-tsc --noEmit`
- ✅ full `vitest run` — **4950 passed | 6 skipped**, no snapshot drift (template-only; ContentToc has no component snapshot spec).

### Ledger (per-port maintenance, #75 §1)
- `.sync/nuxt-ui.json`: `cursor` → `252b9065`; `2890c833` finalized (`pr: 104`, `b24ui_sha: d08ad977`).
- `.sync/log/252b9065….md`: decision record.

https://claude.ai/code/session_01Qz7EXMncvEGiCj4WbmYgJo

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qz7EXMncvEGiCj4WbmYgJo)_