### PR TITLE
fix(ProseKbd): add default slot and make `value` optional

### DIFF
--- a/.sync/log/f317c7f6b2b6c9d1050bc9d2e94a58116ddb70e9.md
+++ b/.sync/log/f317c7f6b2b6c9d1050bc9d2e94a58116ddb70e9.md
@@ -1,0 +1,19 @@
+# port — nuxt/ui@f317c7f6b2b6c9d1050bc9d2e94a58116ddb70e9
+
+**Upstream:** fix(ProseKbd): add default slot and make `value` optional
+
+**Decision:** port (applied 1:1).
+
+**Rationale:** b24ui's `prose/Kbd.vue` mirrors upstream (uses `B24Kbd`, the
+`b24ui` prop). Applied the same three changes so prose `:kbd` can take slot
+content instead of only a `value` prop:
+
+- `value: string` → `value?: string`.
+- added `ProseKbdSlots { default?(): any }` + `defineSlots<ProseKbdSlots>()`.
+- template: forward `<slot />` into `B24Kbd` (its base `Kbd.vue` already renders
+  a default `<slot>` with the `value` fallback).
+
+**b24ui divergence:** prop name only — `b24ui` / `B24Kbd` (vs upstream `ui` / `UKbd`).
+
+**Validation:** `dev:prepare` · `eslint` · `vue-tsc --noEmit` · full `vitest run`
+(no render-snapshot change for existing `value`-based usage).

--- a/.sync/nuxt-ui.json
+++ b/.sync/nuxt-ui.json
@@ -2,7 +2,7 @@
   "upstream": "nuxt/ui",
   "branch": "v4",
   "sync_enabled": false,
-  "cursor": "e96a0b62945d3a2412f3e779d3e71ffc386c667a",
+  "cursor": "f317c7f6b2b6c9d1050bc9d2e94a58116ddb70e9",
   "_cursor_note": "cursor = last upstream commit ported into b24ui (oldest-first, manual cadence). sync_enabled stays false until Phase 2 (porter workflow #67 + CLAUDE_CODE_OAUTH_TOKEN) is wired and trusted. `processed` is maintained per port from now on (backfilled #68-#72 on 2026-06-09).",
   "stats": {
     "queue_depth": 0,
@@ -89,10 +89,16 @@
       "summary": "fix(ContentToc): apply `ui.trigger` prop to trigger elements"
     },
     "e96a0b62945d3a2412f3e779d3e71ffc386c667a": {
+      "pr": 106,
+      "b24ui_sha": "bf8a174d",
+      "decision": "port",
+      "summary": "fix(Textarea): autoresize on mount with pre-filled value"
+    },
+    "f317c7f6b2b6c9d1050bc9d2e94a58116ddb70e9": {
       "pr": null,
       "b24ui_sha": "pending-merge",
       "decision": "port",
-      "summary": "fix(Textarea): autoresize on mount with pre-filled value"
+      "summary": "fix(ProseKbd): add default slot and make `value` optional"
     }
   }
 }

--- a/src/runtime/components/prose/Kbd.vue
+++ b/src/runtime/components/prose/Kbd.vue
@@ -6,9 +6,13 @@ import type { ComponentConfig } from '../../types/tv'
 type ProseKbd = ComponentConfig<typeof theme, AppConfig, 'kbd', 'b24ui.prose'>
 
 export interface ProseKbdProps {
-  value: string
+  value?: string
   class?: any
   b24ui?: { base?: any }
+}
+
+export interface ProseKbdSlots {
+  default?(props?: {}): any
 }
 </script>
 
@@ -20,6 +24,7 @@ import { tv } from '../../utils/tv'
 import B24Kbd from '../Kbd.vue'
 
 const _props = defineProps<ProseKbdProps>()
+defineSlots<ProseKbdSlots>()
 
 const props = useComponentProps('prose.kbd', _props)
 
@@ -30,5 +35,7 @@ const b24ui = computed(() => tv({ extend: tv(theme), ...(appConfig.b24ui?.prose?
 </script>
 
 <template>
-  <B24Kbd :value="props.value" :class="b24ui({ class: [props.b24ui?.base, props.class] })" />
+  <B24Kbd :value="props.value" :class="b24ui({ class: [props.b24ui?.base, props.class] })">
+    <slot />
+  </B24Kbd>
 </template>


### PR DESCRIPTION
## Live sync — next commit in queue

**Upstream:** [`f317c7f6`](https://github.com/nuxt/ui/commit/f317c7f6b2b6c9d1050bc9d2e94a58116ddb70e9) — fix(ProseKbd): add default slot and make `value` optional

Immediate next commit after `e96a0b62` (#106) in the oldest-first queue.

### What & why
`ProseKbd` (the `:kbd` prose component) required a `value` prop. Now it also accepts slot content:
- `value: string` → `value?: string`
- added `ProseKbdSlots { default?(): any }` + `defineSlots<ProseKbdSlots>()`
- forwarded `<slot />` into `B24Kbd` (its base `Kbd.vue` already renders a default `<slot>` with the `value` fallback, so existing `value`-based usage is unchanged).

**b24ui divergence:** prop/component names only — `b24ui` / `B24Kbd` (vs upstream `ui` / `UKbd`).

### Validation (linux verify script; windows .ps1 below in chat)
- ✅ `dev:prepare` · ✅ `eslint` · ✅ `vue-tsc --noEmit`
- ✅ full `vitest run` — **4950 passed | 6 skipped**, no snapshot drift.

### Ledger (per-port maintenance, #75 §1)
- `.sync/nuxt-ui.json`: `cursor` → `f317c7f6`; `e96a0b62` finalized (`pr: 106`, `b24ui_sha: bf8a174d`).
- `.sync/log/f317c7f6….md`: decision record.

https://claude.ai/code/session_01Qz7EXMncvEGiCj4WbmYgJo

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qz7EXMncvEGiCj4WbmYgJo)_