### PR TITLE
fix(InputMenu/Select/SelectMenu): respect `trailing: false` over default `trailingIcon`

### DIFF
--- a/.sync/log/65b47ce7b491238755fc7ab9e403822646da89fd.md
+++ b/.sync/log/65b47ce7b491238755fc7ab9e403822646da89fd.md
@@ -1,0 +1,26 @@
+# port — nuxt/ui@65b47ce7b491238755fc7ab9e403822646da89fd
+
+**Upstream:** fix(InputMenu/Select/SelectMenu): respect `trailing: false` over default `trailingIcon` (#6457)
+
+**Decision:** port (1:1).
+
+**What:** in `useComponentIcons.ts`, `isTrailing` now requires
+`trailing !== false` for the default `trailingIcon` branch, so an explicit
+`trailing: false` suppresses the trailing section even when a component
+supplies a default `trailingIcon` (InputMenu/Select/SelectMenu).
+
+```
+- || !!props.value.trailingIcon)
++ || (!!props.value.trailingIcon && props.value.trailing !== false))
+```
+
+**Parity notes:**
+- b24ui's `isTrailing` line matched upstream pre-fix exactly → applied verbatim.
+- b24ui's `isLeading` differs from upstream (b24ui uses an `avatar` branch where
+  upstream uses `leadingIcon`); untouched — out of scope.
+- Added the 3 upstream tests verbatim (one per spec, before the a11y test),
+  asserting `data-slot="trailing"`/`"trailingIcon"` absent when `trailing: false`.
+  `mount` already imported in all three specs; `const props` already present.
+
+**Validation:** `dev:prepare` · full `typecheck` · `lint` · full `vitest run`
+(4956 passed | 6 skipped — +6 vs prior = 3 new tests × nuxt+vue projects).

--- a/.sync/nuxt-ui.json
+++ b/.sync/nuxt-ui.json
@@ -2,7 +2,7 @@
   "upstream": "nuxt/ui",
   "branch": "v4",
   "sync_enabled": false,
-  "cursor": "081cf01acb50041aa67c339350076eb7c816b10d",
+  "cursor": "65b47ce7b491238755fc7ab9e403822646da89fd",
   "_cursor_note": "cursor = last upstream commit ported into b24ui (oldest-first, manual cadence). sync_enabled stays false until Phase 2 (porter workflow #67 + CLAUDE_CODE_OAUTH_TOKEN) is wired and trusted. `processed` is maintained per port from now on (backfilled #68-#72 on 2026-06-09).",
   "stats": {
     "queue_depth": 0,
@@ -107,10 +107,16 @@
       "summary": "chore(deps): update vue-tsc to ^3.3.0 (+ b24ui ChatPrompt TS1117 fix it surfaced)"
     },
     "081cf01acb50041aa67c339350076eb7c816b10d": {
+      "pr": 109,
+      "b24ui_sha": "e79494ec",
+      "decision": "port",
+      "summary": "chore(deps): update all non-major dependencies (selective — shared deps; + pnpm dedupe for jiti/vite)"
+    },
+    "65b47ce7b491238755fc7ab9e403822646da89fd": {
       "pr": null,
       "b24ui_sha": "pending-merge",
       "decision": "port",
-      "summary": "chore(deps): update all non-major dependencies (selective — shared deps; + pnpm dedupe for jiti/vite)"
+      "summary": "fix(InputMenu/Select/SelectMenu): respect `trailing: false` over default `trailingIcon`"
     }
   }
 }

