### PR TITLE
chore(deps): update pnpm/action-setup action to v6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v5
+        uses: pnpm/action-setup@v6
 
       - name: Install node
         uses: actions/setup-node@v6

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,7 +37,7 @@ jobs:
           fetch-depth: 0
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v5
+        uses: pnpm/action-setup@v6
 
       - name: Install node
         uses: actions/setup-node@v6

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -51,7 +51,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v5
+        uses: pnpm/action-setup@v6
 
       - name: Install node
         uses: actions/setup-node@v6

--- a/.sync/log/dc3141cf1618a6978af6250417e9ecf8f1e44f15.md
+++ b/.sync/log/dc3141cf1618a6978af6250417e9ecf8f1e44f15.md
@@ -1,0 +1,25 @@
+# port — nuxt/ui@dc3141cf1618a6978af6250417e9ecf8f1e44f15
+
+**Upstream:** chore(deps): update pnpm/action-setup action to v6 (#6469)
+
+**Decision:** port (adapted to b24ui's workflow set).
+
+## Change
+Bump `pnpm/action-setup@v5` → `@v6` in b24ui's GitHub Actions workflows:
+- `.github/workflows/ci.yml`
+- `.github/workflows/deploy.yml`
+- `.github/workflows/npm-publish.yml`
+
+## Adaptation notes
+- Upstream touched `module.yml` + `release.yml` (12 + 1 occurrences). b24ui has
+  a different workflow set (`ci.yml`, `deploy.yml`, `npm-publish.yml`) — applied
+  the same bump to b24ui's 3 occurrences.
+- `pnpm/action-setup@v6` resolves the pnpm version from the `packageManager`
+  field; b24ui's `package.json` declares `"packageManager": "pnpm@10.33.4"`,
+  and no workflow pins a `version:` input, so the upgrade is drop-in.
+
+## Validation
+CI-only change — local code verify (typecheck/lint/vitest/build) is N/A (no
+buildable source touched). Verified all 3 workflow YAMLs still parse; the
+definitive check is this PR's own CI run, which now exercises
+`action-setup@v6`.

--- a/.sync/nuxt-ui.json
+++ b/.sync/nuxt-ui.json
@@ -2,7 +2,7 @@
   "upstream": "nuxt/ui",
   "branch": "v4",
   "sync_enabled": false,
-  "cursor": "f639b19db25161ce0cd34f0e21c3303f8fe3caf8",
+  "cursor": "dc3141cf1618a6978af6250417e9ecf8f1e44f15",
   "_cursor_note": "cursor = last upstream commit ported into b24ui (oldest-first, manual cadence). sync_enabled stays false until Phase 2 (porter workflow #67 + CLAUDE_CODE_OAUTH_TOKEN) is wired and trusted. `processed` is maintained per port from now on (backfilled #68-#72 on 2026-06-09).",
   "stats": {
     "queue_depth": 0,
@@ -137,10 +137,16 @@
       "summary": "fix(components): apply theme.prefix to hardcoded utility classes via usePrefix (10 of 14 components; rest absent in b24ui)"
     },
     "f639b19db25161ce0cd34f0e21c3303f8fe3caf8": {
+      "pr": 114,
+      "b24ui_sha": "25e89d68",
+      "decision": "port",
+      "summary": "fix(ContentSearch): preserve intermediate ancestors in breadcrumb prefix (follow-up to #111)"
+    },
+    "dc3141cf1618a6978af6250417e9ecf8f1e44f15": {
       "pr": null,
       "b24ui_sha": "pending-merge",
       "decision": "port",
-      "summary": "fix(ContentSearch): preserve intermediate ancestors in breadcrumb prefix (follow-up to #111)"
+      "summary": "chore(deps): update pnpm/action-setup action to v6 (3 b24ui workflows)"
     }
   }
 }


### PR DESCRIPTION
## Live sync — next commit in queue

**Upstream:** [`dc3141cf`](https://github.com/nuxt/ui/commit/dc3141cf1618a6978af6250417e9ecf8f1e44f15) — chore(deps): update pnpm/action-setup action to v6 (#6469)

Immediate next commit after `f639b19d` (#114).

### Change
Bump `pnpm/action-setup@v5` → `@v6` in b24ui's GitHub Actions workflows:
- `.github/workflows/ci.yml`
- `.github/workflows/deploy.yml`
- `.github/workflows/npm-publish.yml`

### Adaptation
- Upstream touched `module.yml` + `release.yml`; b24ui has a different workflow set, so the same bump was applied to b24ui's 3 occurrences.
- `action-setup@v6` resolves the pnpm version from the `packageManager` field — b24ui declares `"packageManager": "pnpm@10.33.4"` and no workflow pins a `version:` input, so it's drop-in.

### Validation
CI-only change — local code verify (typecheck/lint/vitest/build) is **N/A** (no buildable source touched). All 3 workflow YAMLs parse cleanly; the definitive check is **this PR's own CI run**, which now exercises `action-setup@v6`. (No Windows .ps1 — nothing to run locally.)

### Ledger
- `.sync/nuxt-ui.json`: `cursor` → `dc3141cf`; `f639b19d` finalized (`pr: 114`, `b24ui_sha: 25e89d68`).
- `.sync/log/dc3141cf….md`: decision record.

https://claude.ai/code/session_01Qz7EXMncvEGiCj4WbmYgJo

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qz7EXMncvEGiCj4WbmYgJo)_