### PR TITLE
fix(Textarea): autoresize on mount with pre-filled value

### DIFF
--- a/.sync/log/e96a0b62945d3a2412f3e779d3e71ffc386c667a.md
+++ b/.sync/log/e96a0b62945d3a2412f3e779d3e71ffc386c667a.md
@@ -1,0 +1,23 @@
+# port — nuxt/ui@e96a0b62945d3a2412f3e779d3e71ffc386c667a
+
+**Upstream:** fix(Textarea): autoresize on mount with pre-filled value (closes nuxt/ui#5962)
+
+**Decision:** port (applied 1:1).
+
+**Rationale:** b24ui's `Textarea.vue` has the same `onMounted` autoresize
+`setTimeout`. With a pre-filled value the DOM isn't laid out yet when
+`autoResize()` runs, so the initial height is wrong. Awaiting `nextTick()` first
+fixes it. Applied identically (`nextTick` was already imported):
+
+```diff
+- setTimeout(() => {
++ setTimeout(async () => {
++   await nextTick()
+    autoResize()
+  }, props.autoresizeDelay)
+```
+
+**b24ui divergence:** none.
+
+**Validation:** `dev:prepare` · `eslint` · `vue-tsc --noEmit` · full `vitest run`
+(post-mount async timing — no render-snapshot change expected).

--- a/.sync/nuxt-ui.json
+++ b/.sync/nuxt-ui.json
@@ -2,7 +2,7 @@
   "upstream": "nuxt/ui",
   "branch": "v4",
   "sync_enabled": false,
-  "cursor": "252b90659ce93f3795d97c4c056c14f027e02e1d",
+  "cursor": "e96a0b62945d3a2412f3e779d3e71ffc386c667a",
   "_cursor_note": "cursor = last upstream commit ported into b24ui (oldest-first, manual cadence). sync_enabled stays false until Phase 2 (porter workflow #67 + CLAUDE_CODE_OAUTH_TOKEN) is wired and trusted. `processed` is maintained per port from now on (backfilled #68-#72 on 2026-06-09).",
   "stats": {
     "queue_depth": 0,
@@ -83,10 +83,16 @@
       "summary": "fix(FileUpload): pass `disabled` attribute to button variant"
     },
     "252b90659ce93f3795d97c4c056c14f027e02e1d": {
+      "pr": 105,
+      "b24ui_sha": "bb201030",
+      "decision": "port",
+      "summary": "fix(ContentToc): apply `ui.trigger` prop to trigger elements"
+    },
+    "e96a0b62945d3a2412f3e779d3e71ffc386c667a": {
       "pr": null,
       "b24ui_sha": "pending-merge",
       "decision": "port",
-      "summary": "fix(ContentToc): apply `ui.trigger` prop to trigger elements"
+      "summary": "fix(Textarea): autoresize on mount with pre-filled value"
     }
   }
 }

--- a/src/runtime/components/Textarea.vue
+++ b/src/runtime/components/Textarea.vue
@@ -231,7 +231,8 @@ onMounted(() => {
     autoFocus()
   }, props.autofocusDelay)
 
-  setTimeout(() => {
+  setTimeout(async () => {
+    await nextTick()
     autoResize()
   }, props.autoresizeDelay)
 })


### PR DESCRIPTION
## Live sync — next commit in queue

**Upstream:** [`e96a0b62`](https://github.com/nuxt/ui/commit/e96a0b62945d3a2412f3e779d3e71ffc386c667a) — fix(Textarea): autoresize on mount with pre-filled value _(closes nuxt/ui#5962)_

Immediate next commit after `252b9065` (#105) in the oldest-first queue.

### What & why
With a pre-filled value the textarea isn't laid out yet when the `onMounted` `autoResize()` runs, so the initial height is wrong. Await `nextTick()` first:
```diff
- setTimeout(() => {
+ setTimeout(async () => {
+   await nextTick()
    autoResize()
  }, props.autoresizeDelay)
```
`nextTick` was already imported. Applied 1:1 — **no b24ui divergence**.

### Validation (linux verify script; windows .ps1 below in chat)
- ✅ `dev:prepare` · ✅ `eslint` · ✅ `vue-tsc --noEmit`
- ✅ full `vitest run` — **4950 passed | 6 skipped**, no snapshot drift (post-mount async timing).

### Ledger (per-port maintenance, #75 §1)
- `.sync/nuxt-ui.json`: `cursor` → `e96a0b62`; `252b9065` finalized (`pr: 105`, `b24ui_sha: bb201030`).
- `.sync/log/e96a0b62….md`: decision record.

https://claude.ai/code/session_01Qz7EXMncvEGiCj4WbmYgJo

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qz7EXMncvEGiCj4WbmYgJo)_