### PR TITLE
fix(components): apply `theme.prefix` to hardcoded utility classes

### DIFF
--- a/.sync/log/f51b1e8809b5a35e9e3583db7a433cd7dd2c8f97.md
+++ b/.sync/log/f51b1e8809b5a35e9e3583db7a433cd7dd2c8f97.md
@@ -1,0 +1,43 @@
+# port — nuxt/ui@f51b1e8809b5a35e9e3583db7a433cd7dd2c8f97
+
+**Upstream:** fix(components): apply `theme.prefix` to hardcoded utility classes
+
+**Decision:** port (adapted to b24ui).
+
+## Problem
+Static utility classes hardcoded in component templates (e.g.
+`class="focus:outline-none"`, `class="dark:hidden"`, `class="hidden lg:block"`)
+bypass `applyPrefixToObject` (which only walks theme objects). With a consumer
+`theme.prefix` + matching Tailwind `prefix(...)`, those classes silently stop
+applying — both light/dark variants of ColorMode* render at once, mobile +
+desktop ContentToc both show, overlay anchors lose focus styles, etc.
+
+## Change (b24ui)
+- **New `src/runtime/composables/usePrefix.ts`** — returns
+  `(classString) => prefixedClassString`. **Adaptation:** reads
+  `appConfig.b24ui?.prefix` (upstream: `appConfig.ui?.prefix`). The prefix is
+  already populated into `appConfig.b24ui.prefix` by
+  `getDefaultConfig(options.theme)` (`src/utils/defaults.ts`), so the runtime
+  value is available. Logic mirrors b24ui's build-time `prefixClasses`
+  (`src/utils/theme.ts`).
+- **Wrapped hardcoded utility strings** with `prefix(...)` in 10 components
+  that exist in b24ui: Banner, PageCard, PageFeature, PageSection, User,
+  ColorModeAvatar, ColorModeButton, ColorModeImage, ContentSurround,
+  ContentToc. Class literals matched upstream exactly; only the surrounding
+  markup differs (b24ui uses `B24*` imports, `appConfig.b24ui`, the `icons`
+  dictionary, and a `<slot name="content">` in ContentToc).
+
+## Skipped vs upstream
+- **BlogPost, ChangelogVersion, PageCTA, PageHero** — not present in b24ui.
+- **prose/Card.vue, prose/Callout.vue** carry the same `focus:outline-none` /
+  `absolute inset-0` literals, but upstream's commit did **not** touch prose
+  components, so left as-is to stay 1:1 with this commit (revisit if a later
+  upstream commit prefixes them).
+
+## Notes
+- When `prefix` is empty (default), `prefix(cls)` returns `cls` unchanged →
+  rendered output identical → component snapshots unaffected (confirmed: 0
+  snapshot writes).
+
+**Validation:** dev:prepare · typecheck · lint · vitest run (4971 passed | 6
+skipped, no snapshot changes) · module build.

--- a/.sync/nuxt-ui.json
+++ b/.sync/nuxt-ui.json
@@ -2,7 +2,7 @@
   "upstream": "nuxt/ui",
   "branch": "v4",
   "sync_enabled": false,
-  "cursor": "083c2a9846a8784f14012f666b98eef443057fe6",
+  "cursor": "f51b1e8809b5a35e9e3583db7a433cd7dd2c8f97",
   "_cursor_note": "cursor = last upstream commit ported into b24ui (oldest-first, manual cadence). sync_enabled stays false until Phase 2 (porter workflow #67 + CLAUDE_CODE_OAUTH_TOKEN) is wired and trusted. `processed` is maintained per port from now on (backfilled #68-#72 on 2026-06-09).",
   "stats": {
     "queue_depth": 0,
@@ -125,10 +125,16 @@
       "summary": "feat(ContentSearch): add async search support via search/searchStatus (core + docs, adapted)"
     },
     "083c2a9846a8784f14012f666b98eef443057fe6": {
+      "pr": 112,
+      "b24ui_sha": "8bd6ed89",
+      "decision": "port",
+      "summary": "fix(module): ship stripped #build/b24ui.css fallback (b24ui.static.css) for tooling"
+    },
+    "f51b1e8809b5a35e9e3583db7a433cd7dd2c8f97": {
       "pr": null,
       "b24ui_sha": "pending-merge",
       "decision": "port",
-      "summary": "fix(module): ship stripped #build/b24ui.css fallback (b24ui.static.css) for tooling"
+      "summary": "fix(components): apply theme.prefix to hardcoded utility classes via usePrefix (10 of 14 components; rest absent in b24ui)"
     }
   }
 }

