### PR TITLE
fix(module): ship stripped `#build/b24ui.css` fallback for tooling

### DIFF
--- a/.sync/log/083c2a9846a8784f14012f666b98eef443057fe6.md
+++ b/.sync/log/083c2a9846a8784f14012f666b98eef443057fe6.md
@@ -1,0 +1,37 @@
+# port — nuxt/ui@083c2a9846a8784f14012f666b98eef443057fe6
+
+**Upstream:** fix(module): ship stripped `#build/ui.css` fallback for tooling (resolves #5504, #6070)
+
+**Decision:** port (adapted to b24ui naming).
+
+## Problem
+Tools resolving `#build/ui.css` via Node's `imports` field (Prettier +
+`prettier-plugin-tailwindcss`, Tailwind IntelliSense) read the shipped
+`.nuxt/*.css`, which contained an unprefixed `@apply antialiased …`. With
+`theme.prefix` set, Tailwind threw `Cannot apply unprefixed utility class
+'antialiased'`, breaking Prettier and IntelliSense.
+
+## Change (b24ui)
+- **package.json**: `imports["#build/b24ui.css"]` and the `files` entry →
+  `./.nuxt/b24ui.static.css` (was `b24ui.css`).
+- **src/templates.ts**: extracted the `@theme` blocks into a `themeBlocks`
+  const. The dynamic `b24ui.css` template is unchanged in output (sources +
+  `@layer base` body + themeBlocks) and still drives the runtime
+  (`src/runtime/index.css` → `@import '#build/b24ui.css'` resolves to
+  `.nuxt/b24ui.css` via Nuxt's build alias). Added a new `b24ui.static.css`
+  template = `themeBlocks` only (no `@source`, no body `@apply`), shipped in
+  the npm package as the tooling-facing fallback.
+
+## b24ui adaptation notes
+- Naming: `ui.css`/`ui.static.css` → `b24ui.css`/`b24ui.static.css`.
+- b24ui's `@theme static {}` / `@theme default inline {}` are **empty
+  placeholders** (vs upstream's full color-var block), so the static file is
+  minimal (43 B). The fix still applies: the win is that the shipped fallback
+  no longer carries the unprefixed `@apply antialiased` / `@source` paths.
+- Out of scope / pre-existing: `templates.ts` HMR `updateTemplates({ filter:
+  template => template.filename === 'ui.css' })` references `'ui.css'` (not
+  `'b24ui.css'`) — a b24ui name mismatch unrelated to this commit; left as-is.
+
+**Validation:** dev:prepare (both `.nuxt/b24ui.css` full + `.nuxt/b24ui.static.css`
+theme-only generated) · `typecheck` · `lint` · `vitest run` (4971 passed | 6
+skipped) · module `build` (static css present in output).

--- a/.sync/nuxt-ui.json
+++ b/.sync/nuxt-ui.json
@@ -2,7 +2,7 @@
   "upstream": "nuxt/ui",
   "branch": "v4",
   "sync_enabled": false,
-  "cursor": "a1bef8babc7eab2ebdf4e34d3d5205cb3053a1c7",
+  "cursor": "083c2a9846a8784f14012f666b98eef443057fe6",
   "_cursor_note": "cursor = last upstream commit ported into b24ui (oldest-first, manual cadence). sync_enabled stays false until Phase 2 (porter workflow #67 + CLAUDE_CODE_OAUTH_TOKEN) is wired and trusted. `processed` is maintained per port from now on (backfilled #68-#72 on 2026-06-09).",
   "stats": {
     "queue_depth": 0,
@@ -119,10 +119,16 @@
       "summary": "fix(InputMenu/Select/SelectMenu): respect `trailing: false` over default `trailingIcon`"
     },
     "a1bef8babc7eab2ebdf4e34d3d5205cb3053a1c7": {
+      "pr": 111,
+      "b24ui_sha": "557a5178",
+      "decision": "port",
+      "summary": "feat(ContentSearch): add async search support via search/searchStatus (core + docs, adapted)"
+    },
+    "083c2a9846a8784f14012f666b98eef443057fe6": {
       "pr": null,
       "b24ui_sha": "pending-merge",
       "decision": "port",
-      "summary": "feat(ContentSearch): add async search support via search/searchStatus (core + docs, adapted)"
+      "summary": "fix(module): ship stripped #build/b24ui.css fallback (b24ui.static.css) for tooling"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     }
   },
   "imports": {
-    "#build/b24ui.css": "./.nuxt/b24ui.css"
+    "#build/b24ui.css": "./.nuxt/b24ui.static.css"
   },
   "bin": {
     "bitrix24-ui": "./cli/index.mjs"
@@ -101,7 +101,7 @@
   "files": [
     "README.md",
     "LICENSE",
-    ".nuxt/b24ui.css",
+    ".nuxt/b24ui.static.css",
     "dist",
     "cli",
     "vue-plugin.d.ts"

--- a/src/templates.ts
+++ b/src/templates.ts
@@ -189,6 +189,11 @@ export function getTemplates(options: ModuleOptions, uiConfig: Record<string, an
     return sources.join('\n')
   }
 
+  const themeBlocks = `@theme static {}
+
+@theme default inline {}
+`
+
   /**
    * use to generate tw colors
    * in `index.css` add `@import '#build/b24ui.css';`
@@ -220,11 +225,20 @@ export function getTemplates(options: ModuleOptions, uiConfig: Record<string, an
   }
 }
 
-@theme static {}
-
-@theme default inline {}
-`
+${themeBlocks}`
     }
+  })
+
+  // Static fallback shipped in the published npm package and exposed via
+  // `package.json` `imports` so tooling that resolves `#build/b24ui.css` through
+  // Node module resolution (Prettier, Tailwind IntelliSense) has something to
+  // read. Strips `@source` directives (paths don't exist on consumer machines)
+  // and the body rule (the runtime template handles it with the user's prefix,
+  // avoiding an unprefixed `@apply` that breaks tooling when `theme.prefix` is set).
+  templates.push({
+    filename: 'b24ui.static.css',
+    write: true,
+    getContents: () => themeBlocks
   })
 
   templates.push({


### PR DESCRIPTION
## Live sync — next commit in queue

**Upstream:** [`083c2a98`](https://github.com/nuxt/ui/commit/083c2a9846a8784f14012f666b98eef443057fe6) — fix(module): ship stripped `#build/ui.css` fallback for tooling (resolves nuxt/ui#5504, nuxt/ui#6070)

Immediate next commit after `a1bef8ba` (#111).

### Problem
Tools that resolve `#build/b24ui.css` via Node's `imports` field — Prettier (`prettier-plugin-tailwindcss`), Tailwind IntelliSense — read the shipped `.nuxt/*.css`, which contained an **unprefixed** `@apply antialiased …`. With `theme.prefix` set, Tailwind throws `Cannot apply unprefixed utility class 'antialiased'`, breaking Prettier and killing IntelliSense.

### Change
- **`src/templates.ts`**: extracted the `@theme` blocks into a `themeBlocks` const. The dynamic **`b24ui.css`** template output is unchanged (sources + `@layer base` body + theme) and still drives the **runtime** (`src/runtime/index.css` → `@import '#build/b24ui.css'` resolves to `.nuxt/b24ui.css` through Nuxt's build alias). Added a new **`b24ui.static.css`** template = theme blocks only — no `@source` (paths don't exist on consumer machines), no body `@apply`.
- **`package.json`**: `imports["#build/b24ui.css"]` and the `files` entry now point at `./.nuxt/b24ui.static.css`. So **non-Nuxt tooling** reads the prefix-safe static file; the Nuxt runtime keeps getting the full dynamic file.

### b24ui adaptation
- Naming `ui.css`/`ui.static.css` → **`b24ui.css`/`b24ui.static.css`**.
- b24ui's `@theme static {}` / `@theme default inline {}` are **empty placeholders** (vs upstream's full color block), so the static file is minimal (43 B). The fix still applies — the win is the shipped fallback no longer carries the unprefixed `@apply` / non-existent `@source` paths.
- **Out of scope:** `templates.ts` HMR filter `template.filename === 'ui.css'` references `'ui.css'` (not `'b24ui.css'`) — a pre-existing b24ui name mismatch unrelated to this commit; left as-is.

### Validation (linux verify; windows .ps1 in chat)
- ✅ `dev:prepare` — generates both `.nuxt/b24ui.css` (full) and `.nuxt/b24ui.static.css` (theme-only, 43 B, no `@source`/body)
- ✅ `typecheck` · ✅ `lint` · ✅ `vitest run` — **4971 passed | 6 skipped** · ✅ module `build` (static css present in output)

### Ledger
- `.sync/nuxt-ui.json`: `cursor` → `083c2a98`; `a1bef8ba` finalized (`pr: 111`, `b24ui_sha: 557a5178`).
- `.sync/log/083c2a98….md`: decision record.

https://claude.ai/code/session_01Qz7EXMncvEGiCj4WbmYgJo

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qz7EXMncvEGiCj4WbmYgJo)_