--- a/src/runtime/composables/useComponentIcons.ts
+++ b/src/runtime/composables/useComponentIcons.ts
@@ -27,7 +27,7 @@ export function useComponentIcons(componentProps: MaybeRefOrGetter<UseComponentI
 
   const isLeading = computed(() => (props.value.icon && !props.value.trailing) || (props.value.loading && !props.value.trailing) || (props.value.avatar))
 
-  const isTrailing = computed(() => (props.value.icon && props.value.trailing) || (props.value.loading && props.value.trailing) || !!props.value.trailingIcon)
+  const isTrailing = computed(() => (props.value.icon && props.value.trailing) || (props.value.loading && props.value.trailing) || (!!props.value.trailingIcon && props.value.trailing !== false))
 
   const leadingIconName = computed(() => {
     if (props.value.loading) {

--- a/test/components/InputMenu.spec.ts
+++ b/test/components/InputMenu.spec.ts
@@ -119,6 +119,18 @@ describe('InputMenu', () => {
     }
   )
 
+  it('with trailing false should not render trailing section', () => {
+    const wrapper = mount(InputMenu, {
+      props: {
+        ...props,
+        trailing: false
+      }
+    })
+
+    expect(wrapper.find('[data-slot="trailing"]').exists()).toBe(false)
+    expect(wrapper.find('[data-slot="trailingIcon"]').exists()).toBe(false)
+  })
+
   it('passes accessibility tests', async () => {
     const wrapper = await mountSuspended(InputMenu, {
       props: {

--- a/test/components/Select.spec.ts
+++ b/test/components/Select.spec.ts
@@ -110,6 +110,18 @@ describe('Select', () => {
     }
   )
 
+  it('with trailing false should not render trailing section', () => {
+    const wrapper = mount(Select, {
+      props: {
+        ...props,
+        trailing: false
+      }
+    })
+
+    expect(wrapper.find('[data-slot="trailing"]').exists()).toBe(false)
+    expect(wrapper.find('[data-slot="trailingIcon"]').exists()).toBe(false)
+  })
+
   it('passes accessibility tests', async () => {
     const wrapper = await mountSuspended(Select, {
       props: {

--- a/test/components/SelectMenu.spec.ts
+++ b/test/components/SelectMenu.spec.ts
@@ -114,6 +114,18 @@ describe('SelectMenu', () => {
     }
   )
 
+  it('with trailing false should not render trailing section', () => {
+    const wrapper = mount(SelectMenu, {
+      props: {
+        ...props,
+        trailing: false
+      }
+    })
+
+    expect(wrapper.find('[data-slot="trailing"]').exists()).toBe(false)
+    expect(wrapper.find('[data-slot="trailingIcon"]').exists()).toBe(false)
+  })
+
   it('passes accessibility tests', async () => {
     const wrapper = await mountSuspended(SelectMenu, {
       props: {


### PR DESCRIPTION
## Live sync — next commit in queue

**Upstream:** [`65b47ce7`](https://github.com/nuxt/ui/commit/65b47ce7b491238755fc7ab9e403822646da89fd) — fix(InputMenu/Select/SelectMenu): respect `trailing: false` over default `trailingIcon` (#6457)

Immediate next commit after `081cf01a` (#109) in the oldest-first queue.

### Port (1:1)
In `useComponentIcons.ts`, the default-`trailingIcon` branch of `isTrailing` now also requires `trailing !== false`:
```diff
- || !!props.value.trailingIcon)
+ || (!!props.value.trailingIcon && props.value.trailing !== false))
```
So an explicit `trailing: false` suppresses the trailing section even when InputMenu/Select/SelectMenu supply a **default** `trailingIcon` (chevron). Added the 3 upstream specs (one per component) asserting `data-slot="trailing"`/`"trailingIcon"` are absent when `trailing: false`.

**Parity notes:**
- b24ui's `isTrailing` matched upstream pre-fix exactly → applied verbatim.
- b24ui's `isLeading` diverges (b24ui has an `avatar` branch where upstream uses `leadingIcon`) — untouched, out of scope.
- `mount` already imported and `const props` already present in all three specs.

### Validation (linux verify script; windows .ps1 below in chat)
- ✅ `dev:prepare` · ✅ full `typecheck` · ✅ `lint`
- ✅ full `vitest run` — **4956 passed | 6 skipped** (+6 vs prior `main` = 3 new tests × nuxt+vue projects)

### Ledger (per-port maintenance, #75 §1)
- `.sync/nuxt-ui.json`: `cursor` → `65b47ce7`; `081cf01a` finalized (`pr: 109`, `b24ui_sha: e79494ec`).
- `.sync/log/65b47ce7….md`: decision record.

https://claude.ai/code/session_01Qz7EXMncvEGiCj4WbmYgJo

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qz7EXMncvEGiCj4WbmYgJo)_