### PR TITLE
chore(sync): noop b0461e72 (transformMDC already implemented)

### DIFF
--- a/.sync/log/b0461e72dccd57503a5c4cfab0b84b33c53a693c.md
+++ b/.sync/log/b0461e72dccd57503a5c4cfab0b84b33c53a693c.md
@@ -1,0 +1,32 @@
+# port — nuxt/ui@b0461e72dccd57503a5c4cfab0b84b33c53a693c
+
+**Upstream:** docs: preserve component-code implementation details in raw markdown (#6472)
+
+**Decision: noop** — b24ui already has equivalent (richer) functionality.
+
+## What upstream does
+Rewrites `docs/server/utils/transformMDC.ts` `generateComponentCode` to add:
+- `slug`/`prose`/`:model`/`:cast` component attributes;
+- `CAST_TEMPLATES` + `CAST_IMPORTS` for `DateValue`/`DateValue[]`/`DateRange`/
+  `TimeValue`/`TimeRangeValue` (CalendarDate/Time codegen);
+- a `prose` branch emitting `::component{props}` MDC;
+- per-prop attribute building with `v-model`, boolean/number/object handling,
+  typed `ref`/`shallowRef` declarations and cast imports.
+
+## Why noop for b24ui
+b24ui's `transformMDC.ts` (1166 lines, heavily diverged) **already implements
+all of this**, in a richer/unified form predating this upstream commit:
+- `castMap` (≡ upstream `CAST_TEMPLATES` + `CAST_IMPORTS`) with unified
+  `get` / `template` / `imports` for the same DateValue/Time cast types;
+- `prose` branch (wraps output in a ```mdc fence — richer than upstream);
+- `<script setup>` codegen with cast imports, typed refs and `shallowRef` for
+  date casts;
+- `propsCast` / `:cast`, `model` / `:model`, `:slug`, B24/Prose prefix logic,
+  b24icons `RocketIcon`, and `@bitrix24/b24ui-nuxt` type imports.
+
+Applying upstream's hunks would conflict with — and regress — b24ui's existing
+implementation. b24ui is at or ahead of upstream here; nothing to port.
+
+## Validation
+No source change (ledger/log only). b24ui's `transformMDC.ts` is untouched and
+already green on the current main.

--- a/.sync/nuxt-ui.json
+++ b/.sync/nuxt-ui.json
@@ -2,7 +2,7 @@
   "upstream": "nuxt/ui",
   "branch": "v4",
   "sync_enabled": false,
-  "cursor": "527b4389957b646f522c42b0219666a3424c4b2a",
+  "cursor": "b0461e72dccd57503a5c4cfab0b84b33c53a693c",
   "_cursor_note": "cursor = last upstream commit ported into b24ui (oldest-first, manual cadence). sync_enabled stays false until Phase 2 (porter workflow #67 + CLAUDE_CODE_OAUTH_TOKEN) is wired and trusted. `processed` is maintained per port from now on (backfilled #68-#72 on 2026-06-09).",
   "stats": {
     "queue_depth": 0,
@@ -161,10 +161,16 @@
       "summary": "chore(deps): update nuxt framework to ^4.4.6 (+ LinkBase href string|null forward-port; + vite dedupe for CI)"
     },
     "527b4389957b646f522c42b0219666a3424c4b2a": {
-      "pr": null,
-      "b24ui_sha": "pending-merge",
+      "pr": 118,
+      "b24ui_sha": "c9d3b4d0",
       "decision": "port",
       "summary": "chore(deps): update vite/vue/plugin-vue/vue-router ranges (root + repl/vue playgrounds) + lockfile dedupe"
+    },
+    "b0461e72dccd57503a5c4cfab0b84b33c53a693c": {
+      "pr": null,
+      "b24ui_sha": "pending-merge",
+      "decision": "noop",
+      "summary": "docs(transformMDC): preserve component-code details — b24ui already implements richer cast/model/prose codegen"
     }
   }
 }


### PR DESCRIPTION
## Live sync — next commit in queue

**Upstream:** [`b0461e72`](https://github.com/nuxt/ui/commit/b0461e72dccd57503a5c4cfab0b84b33c53a693c) — docs: preserve component-code implementation details in raw markdown (#6472)

Immediate next commit after `527b4389` (#118).

### Decision: **noop** — b24ui already has this (in a richer form)

Upstream rewrites `docs/server/utils/transformMDC.ts` `generateComponentCode` to add `:cast`/`:model`/`prose`/`slug` attributes, `CAST_TEMPLATES`+`CAST_IMPORTS` (DateValue/Time codegen), a prose `::component{}` branch, and per-prop `v-model`/typed-ref attribute building.

b24ui's `transformMDC.ts` (1166 lines, heavily diverged) **already implements all of it**, predating this commit, in a unified/richer shape:
- `castMap` ≡ upstream's `CAST_TEMPLATES` + `CAST_IMPORTS` — unified `get` / `template` / `imports` for the same `DateValue` / `DateValue[]` / `DateRange` / `TimeValue` cast types;
- `prose` branch (wraps output in a ```mdc fence — richer than upstream);
- `<script setup>` codegen with cast imports, typed refs, `shallowRef` for date casts;
- `propsCast` / `:cast`, `model` / `:model`, `:slug`, `B24`/`Prose` prefix logic, b24icons `RocketIcon`, `@bitrix24/b24ui-nuxt` type imports.

Applying upstream's hunks would conflict with and **regress** b24ui's existing implementation. Nothing to port.

### Changes
Ledger/log only — `transformMDC.ts` untouched.
- `.sync/nuxt-ui.json`: `cursor` → `b0461e72` (decision **noop**); `527b4389` finalized (`pr: 118`, `b24ui_sha: c9d3b4d0`).
- `.sync/log/b0461e72….md`: decision record.

### Validation
No source change → verify N/A. b24ui's `transformMDC.ts` is unchanged and already green on `main`.

https://claude.ai/code/session_01Qz7EXMncvEGiCj4WbmYgJo

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qz7EXMncvEGiCj4WbmYgJo)_