--- a/src/runtime/components/Banner.vue
+++ b/src/runtime/components/Banner.vue
@@ -70,6 +70,7 @@ import { Primitive } from 'reka-ui'
 import { useHead, useAppConfig } from '#imports'
 import { useComponentProps } from '../composables/useComponentProps'
 import { useLocale } from '../composables/useLocale'
+import { usePrefix } from '../composables/usePrefix'
 import { tv } from '../utils/tv'
 import icons from '../dictionary/icons'
 import B24Link from './Link.vue'
@@ -86,6 +87,7 @@ const props = useComponentProps('banner', _props)
 
 const { t } = useLocale()
 const appConfig = useAppConfig() as Banner['AppConfig']
+const prefix = usePrefix()
 
 // eslint-disable-next-line vue/no-dupe-keys
 const b24ui = computed(() => tv({ extend: tv(theme), ...(appConfig.b24ui?.banner || {}) })({
@@ -159,11 +161,11 @@ function onClose() {
       v-if="props.to"
       :aria-label="props.title"
       v-bind="{ to: props.to, target: props.target, ...$attrs }"
-      class="focus:outline-none"
+      :class="prefix('focus:outline-none')"
       tabindex="-1"
       raw
     >
-      <span class="absolute inset-0" aria-hidden="true" />
+      <span :class="prefix('absolute inset-0')" aria-hidden="true" />
     </B24Link>
 
     <B24Container data-slot="container" :class="b24ui.container({ class: props.b24ui?.container })">

--- a/src/runtime/components/PageCard.vue
+++ b/src/runtime/components/PageCard.vue
@@ -75,6 +75,7 @@ import { computed, ref } from 'vue'
 import { Primitive } from 'reka-ui'
 import { useAppConfig } from '#imports'
 import { useComponentProps } from '../composables/useComponentProps'
+import { usePrefix } from '../composables/usePrefix'
 import { getSlotChildrenText } from '../utils'
 import { tv } from '../utils/tv'
 import B24Avatar from './Avatar.vue'
@@ -92,6 +93,7 @@ const props = useComponentProps('pageCard', _props)
 const cardRef = ref<HTMLElement>()
 
 const appConfig = useAppConfig() as PageCard['AppConfig']
+const prefix = usePrefix()
 
 // eslint-disable-next-line vue/no-dupe-keys
 const b24ui = computed(() => tv({ extend: tv(theme), ...(appConfig.b24ui?.pageCard || {}) })({
@@ -172,10 +174,10 @@ const ariaLabel = computed(() => {
       v-if="props.to"
       :aria-label="ariaLabel"
       v-bind="{ to: props.to, target: props.target, ...$attrs }"
-      class="focus:outline-none peer"
+      :class="prefix('focus:outline-none peer')"
       raw
     >
-      <span class="absolute inset-0" aria-hidden="true" />
+      <span :class="prefix('absolute inset-0')" aria-hidden="true" />
     </B24Link>
   </Primitive>
 </template>

--- a/src/runtime/components/PageFeature.vue
+++ b/src/runtime/components/PageFeature.vue
@@ -45,6 +45,7 @@ import { computed } from 'vue'
 import { Primitive } from 'reka-ui'
 import { useAppConfig } from '#imports'
 import { useComponentProps } from '../composables/useComponentProps'
+import { usePrefix } from '../composables/usePrefix'
 import { getSlotChildrenText } from '../utils'
 import { tv } from '../utils/tv'
 import B24Link from './Link.vue'
@@ -59,6 +60,7 @@ const slots = defineSlots<PageFeatureSlots>()
 const props = useComponentProps('pageFeature', _props)
 
 const appConfig = useAppConfig() as PageFeature['AppConfig']
+const prefix = usePrefix()
 
 // eslint-disable-next-line vue/no-dupe-keys
 const b24ui = computed(() => tv({ extend: tv(theme), ...(appConfig.b24ui?.pageFeature || {}) })({
@@ -91,10 +93,10 @@ const ariaLabel = computed(() => {
         v-if="props.to"
         :aria-label="ariaLabel"
         v-bind="{ to: props.to, target: props.target, ...$attrs }"
-        class="focus:outline-none peer"
+        :class="prefix('focus:outline-none peer')"
         raw
       >
-        <span class="absolute inset-0" aria-hidden="true" />
+        <span :class="prefix('absolute inset-0')" aria-hidden="true" />
       </B24Link>
 
       <slot>

--- a/src/runtime/components/PageSection.vue
+++ b/src/runtime/components/PageSection.vue
@@ -68,6 +68,7 @@ import { computed } from 'vue'
 import { Primitive } from 'reka-ui'
 import { useAppConfig } from '#imports'
 import { useComponentProps } from '../composables/useComponentProps'
+import { usePrefix } from '../composables/usePrefix'
 import { tv } from '../utils/tv'
 import B24PageFeature from './PageFeature.vue'
 import B24Container from './Container.vue'
@@ -82,6 +83,7 @@ const slots = defineSlots<PageSectionSlots>()
 const props = useComponentProps('pageSection', _props)
 
 const appConfig = useAppConfig() as PageSection['AppConfig']
+const prefix = usePrefix()
 
 // eslint-disable-next-line vue/no-dupe-keys
 const b24ui = computed(() => tv({ extend: tv(theme), ...(appConfig.b24ui?.pageSection || {}) })({
@@ -159,7 +161,7 @@ const b24ui = computed(() => tv({ extend: tv(theme), ...(appConfig.b24ui?.pageSe
       </div>
 
       <slot v-if="!!slots.default" />
-      <div v-else-if="props.orientation === 'horizontal'" class="hidden lg:block" />
+      <div v-else-if="props.orientation === 'horizontal'" :class="prefix('hidden lg:block')" />
     </B24Container>
 
     <slot name="bottom" />

--- a/src/runtime/components/User.vue
+++ b/src/runtime/components/User.vue
@@ -46,6 +46,7 @@ import { computed } from 'vue'
 import { Primitive } from 'reka-ui'
 import { useAppConfig } from '#imports'
 import { useComponentProps } from '../composables/useComponentProps'
+import { usePrefix } from '../composables/usePrefix'
 import { tv } from '../utils/tv'
 import B24Chip from './Chip.vue'
 import B24Avatar from './Avatar.vue'
@@ -61,6 +62,7 @@ const slots = defineSlots<UserSlots>()
 const props = useComponentProps('user', _props)
 
 const appConfig = useAppConfig() as User['AppConfig']
+const prefix = usePrefix()
 
 // eslint-disable-next-line vue/no-dupe-keys
 const b24ui = computed(() => tv({ extend: tv(theme), ...(appConfig.b24ui?.user || {}) })({
@@ -106,10 +108,10 @@ const chipSize = computed<ChipProps['size']>(() => {
         v-if="props.to"
         :aria-label="props.name"
         v-bind="{ to: props.to, target: props.target, ...$attrs }"
-        class="focus:outline-none peer"
+        :class="prefix('focus:outline-none peer')"
         raw
       >
-        <span class="absolute inset-0" aria-hidden="true" />
+        <span :class="prefix('absolute inset-0')" aria-hidden="true" />
       </B24Link>
 
       <slot>

--- a/src/runtime/components/color-mode/ColorModeAvatar.vue
+++ b/src/runtime/components/color-mode/ColorModeAvatar.vue
@@ -10,6 +10,7 @@ export interface ColorModeAvatarProps extends Omit<AvatarProps, 'src'> {
 <script setup lang="ts">
 import { useForwardProps } from 'reka-ui'
 import { reactiveOmit } from '@vueuse/core'
+import { usePrefix } from '../../composables/usePrefix'
 import B24Avatar from '../Avatar.vue'
 
 defineOptions({ inheritAttrs: false })
@@ -17,9 +18,10 @@ defineOptions({ inheritAttrs: false })
 const props = defineProps<ColorModeAvatarProps>()
 
 const avatarProps = useForwardProps(reactiveOmit(props, 'light', 'dark'))
+const prefix = usePrefix()
 </script>
 
 <template>
-  <B24Avatar v-bind="{ ...avatarProps, ...$attrs }" :src="light" class="dark:hidden" />
-  <B24Avatar v-bind="{ ...avatarProps, ...$attrs }" :src="dark" class="hidden dark:block" />
+  <B24Avatar v-bind="{ ...avatarProps, ...$attrs }" :src="light" :class="prefix('dark:hidden')" />
+  <B24Avatar v-bind="{ ...avatarProps, ...$attrs }" :src="dark" :class="prefix('hidden dark:block')" />
 </template>

--- a/src/runtime/components/color-mode/ColorModeButton.vue
+++ b/src/runtime/components/color-mode/ColorModeButton.vue
@@ -16,6 +16,7 @@ import { useColorMode } from '#imports'
 import { useComponentProps } from '../../composables/useComponentProps'
 import { useForwardProps } from '../../composables/useForwardProps'
 import { useLocale } from '../../composables/useLocale'
+import { usePrefix } from '../../composables/usePrefix'
 import icons from '../../dictionary/icons'
 import B24Button from '../Button.vue'
 
@@ -32,6 +33,7 @@ const colorMode = useColorMode()
 // const appConfig = useAppConfig()
 
 const buttonProps = useForwardProps(reactiveOmit(props, 'icon'))
+const prefix = usePrefix()
 
 const isDark = computed({
   get() {
@@ -53,8 +55,8 @@ const isDark = computed({
     @click="isDark = !isDark"
   >
     <template #leading="{ b24ui }">
-      <Component :is="icons.dark" data-slot="leadingIcon" :class="b24ui.leadingIcon({ class: [props.b24ui?.leadingIcon, 'hidden dark:inline-block'] })" />
-      <Component :is="icons.light" data-slot="leadingIcon" :class="b24ui.leadingIcon({ class: [props.b24ui?.leadingIcon, 'dark:hidden'] })" />
+      <Component :is="icons.dark" data-slot="leadingIcon" :class="b24ui.leadingIcon({ class: [props.b24ui?.leadingIcon, prefix('hidden dark:inline-block')] })" />
+      <Component :is="icons.light" data-slot="leadingIcon" :class="b24ui.leadingIcon({ class: [props.b24ui?.leadingIcon, prefix('dark:hidden')] })" />
     </template>
   </B24Button>
 </template>

--- a/src/runtime/components/color-mode/ColorModeImage.vue
+++ b/src/runtime/components/color-mode/ColorModeImage.vue
@@ -11,6 +11,7 @@ export interface ColorModeImageProps extends /** @vue-ignore */ Omit<ImgHTMLAttr
 import { computed } from 'vue'
 import { useRuntimeConfig } from '#imports'
 import ImageComponent from '#build/b24ui-image-component'
+import { usePrefix } from '../../composables/usePrefix'
 import { resolveBaseURL } from '../../utils'
 
 defineOptions({ inheritAttrs: false })
@@ -19,9 +20,10 @@ const props = defineProps<ColorModeImageProps>()
 
 const refinedLight = computed(() => resolveBaseURL(props.light, useRuntimeConfig().app.baseURL))
 const refinedDark = computed(() => resolveBaseURL(props.dark, useRuntimeConfig().app.baseURL))
+const prefix = usePrefix()
 </script>
 
 <template>
-  <component :is="ImageComponent" :src="refinedLight" class="dark:hidden" v-bind="$attrs" />
-  <component :is="ImageComponent" :src="refinedDark" class="hidden dark:block" v-bind="$attrs" />
+  <component :is="ImageComponent" :src="refinedLight" :class="prefix('dark:hidden')" v-bind="$attrs" />
+  <component :is="ImageComponent" :src="refinedDark" :class="prefix('hidden dark:block')" v-bind="$attrs" />
 </template>

--- a/src/runtime/components/content/ContentSurround.vue
+++ b/src/runtime/components/content/ContentSurround.vue
@@ -58,6 +58,7 @@ import { createReusableTemplate } from '@vueuse/core'
 import { useAppConfig } from '#imports'
 import { useComponentProps } from '../../composables/useComponentProps'
 import { useLocale } from '../../composables/useLocale'
+import { usePrefix } from '../../composables/usePrefix'
 import { tv } from '../../utils/tv'
 import icons from '../../dictionary/icons'
 import B24Link from '../Link.vue'
@@ -72,6 +73,7 @@ const props = useComponentProps<ContentSurroundProps<T>>('contentSurround', _pro
 
 const { dir } = useLocale()
 const appConfig = useAppConfig() as ContentSurround['AppConfig']
+const prefix = usePrefix()
 
 const [DefineLinkTemplate, ReuseLinkTemplate] = createReusableTemplate<{ link?: ContentSurroundLink, icon: IconComponent, direction: 'left' | 'right' }>({
   props: {
@@ -123,7 +125,7 @@ const nextIcon = computed(() => props.nextIcon || (dir.value === 'rtl' ? icons.a
         </p>
       </slot>
     </B24Link>
-    <span v-else class="hidden sm:block">&nbsp;</span>
+    <span v-else :class="prefix('hidden sm:block')">&nbsp;</span>
   </DefineLinkTemplate>
 
   <Primitive v-if="props.surround" :as="props.as" v-bind="$attrs" data-slot="root" :class="b24ui.root({ class: [props.b24ui?.root, props.class] })">

--- a/src/runtime/components/content/ContentToc.vue
+++ b/src/runtime/components/content/ContentToc.vue
@@ -66,6 +66,7 @@ import { useComponentProps } from '../../composables/useComponentProps'
 import { useForwardProps } from '../../composables/useForwardProps'
 import { useScrollspy } from '../../composables/useScrollspy'
 import { useLocale } from '../../composables/useLocale'
+import { usePrefix } from '../../composables/usePrefix'
 import { tv } from '../../utils/tv'
 import icons from '../../dictionary/icons'
 
@@ -84,6 +85,7 @@ const rootProps = useForwardProps(reactivePick(props, 'as', 'open', 'defaultOpen
 const { t } = useLocale()
 const router = useRouter()
 const appConfig = useAppConfig() as ContentToc['AppConfig']
+const prefix = usePrefix()
 const { activeHeadings, updateHeadings } = useScrollspy()
 
 const [DefineListTemplate, ReuseListTemplate] = createReusableTemplate<{ links: T[], level: number }>({
@@ -193,21 +195,21 @@ onUnmounted(() => {
       </div>
 
       <template v-if="props.links?.length">
-        <CollapsibleTrigger data-slot="trigger" :class="b24ui.trigger({ class: [props.b24ui?.trigger, 'lg:hidden'] })">
+        <CollapsibleTrigger data-slot="trigger" :class="b24ui.trigger({ class: [props.b24ui?.trigger, prefix('lg:hidden')] })">
           <ReuseTriggerTemplate :open="open" />
         </CollapsibleTrigger>
 
-        <CollapsibleContent data-slot="content" :class="b24ui.content({ class: [props.b24ui?.content, 'lg:hidden'] })">
+        <CollapsibleContent data-slot="content" :class="b24ui.content({ class: [props.b24ui?.content, prefix('lg:hidden')] })">
           <slot name="content" :links="props.links">
             <ReuseListTemplate :links="props.links" :level="0" />
           </slot>
         </CollapsibleContent>
 
-        <p data-slot="trigger" :class="b24ui.trigger({ class: [props.b24ui?.trigger, 'hidden lg:flex'] })">
+        <p data-slot="trigger" :class="b24ui.trigger({ class: [props.b24ui?.trigger, prefix('hidden lg:flex')] })">
           <ReuseTriggerTemplate :open="open" />
         </p>
 
-        <div data-slot="content" :class="b24ui.content({ class: [props.b24ui?.content, 'hidden lg:flex'] })">
+        <div data-slot="content" :class="b24ui.content({ class: [props.b24ui?.content, prefix('hidden lg:flex')] })">
           <slot name="content" :links="props.links">
             <ReuseListTemplate :links="props.links" :level="0" />
           </slot>

--- a/src/runtime/composables/usePrefix.ts
+++ b/src/runtime/composables/usePrefix.ts
@@ -1,0 +1,22 @@
+import { useAppConfig } from '#imports'
+
+/**
+ * Prefixes Tailwind utility class strings with the configured `theme.prefix`,
+ * so static utility classes inside Bitrix24 UI components match the consumer's
+ * Tailwind `prefix(...)` configuration.
+ */
+export function usePrefix() {
+  const appConfig = useAppConfig() as { b24ui?: { prefix?: string } }
+  const prefix = appConfig.b24ui?.prefix
+
+  return (classString: string): string => {
+    if (!prefix || !classString) {
+      return classString
+    }
+    return classString
+      .split(/\s+/)
+      .filter(Boolean)
+      .map(cls => `${prefix}:${cls}`)
+      .join(' ')
+  }
+}


### PR DESCRIPTION
## Live sync — next commit in queue

**Upstream:** [`f51b1e88`](https://github.com/nuxt/ui/commit/f51b1e8809b5a35e9e3583db7a433cd7dd2c8f97) — fix(components): apply `theme.prefix` to hardcoded utility classes

Immediate next commit after `083c2a98` (#112).

### Problem
Static utility classes hardcoded in component templates (`focus:outline-none`, `dark:hidden`, `hidden lg:block`, …) bypass `applyPrefixToObject` (which only walks theme objects). With a consumer `theme.prefix` + matching Tailwind `prefix(...)`, those classes silently stop applying — both light/dark `ColorMode*` variants render at once, mobile + desktop `ContentToc` both show, overlay anchors lose focus styles, etc.

### Change
- **New `src/runtime/composables/usePrefix.ts`** — returns `(classString) => prefixedClassString`. **Adaptation:** reads `appConfig.b24ui?.prefix` (upstream: `appConfig.ui?.prefix`). That value is already populated by `getDefaultConfig(options.theme)` (`src/utils/defaults.ts`), so it's available at runtime; logic mirrors b24ui's build-time `prefixClasses` (`src/utils/theme.ts`).
- **Wrapped hardcoded utility strings** with `prefix(...)` in the **10** affected components present in b24ui: `Banner`, `PageCard`, `PageFeature`, `PageSection`, `User`, `ColorMode{Avatar,Button,Image}`, `ContentSurround`, `ContentToc`. Class literals matched upstream exactly; only surrounding markup differs (`B24*` imports, `appConfig.b24ui`, `icons` dictionary, `<slot name="content">` in ContentToc).

### Skipped vs upstream
- **BlogPost, ChangelogVersion, PageCTA, PageHero** — not present in b24ui.
- **prose/Card, prose/Callout** carry the same literals but this upstream commit doesn't touch prose components → left 1:1 (revisit if a later commit prefixes them).

### Validation (linux verify; windows .ps1 in chat)
- ✅ `dev:prepare` · ✅ `typecheck` · ✅ `lint` · ✅ `vitest run` — **4971 passed | 6 skipped** · ✅ module `build`
- No snapshot changes: with an empty prefix, `prefix(cls)` returns `cls` unchanged, so rendered output is identical.

### Ledger
- `.sync/nuxt-ui.json`: `cursor` → `f51b1e88`; `083c2a98` finalized (`pr: 112`, `b24ui_sha: 8bd6ed89`).
- `.sync/log/f51b1e88….md`: decision record.

https://claude.ai/code/session_01Qz7EXMncvEGiCj4WbmYgJo

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qz7EXMncvEGiCj4WbmYgJo)_