### PR TITLE
chore(repl): expose composables subpath in the playground

### DIFF
--- a/.sync/log/fd24978578586555b463e373de096676cf13d993.md
+++ b/.sync/log/fd24978578586555b463e373de096676cf13d993.md
@@ -1,0 +1,43 @@
+# Port: chore(repl): expose `@nuxt/ui/composables` subpath
+
+**Upstream:** `fd24978578586555b463e373de096676cf13d993` (nuxt/ui, #6473 area)
+**Decision:** port
+
+## Upstream change
+Re-export all composables from the REPL entry and alias `@nuxt/ui/composables`
+to the same bundle in the import map, so docs snippets that import from
+`@nuxt/ui/composables` (e.g. `useScrollShadow`) run in the REPL.
+- `playgrounds/repl/src/entry.ts`: replace explicit composable re-exports with
+  `export * from '../../../src/runtime/composables'`.
+- `playgrounds/repl/src/App.vue`: add `'@nuxt/ui/composables': '/nuxt-ui.js'`
+  to the import map.
+
+## b24ui adaptation
+The b24ui REPL is renamed: the bundle alias is `@bitrix24/b24ui-builtin ->
+./bitrix24-b24ui.js` (not `@nuxt/ui -> /nuxt-ui.js`).
+- `entry.ts`: replaced the 7 explicit re-exports (useToast, useOverlay,
+  defineShortcuts/extractShortcuts, useDevice, useConfetti,
+  useSpeechRecognition, useColorMode) with `export * from
+  '../../../src/runtime/composables'`. b24ui's barrel `src/runtime/composables/
+  index.ts` already re-exports all of those plus the rest, so the names the
+  REPL's `importCode` destructures off the bundle stay exported.
+- `App.vue`: added `'@bitrix24/b24ui-nuxt/composables': './bitrix24-b24ui.js'`
+  to the import map. b24ui docs snippets import composables from
+  `@bitrix24/b24ui-nuxt/composables` (e.g. color-mode/i18n vue.md examples),
+  and `package.json` already exposes the `./composables` export — this maps
+  that subpath onto the same REPL bundle, matching upstream's intent.
+
+## Note: 2799fa6f already ported
+The commit between the cursor (9ea1b219) and this one,
+`2799fa6f fix(InputMenu)!: rename autocomplete -> mode`, is already in the
+ledger as **#68** (b24ui_sha 081a9799, backfilled). Skipped to avoid a
+duplicate; cursor advanced straight to fd249785.
+
+## Verification (pnpm 11.1.3, minimumReleaseAge gate ON)
+frozen install · dev:prepare · lint · typecheck · test (4972 passed, 6 skipped)
+· module build · **repl bundle** (`pnpm --filter playground-repl bundle`,
+exercises the `export *` barrel) — all green.
+
+Platform note: b24ui CI is `ubuntu-latest` only (no Windows runner), and this
+change is OS-independent (a TS re-export + a JSON import-map alias), so there is
+no Windows-specific surface to verify.

--- a/.sync/nuxt-ui.json
+++ b/.sync/nuxt-ui.json
@@ -2,7 +2,7 @@
   "upstream": "nuxt/ui",
   "branch": "v4",
   "sync_enabled": false,
-  "cursor": "9ea1b21982548bc402921c3fd79543d86e1f8ca0",
+  "cursor": "fd24978578586555b463e373de096676cf13d993",
   "_cursor_note": "cursor = last upstream commit ported into b24ui (oldest-first, manual cadence). sync_enabled stays false until Phase 2 (porter workflow #67 + CLAUDE_CODE_OAUTH_TOKEN) is wired and trusted. `processed` is maintained per port from now on (backfilled #68-#72 on 2026-06-09).",
   "stats": {
     "queue_depth": 0,
@@ -173,10 +173,16 @@
       "summary": "docs(transformMDC): preserve component-code details — b24ui already implements richer cast/model/prose codegen"
     },
     "9ea1b21982548bc402921c3fd79543d86e1f8ca0": {
+      "pr": 120,
+      "b24ui_sha": "8112cce8",
+      "decision": "port",
+      "summary": "chore(deps): update pnpm to v11 (packageManager 11.1.3; resolutions->overrides; allowBuilds; drop @nuxt/a11y; lock regen under pnpm 11; pin nuxt-og-image/nuxtseo-shared to aged versions for the minimumReleaseAge gate)"
+    },
+    "fd24978578586555b463e373de096676cf13d993": {
       "pr": null,
       "b24ui_sha": "pending-merge",
       "decision": "port",
-      "summary": "chore(deps): update pnpm to v11 (packageManager 11.1.3; resolutions->overrides; allowBuilds; drop @nuxt/a11y; lock regen under pnpm 11)"
+      "summary": "chore(repl): expose composables subpath — barrel re-export in entry.ts + @bitrix24/b24ui-nuxt/composables import-map alias (2799fa6f between cursor and this was already ported as #68)"
     }
   }
 }

--- a/playgrounds/repl/src/App.vue
+++ b/playgrounds/repl/src/App.vue
@@ -25,6 +25,7 @@ const builtinImportMap = computed(() => ({
   imports: {
     ...vueImportMap.value.imports,
     '@bitrix24/b24ui-builtin': './bitrix24-b24ui.js',
+    '@bitrix24/b24ui-nuxt/composables': './bitrix24-b24ui.js',
     '@bitrix24/b24icons-vue': 'https://esm.sh/@bitrix24/b24icons-vue@2.0.7',
     '@bitrix24/b24icons-vue/': 'https://esm.sh/@bitrix24/b24icons-vue@2.0.7/',
     'zod': 'https://esm.sh/zod@4?external=vue',

--- a/playgrounds/repl/src/entry.ts
+++ b/playgrounds/repl/src/entry.ts
@@ -38,10 +38,4 @@ export function install(app: App) {
 
 export default { install }
 
-export { useToast } from '../../../src/runtime/composables/useToast'
-export { useOverlay } from '../../../src/runtime/composables/useOverlay'
-export { defineShortcuts, extractShortcuts } from '../../../src/runtime/composables/defineShortcuts'
-export { useDevice } from '../../../src/runtime/composables/useDevice'
-export { useConfetti } from '../../../src/runtime/composables/useConfetti'
-export { useSpeechRecognition } from '../../../src/runtime/composables/useSpeechRecognition'
-export { useColorMode } from '../../../src/runtime/composables/color-mode/useColorMode'
+export * from '../../../src/runtime/composables'


### PR DESCRIPTION
Port of nuxt/ui [`fd249785`](https://github.com/nuxt/ui/commit/fd24978578586555b463e373de096676cf13d993) — _chore(repl): expose `@nuxt/ui/composables` subpath_.

## What
Make composables importable from the REPL playground, so docs snippets that import them work when run there.

- **`entry.ts`** — re-export the whole composables barrel (`export * from '../../../src/runtime/composables'`) instead of listing each composable by hand. Every public composable is now exposed from the REPL bundle; the names the REPL's `importCode` destructures off the bundle stay exported.
- **`App.vue`** — alias `@bitrix24/b24ui-nuxt/composables` to the same bundle (`./bitrix24-b24ui.js`) in the import map, mirroring upstream aliasing `@nuxt/ui/composables`. b24ui docs snippets import composables from this subpath (e.g. color-mode / i18n examples), and `package.json` already exposes the `./composables` export.

## Adaptation notes
- b24ui's REPL bundle alias is renamed (`@bitrix24/b24ui-builtin → ./bitrix24-b24ui.js`), so the import-map key is the b24ui subpath rather than `@nuxt/ui/composables`.
- The commit between the sync cursor and this one — `2799fa6f` (`fix(InputMenu)!: rename autocomplete → mode`) — was already ported as **#68**, so it's skipped to avoid a duplicate; the cursor advances straight to `fd249785`.

## Verification
Under pnpm 11.1.3 with the `minimumReleaseAge` gate **ON**: frozen install · `dev:prepare` · lint · typecheck · test (**4972 passed**, 6 skipped) · module build · **repl bundle** build (exercises the `export *` barrel) — all green.

Platform: b24ui CI is `ubuntu-latest` only; this change is OS-independent (a TS re-export + a JSON import-map alias), so there is no Windows-specific surface.

https://claude.ai/code/session_01Qz7EXMncvEGiCj4WbmYgJo

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qz7EXMncvEGiCj4WbmYgJo)_