### PR TITLE
chore(deps): update vite

### DIFF
--- a/.sync/log/527b4389957b646f522c42b0219666a3424c4b2a.md
+++ b/.sync/log/527b4389957b646f522c42b0219666a3424c4b2a.md
@@ -1,0 +1,26 @@
+# port — nuxt/ui@527b4389957b646f522c42b0219666a3424c4b2a
+
+**Upstream:** chore(deps): update vite (#6263)
+
+**Decision:** port (full apply — all shared with b24ui).
+
+## Change
+Bump the vite/vue dep ranges everywhere they appear (b24ui carried the same
+pre-versions) and regenerate the lockfile:
+- `package.json`: `@vitejs/plugin-vue` ^6.0.5 → **^6.0.7**, `vue` ^3.5.30 → **^3.5.34**.
+- `playgrounds/repl/package.json`: `vue` ^3.5.30 → ^3.5.34, `@vitejs/plugin-vue`
+  ^6.0.5 → ^6.0.7, `vite` ^7.3.1 → **^7.3.3**.
+- `playgrounds/vue/package.json`: `vue` ^3.5.30 → ^3.5.34, `vue-router`
+  ^5.0.4 → **^5.0.7**, `@vitejs/plugin-vue` ^6.0.5 → ^6.0.7, `vite` ^7.3.1 → ^7.3.3.
+
+## Notes
+- `pnpm install` + **`pnpm dedupe`** → lockfile keeps a single `vite@7.3.5` and
+  single `vue@3.5.38` (no duplicates — proactively avoiding the dual-vite issue
+  that broke #117's first CI run).
+- Most ranges were already satisfied by #117's resolve; this realigns the
+  declared ranges with upstream.
+
+## Validation
+Verified with a **frozen-lockfile** install (mirrors CI): dev:prepare ·
+typecheck · lint · vitest run (4972 passed | 6 skipped) · module build — all
+green.

--- a/.sync/nuxt-ui.json
+++ b/.sync/nuxt-ui.json
@@ -2,7 +2,7 @@
   "upstream": "nuxt/ui",
   "branch": "v4",
   "sync_enabled": false,
-  "cursor": "3736eeeb2d3adff03a33db275edecaaf25f01dc5",
+  "cursor": "527b4389957b646f522c42b0219666a3424c4b2a",
   "_cursor_note": "cursor = last upstream commit ported into b24ui (oldest-first, manual cadence). sync_enabled stays false until Phase 2 (porter workflow #67 + CLAUDE_CODE_OAUTH_TOKEN) is wired and trusted. `processed` is maintained per port from now on (backfilled #68-#72 on 2026-06-09).",
   "stats": {
     "queue_depth": 0,
@@ -155,10 +155,16 @@
       "summary": "chore(deps): update all non-major dependencies (docs: mcp-toolkit/takumi/og-image/shiki + lockfile regen)"
     },
     "3736eeeb2d3adff03a33db275edecaaf25f01dc5": {
+      "pr": 117,
+      "b24ui_sha": "b538d45c",
+      "decision": "port",
+      "summary": "chore(deps): update nuxt framework to ^4.4.6 (+ LinkBase href string|null forward-port; + vite dedupe for CI)"
+    },
+    "527b4389957b646f522c42b0219666a3424c4b2a": {
       "pr": null,
       "b24ui_sha": "pending-merge",
       "decision": "port",
-      "summary": "chore(deps): update nuxt framework to ^4.4.6 (+ LinkBase href string|null forward-port for vue-router types)"
+      "summary": "chore(deps): update vite/vue/plugin-vue/vue-router ranges (root + repl/vue playgrounds) + lockfile dedupe"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -207,7 +207,7 @@
     "@nuxt/module-builder": "^1.0.2",
     "@nuxt/test-utils": "^4.0.2",
     "@tanstack/table-core": "^8.21.3",
-    "@vitejs/plugin-vue": "^6.0.5",
+    "@vitejs/plugin-vue": "^6.0.7",
     "@vue/test-utils": "^2.4.10",
     "ai": "^6.0.185",
     "embla-carousel": "^8.6.0",
@@ -218,7 +218,7 @@
     "vitest": "^4.1.6",
     "vitest-axe": "^0.1.0",
     "vitest-environment-nuxt": "^1.0.1",
-    "vue": "^3.5.30",
+    "vue": "^3.5.34",
     "vue-tsc": "^3.3.0",
     "@types/canvas-confetti": "^1.9.0",
     "@types/node": "^25.3.0"

--- a/playgrounds/repl/package.json
+++ b/playgrounds/repl/package.json
@@ -12,10 +12,10 @@
     "@bitrix24/b24ui-nuxt": "workspace:*",
     "@vue/repl": "^4.7.2",
     "tailwindcss": "^4.3.0",
-    "vue": "^3.5.30"
+    "vue": "^3.5.34"
   },
   "devDependencies": {
-    "@vitejs/plugin-vue": "^6.0.5",
-    "vite": "^7.3.1"
+    "@vitejs/plugin-vue": "^6.0.7",
+    "vite": "^7.3.3"
   }
 }

--- a/playgrounds/vue/package.json
+++ b/playgrounds/vue/package.json
@@ -16,15 +16,15 @@
     "@tiptap/extension-text-align": "^3.22.4",
     "@internationalized/date": "^3.9.0",
     "tailwindcss": "^4.3.0",
-    "vue": "^3.5.30",
-    "vue-router": "^5.0.4",
+    "vue": "^3.5.34",
+    "vue-router": "^5.0.7",
     "zod": "^4.4.3",
     "maska": "^3.2.0"
   },
   "devDependencies": {
-    "@vitejs/plugin-vue": "^6.0.5",
+    "@vitejs/plugin-vue": "^6.0.7",
     "typescript": "^6.0.3",
-    "vite": "^7.3.1",
+    "vite": "^7.3.3",
     "vue-tsc": "^3.3.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -256,7 +256,7 @@ importers:
         specifier: ^25.3.0
         version: 25.6.0
       '@vitejs/plugin-vue':
-        specifier: ^6.0.5
+        specifier: ^6.0.7
         version: 6.0.7(vite@7.3.5(@types/node@25.6.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.9.0))(vue@3.5.38(typescript@6.0.3))
       '@vue/test-utils':
         specifier: ^2.4.10
@@ -289,7 +289,7 @@ importers:
         specifier: ^1.0.1
         version: 1.0.1(@vue/test-utils@2.4.10(@vue/compiler-dom@3.5.38)(@vue/server-renderer@3.5.38(vue@3.5.38(typescript@6.0.3)))(vue@3.5.38(typescript@6.0.3)))(crossws@0.4.5(srvx@0.11.15))(happy-dom@20.9.0)(magicast@0.5.3)(playwright-core@1.59.1)(typescript@6.0.3)(vite@7.3.5(@types/node@25.6.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.1.8(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(happy-dom@20.9.0)(vite@7.3.5(@types/node@25.6.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.9.0)))
       vue:
-        specifier: ^3.5.30
+        specifier: ^3.5.34
         version: 3.5.38(typescript@6.0.3)
       vue-tsc:
         specifier: ^3.3.0
@@ -583,14 +583,14 @@ importers:
         specifier: ^4.3.0
         version: 4.3.0
       vue:
-        specifier: ^3.5.30
+        specifier: ^3.5.34
         version: 3.5.38(typescript@6.0.3)
     devDependencies:
       '@vitejs/plugin-vue':
-        specifier: ^6.0.5
+        specifier: ^6.0.7
         version: 6.0.7(vite@7.3.5(@types/node@25.6.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.9.0))(vue@3.5.38(typescript@6.0.3))
       vite:
-        specifier: ^7.3.1
+        specifier: ^7.3.3
         version: 7.3.5(@types/node@25.6.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.9.0)
 
   playgrounds/vue:
@@ -617,23 +617,23 @@ importers:
         specifier: ^4.3.0
         version: 4.3.0
       vue:
-        specifier: ^3.5.30
+        specifier: ^3.5.34
         version: 3.5.38(typescript@6.0.3)
       vue-router:
-        specifier: ^5.0.4
+        specifier: ^5.0.7
         version: 5.1.0(@vue/compiler-sfc@3.5.38)(vite@7.3.5(@types/node@25.6.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.9.0))(vue@3.5.38(typescript@6.0.3))
       zod:
         specifier: ^4.4.3
         version: 4.4.3
     devDependencies:
       '@vitejs/plugin-vue':
-        specifier: ^6.0.5
+        specifier: ^6.0.7
         version: 6.0.7(vite@7.3.5(@types/node@25.6.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.9.0))(vue@3.5.38(typescript@6.0.3))
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
       vite:
-        specifier: ^7.3.1
+        specifier: ^7.3.3
         version: 7.3.5(@types/node@25.6.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.9.0)
       vue-tsc:
         specifier: ^3.3.0


### PR DESCRIPTION
## Live sync — next commit in queue

**Upstream:** [`527b4389`](https://github.com/nuxt/ui/commit/527b4389957b646f522c42b0219666a3424c4b2a) — chore(deps): update vite (#6263)

Immediate next commit after `3736eeeb` (#117).

### Change
Bump the vite/vue dep ranges everywhere they appear (b24ui carried the same pre-versions) + regenerate the lockfile:
- `package.json`: `@vitejs/plugin-vue` ^6.0.5 → **^6.0.7**, `vue` ^3.5.30 → **^3.5.34**.
- `playgrounds/repl/package.json`: `vue` → ^3.5.34, `@vitejs/plugin-vue` → ^6.0.7, `vite` ^7.3.1 → **^7.3.3**.
- `playgrounds/vue/package.json`: `vue` → ^3.5.34, `vue-router` ^5.0.4 → **^5.0.7**, `@vitejs/plugin-vue` → ^6.0.7, `vite` → ^7.3.3.

### Lockfile hygiene
`pnpm install` + **`pnpm dedupe`** → lockfile keeps a **single** `vite@7.3.5` and a single `vue@3.5.38`, no duplicates — proactively avoiding the dual-vite issue that broke #117's first CI run. Most ranges were already satisfied by #117's resolve; this realigns the declared ranges with upstream.

### Validation
Verified with a **frozen-lockfile** install (mirrors CI exactly): ✅ `dev:prepare` · ✅ `typecheck` · ✅ `lint` · ✅ `vitest run` — **4972 passed | 6 skipped** · ✅ module `build`.

### Ledger
- `.sync/nuxt-ui.json`: `cursor` → `527b4389`; `3736eeeb` finalized (`pr: 117`, `b24ui_sha: b538d45c`).
- `.sync/log/527b4389….md`: decision record.

https://claude.ai/code/session_01Qz7EXMncvEGiCj4WbmYgJo

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qz7EXMncvEGiCj4WbmYgJo)_