### PR TITLE
fix(ContentSearch): preserve intermediate ancestors in breadcrumb prefix

### DIFF
--- a/.sync/log/f639b19db25161ce0cd34f0e21c3303f8fe3caf8.md
+++ b/.sync/log/f639b19db25161ce0cd34f0e21c3303f8fe3caf8.md
@@ -1,0 +1,37 @@
+# port — nuxt/ui@f639b19db25161ce0cd34f0e21c3303f8fe3caf8
+
+**Upstream:** fix(ContentSearch): preserve intermediate ancestors in breadcrumb prefix (#6466)
+
+**Decision:** port (adapted). Follow-up to a1bef8ba (#111).
+
+## Problem
+`mapFile` / `findNavItem` / `mapSearchResults` only tracked the top-level root
++ the immediate parent, so results more than two nav levels deep dropped every
+intermediate ancestor from the breadcrumb prefix.
+
+## Change
+- **src/runtime/composables/useContentSearch.ts** — track the **full ancestor
+  chain**:
+  - `mapFile(file, link, ancestors[])` — prefix from `ancestors.map(a => a.title)`
+    + `file.titles`; icon falls back to `ancestors.findLast(a => a.icon)?.icon`.
+  - `visit(nodes, ancestors[])` accumulates `[...ancestors, link]`; entry call
+    `visit(children, parent ? [parent] : [])`.
+  - `findNavItem` returns `{ link, ancestors }` (root → parent chain) instead of
+    `{ link, parent, root }`.
+  - `mapSearchResults` builds `sectionChain = ancestors.length ? ancestors :
+    (link ? [link] : [])` (fallback keeps top-level index-page section titles).
+  - **Adaptation:** kept b24ui's `icons.hash`/`icons.file` dictionary +
+    `IconComponent` cast (upstream uses `appConfig.ui.icons.* as string`).
+- **test/components/content/ContentSearch.spec.ts** — added the deeply-nested
+  regression test (`Docs > Guide > Best Practices >`).
+
+## Docs / meta (applied — b24ui structures matched)
+- `docs/app/components/chat/Chat.vue` — `meta_i` now closes ContentSearch and
+  opens Chat when search is open (`const { open: searchOpen } = useContentSearch()`).
+- `docs/app/composables/useSearch.ts` — dropped the now-redundant "Ask AI"
+  `description` line (kept b24icon `RobotIcon`).
+- `AGENTS.md` — added the PR-description checklist line (b24ui has
+  `.github/PULL_REQUEST_TEMPLATE.md`).
+
+**Validation:** dev:prepare · typecheck · lint · vitest run (4972 passed | 6
+skipped, +1 new test, no snapshot changes) · module build.

--- a/.sync/nuxt-ui.json
+++ b/.sync/nuxt-ui.json
@@ -2,7 +2,7 @@
   "upstream": "nuxt/ui",
   "branch": "v4",
   "sync_enabled": false,
-  "cursor": "f51b1e8809b5a35e9e3583db7a433cd7dd2c8f97",
+  "cursor": "f639b19db25161ce0cd34f0e21c3303f8fe3caf8",
   "_cursor_note": "cursor = last upstream commit ported into b24ui (oldest-first, manual cadence). sync_enabled stays false until Phase 2 (porter workflow #67 + CLAUDE_CODE_OAUTH_TOKEN) is wired and trusted. `processed` is maintained per port from now on (backfilled #68-#72 on 2026-06-09).",
   "stats": {
     "queue_depth": 0,
@@ -131,10 +131,16 @@
       "summary": "fix(module): ship stripped #build/b24ui.css fallback (b24ui.static.css) for tooling"
     },
     "f51b1e8809b5a35e9e3583db7a433cd7dd2c8f97": {
+      "pr": 113,
+      "b24ui_sha": "47dbcedf",
+      "decision": "port",
+      "summary": "fix(components): apply theme.prefix to hardcoded utility classes via usePrefix (10 of 14 components; rest absent in b24ui)"
+    },
+    "f639b19db25161ce0cd34f0e21c3303f8fe3caf8": {
       "pr": null,
       "b24ui_sha": "pending-merge",
       "decision": "port",
-      "summary": "fix(components): apply theme.prefix to hardcoded utility classes via usePrefix (10 of 14 components; rest absent in b24ui)"
+      "summary": "fix(ContentSearch): preserve intermediate ancestors in breadcrumb prefix (follow-up to #111)"
     }
   }
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -143,6 +143,7 @@ PR Review:
 - [ ] `pnpm run test` passes
 - [ ] Documentation is updated if applicable
 - [ ] Commit message follows conventional commits
+- [ ] PR description follows [.github/PULL_REQUEST_TEMPLATE.md](.github/PULL_REQUEST_TEMPLATE.md) (linked issue, type of change, description, checklist)
 
 Multiple commits are fine — PRs are squash merged, so no need to rebase or force push.
 

--- a/docs/app/components/chat/Chat.vue
+++ b/docs/app/components/chat/Chat.vue
@@ -23,6 +23,7 @@ const toast = useToast()
 const { track } = useAnalytics()
 const route = useRoute()
 const { open, messages } = useChat()
+const { open: searchOpen } = useContentSearch()
 const { framework } = useFrameworks()
 const { resetTheme, applyThemeSettings, hasCSSChanges, hasConfigChanges } = useTheme()
 
@@ -186,7 +187,12 @@ function clearMessages() {
 defineShortcuts({
   meta_i: {
     handler: () => {
-      open.value = !open.value
+      if (searchOpen.value) {
+        searchOpen.value = false
+        open.value = true
+      } else {
+        open.value = !open.value
+      }
     },
     usingInput: true
   }

--- a/docs/app/composables/useSearch.ts
+++ b/docs/app/composables/useSearch.ts
@@ -46,7 +46,6 @@ export function useSearch() {
   const links = computed(() => [
     isAssistantEnabled.value && {
       label: 'Ask AI',
-      description: 'Ask the AI assistant powered by our custom MCP server for help.',
       icon: RobotIcon,
       kbds: ['meta', 'i'],
       b24ui: {

--- a/src/runtime/composables/useContentSearch.ts
+++ b/src/runtime/composables/useContentSearch.ts
@@ -17,16 +17,18 @@ function _useContentSearch() {
   function mapFile(
     file: ContentSearchFile,
     link: ContentNavigationItem,
-    parent?: ContentNavigationItem
+    ancestors: ContentNavigationItem[] = []
   ): ContentSearchItem {
-    const prefix = [...new Set([parent?.title, ...file.titles].filter(Boolean))]
+    // Top-level section title is omitted — items render under their section's group label.
+    const prefix = [...new Set([...ancestors.map(a => a.title), ...file.titles].filter(Boolean))]
+    const ancestorIcon = ancestors.findLast(a => a.icon)?.icon
 
     return {
       prefix: prefix?.length ? (prefix.join(' > ') + ' >') : undefined,
       label: file.id === link.path ? link.title : file.title,
       suffix: file.content.replaceAll('<', '&lt;').replaceAll('>', '&gt;'),
       to: file.id,
-      icon: (link.icon || parent?.icon || (file.level > 1 ? icons.hash : icons.file)) as IconComponent,
+      icon: (link.icon || ancestorIcon || (file.level > 1 ? icons.hash : icons.file)) as IconComponent,
       level: file.level
     }
   }
@@ -55,19 +57,19 @@ function _useContentSearch() {
 
     function visit(
       nodes: ContentNavigationItem[],
-      nodeParent?: ContentNavigationItem
+      ancestors: ContentNavigationItem[]
     ): ContentSearchItem[] {
       return nodes.flatMap((link) => {
         if (link.children?.length) {
-          return visit(link.children, link)
+          return visit(link.children, [...ancestors, link])
         }
 
         const matched = link.path ? filesByPath.get(link.path) : undefined
-        return matched?.map(file => mapFile(file, link, nodeParent)) || []
+        return matched?.map(file => mapFile(file, link, ancestors)) || []
       })
     }
 
-    return visit(children, parent)
+    return visit(children, parent ? [parent] : [])
   }
 
   /**
@@ -90,14 +92,13 @@ function _useContentSearch() {
   }
 
   /**
-   * Find a navigation item by path
+   * Find a navigation item by path, returning the full ancestor chain (root → parent).
    */
-  function findNavItem(path: string, nodes?: ContentNavigationItem[], root?: ContentNavigationItem, parent?: ContentNavigationItem): { link?: ContentNavigationItem, parent?: ContentNavigationItem, root?: ContentNavigationItem } {
+  function findNavItem(path: string, nodes?: ContentNavigationItem[], ancestors: ContentNavigationItem[] = []): { link?: ContentNavigationItem, ancestors?: ContentNavigationItem[] } {
     for (const node of nodes || []) {
-      const currentRoot = root || node
-      if (node.path === path) return { link: node, parent, root: currentRoot }
+      if (node.path === path) return { link: node, ancestors }
       if (node.children?.length) {
-        const found = findNavItem(path, node.children, currentRoot, node)
+        const found = findNavItem(path, node.children, [...ancestors, node])
         if (found.link) return found
       }
     }
@@ -122,17 +123,18 @@ function _useContentSearch() {
         nav = findNavItem(basePath, navigation)
         navCache.set(basePath, nav)
       }
-      const { link, parent, root } = nav
+      const { link, ancestors = [] } = nav
 
       if (navigation?.length && !link) return acc
 
-      // Include `root?.title` so index pages still show their section name in the
-      // prefix. `findNavItem` returns the section root when a result's path matches
-      // a top-level node directly (e.g. `/docs/typography` from `1.index.md`), which
-      // leaves `parent` undefined and would otherwise drop the section context.
-      // For sub-pages, `root.title === parent.title`, and the `Set` dedupes it.
-      const prefixParts = [...new Set([root?.title, parent?.title, ...result.titles].filter(Boolean))]
+      // Fall back to the matched link when ancestors is empty so top-level
+      // index-page results still show their section title (results are flat
+      // here — no group label like `mapFile`).
+      const sectionChain = ancestors.length ? ancestors : (link ? [link] : [])
+      const prefixParts = [...new Set([...sectionChain.map(s => s.title), ...result.titles].filter(Boolean))]
       const prefix = prefixParts.length ? (prefixParts.join(' > ') + ' >') : undefined
+
+      const ancestorIcon = ancestors.findLast(a => a.icon)?.icon
 
       acc.push({
         label: result.title,
@@ -141,7 +143,7 @@ function _useContentSearch() {
         description: result.content.replaceAll('<', '&lt;').replaceAll('>', '&gt;'),
         descriptionHtml: result.snippets?.content ? sanitizeSnippet(result.snippets.content) : undefined,
         to: result.id,
-        icon: (link?.icon || parent?.icon || root?.icon || (result.level > 1 ? icons.hash : icons.file)) as IconComponent,
+        icon: (link?.icon || ancestorIcon || (result.level > 1 ? icons.hash : icons.file)) as IconComponent,
         level: result.level
       })
 

--- a/test/components/content/ContentSearch.spec.ts
+++ b/test/components/content/ContentSearch.spec.ts
@@ -205,5 +205,53 @@ describe('ContentSearch', () => {
 
       wrapper.unmount()
     })
+
+    // Regression test: results more than two nav levels deep used to drop
+    // every intermediate ancestor because `findNavItem` only tracked the
+    // top-level root and the immediate parent.
+    it('includes every intermediate ancestor in the prefix for deeply nested results', async () => {
+      vi.useFakeTimers({ shouldAdvanceTime: true })
+      const deepNavigation = [{
+        title: 'Docs',
+        path: '/docs',
+        children: [{
+          title: 'Guide',
+          path: '/docs/guide',
+          children: [{
+            title: 'Best Practices',
+            path: '/docs/guide/best-practices',
+            children: [{
+              title: 'Nuxt Plugins',
+              path: '/docs/guide/best-practices/plugins'
+            }]
+          }]
+        }]
+      }]
+      const search = vi.fn(async () => [{
+        id: '/docs/guide/best-practices/plugins',
+        title: 'Nuxt Plugins',
+        titles: [],
+        level: 1,
+        content: 'lorem ipsum'
+      }])
+
+      const wrapper = await mountSuspended(ContentSearch, {
+        props: {
+          open: true,
+          portal: false,
+          navigation: deepNavigation,
+          search,
+          searchTerm: ''
+        }
+      })
+
+      await wrapper.setProps({ searchTerm: 'lorem' })
+      await vi.advanceTimersByTimeAsync(150)
+      await wrapper.vm.$nextTick()
+
+      expect(wrapper.text()).toContain('Docs > Guide > Best Practices >')
+
+      wrapper.unmount()
+    })
   })
 })


### PR DESCRIPTION
## Live sync — next commit in queue

**Upstream:** [`f639b19d`](https://github.com/nuxt/ui/commit/f639b19db25161ce0cd34f0e21c3303f8fe3caf8) — fix(ContentSearch): preserve intermediate ancestors in breadcrumb prefix (#6466)

Immediate next commit after `f51b1e88` (#113). **Follow-up to #111** — lands on the ContentSearch async-search code ported there.

### Problem
`mapFile` / `findNavItem` / `mapSearchResults` only tracked the top-level root + the immediate parent, so results **more than two nav levels deep** dropped every intermediate ancestor from the breadcrumb prefix (e.g. showed `Docs >` instead of `Docs > Guide > Best Practices >`).

### Change
- **`src/runtime/composables/useContentSearch.ts`** — track the **full ancestor chain**:
  - `mapFile(file, link, ancestors[])` — prefix from `ancestors.map(a => a.title)` + `file.titles`; icon falls back to `ancestors.findLast(a => a.icon)?.icon`.
  - `visit(nodes, ancestors[])` accumulates `[...ancestors, link]`; entry `visit(children, parent ? [parent] : [])`.
  - `findNavItem` returns `{ link, ancestors }` (root → parent) instead of `{ link, parent, root }`.
  - `mapSearchResults` uses `sectionChain = ancestors.length ? ancestors : (link ? [link] : [])` — fallback keeps top-level index-page section titles.
  - **Adaptation:** kept b24ui's `icons.hash`/`icons.file` dictionary + `IconComponent` cast (upstream uses `appConfig.ui.icons.* as string`).
- **`test/.../ContentSearch.spec.ts`** — added the deeply-nested regression test.

### Docs / meta (applied — b24ui structures matched)
- `docs/app/components/chat/Chat.vue` — `meta_i` hands off from ContentSearch to the assistant when search is open.
- `docs/app/composables/useSearch.ts` — dropped the redundant "Ask AI" `description` (kept b24icon `RobotIcon`).
- `AGENTS.md` — added the PR-template checklist line (b24ui has `.github/PULL_REQUEST_TEMPLATE.md`).

### Validation (linux verify; windows .ps1 in chat)
- ✅ `dev:prepare` · ✅ `typecheck` · ✅ `lint` · ✅ `vitest run` — **4972 passed | 6 skipped** (+1 new test, no snapshot changes) · ✅ module `build`

### Ledger
- `.sync/nuxt-ui.json`: `cursor` → `f639b19d`; `f51b1e88` finalized (`pr: 113`, `b24ui_sha: 47dbcedf`).
- `.sync/log/f639b19d….md`: decision record.

https://claude.ai/code/session_01Qz7EXMncvEGiCj4WbmYgJo

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qz7EXMncvEGiCj4WbmYgJo)_