### PR TITLE
chore(sync): record nuxt/ui v4.8.0 release as no-op

### DIFF
--- a/.sync/log/24b23fdfe81eeadf7ed07a946e7b92203800cf7c.md
+++ b/.sync/log/24b23fdfe81eeadf7ed07a946e7b92203800cf7c.md
@@ -1,0 +1,15 @@
+# Port: chore(release): v4.8.0
+
+**Upstream:** `24b23fdfe81eeadf7ed07a946e7b92203800cf7c` (nuxt/ui)
+**Decision:** no-op
+
+## Upstream change
+Release commit for `@nuxt/ui` v4.8.0 — bumps `package.json` `version`
+(`4.7.1 → 4.8.0`) and appends the release notes to `CHANGELOG.md`. No source,
+theme, or test changes.
+
+## Why no-op for b24ui
+b24ui is published as `@bitrix24/b24ui-nuxt` with its own independent version
+and `CHANGELOG.md`; it does not mirror upstream's release tags or version
+numbers. There is nothing functional to port — only the sync ledger/cursor is
+advanced so the audit trail stays complete.

--- a/.sync/nuxt-ui.json
+++ b/.sync/nuxt-ui.json
@@ -2,7 +2,7 @@
   "upstream": "nuxt/ui",
   "branch": "v4",
   "sync_enabled": false,
-  "cursor": "eb468e6095e36eaf0ad3209660637e0e664856b0",
+  "cursor": "24b23fdfe81eeadf7ed07a946e7b92203800cf7c",
   "_cursor_note": "cursor = last upstream commit ported into b24ui (oldest-first, manual cadence). sync_enabled stays false until Phase 2 (porter workflow #67 + CLAUDE_CODE_OAUTH_TOKEN) is wired and trusted. `processed` is maintained per port from now on (backfilled #68-#72 on 2026-06-09).",
   "stats": {
     "queue_depth": 0,
@@ -191,10 +191,16 @@
       "summary": "feat(ChatMessage): add `body` slot wrapping content+actions; theme actions-alignment (header flex, body min-w-0, side.right header/actions, drop left-11/6.5 compounds, default side left); regen 42 snapshots; playground demos"
     },
     "eb468e6095e36eaf0ad3209660637e0e664856b0": {
-      "pr": null,
-      "b24ui_sha": "pending-merge",
+      "pr": 123,
+      "b24ui_sha": "cb89934a",
       "decision": "port",
       "summary": "fix(ChatMessage): add `wrap-break-word` to content slot theme; regen ChatMessage/ChatMessages snapshots (nuxt+vue)"
+    },
+    "24b23fdfe81eeadf7ed07a946e7b92203800cf7c": {
+      "pr": null,
+      "b24ui_sha": "pending-merge",
+      "decision": "noop",
+      "summary": "chore(release): v4.8.0 — upstream @nuxt/ui version bump + CHANGELOG; n/a (b24ui has its own package name @bitrix24/b24ui-nuxt, version and changelog)"
     }
   }
 }


### PR DESCRIPTION
Port of nuxt/ui [`24b23fdf`](https://github.com/nuxt/ui/commit/24b23fdfe81eeadf7ed07a946e7b92203800cf7c) — _chore(release): v4.8.0_.

## Decision: no-op
Upstream's release commit only bumps `@nuxt/ui`'s `package.json` version (`4.7.1 → 4.8.0`) and appends release notes to its `CHANGELOG.md`. No source, theme, or test changes.

b24ui ships as `@bitrix24/b24ui-nuxt` with its own independent version and changelog and does not mirror upstream's release tags, so there is nothing functional to port. This PR only advances the sync ledger/cursor and records the decision, keeping the audit trail complete.

## Changes
- `.sync/nuxt-ui.json`: cursor → `24b23fdf`; processed entry (`noop`); back-fill #123's merged sha for the previous entry.
- `.sync/log/24b23fdf….md`: decision note.

No code touched — CI is a formality here.

https://claude.ai/code/session_01Qz7EXMncvEGiCj4WbmYgJo

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qz7EXMncvEGiCj4WbmYgJo)_