### PR TITLE
chore(sync): record nuxt/ui docs badge update as no-op

### DIFF
--- a/.sync/log/09f9cd0142275911ab4aa515c94ef56a9e7639e5.md
+++ b/.sync/log/09f9cd0142275911ab4aa515c94ef56a9e7639e5.md
@@ -1,0 +1,28 @@
+# Port: docs(content): update badges
+
+**Upstream:** `09f9cd0142275911ab4aa515c94ef56a9e7639e5` (nuxt/ui)
+**Decision:** no-op
+
+## Upstream change
+Docs-only maintenance across 11 component/typography pages:
+- Relabels section badges `:badge{label="Soon"}` → `:badge{label="4.8+"}`
+  (features that shipped in upstream's 4.8 release).
+- Drops `navigation.badge: New` from `listbox.md` and `typography/prompt.md`.
+
+## Why no-op for b24ui
+- The `4.8+` label tracks **upstream's** release version; b24ui versions
+  independently (`@bitrix24/b24ui-nuxt`) and does not use upstream version
+  numbers in its docs badges.
+- Of the 10 changed component pages, only `content-search.md` even carries a
+  `label="Soon"` badge in b24ui; the rest (avatar, avatar-group, breadcrumb,
+  chat-message, error, input-menu, separator, theme) have no such badge here,
+  and `listbox.md` does not exist in b24ui.
+- b24ui's own `label="Soon"` badges (radio-group, content-search,
+  checkbox-group) reflect b24ui's roadmap, not upstream's — they are left as-is
+  until those features actually land in b24ui (a separate decision, not this
+  cosmetic relabel).
+- b24ui's `navigation.badge: New` markers live on different, b24-specific pages
+  (chat-shimmer, chat-reasoning, chat-tool, use-scroll-shadow); the upstream
+  removal targets (listbox/prompt) don't match.
+
+Nothing functional or docs-meaningful to port; ledger/cursor advanced only.

--- a/.sync/nuxt-ui.json
+++ b/.sync/nuxt-ui.json
@@ -2,7 +2,7 @@
   "upstream": "nuxt/ui",
   "branch": "v4",
   "sync_enabled": false,
-  "cursor": "24b23fdfe81eeadf7ed07a946e7b92203800cf7c",
+  "cursor": "09f9cd0142275911ab4aa515c94ef56a9e7639e5",
   "_cursor_note": "cursor = last upstream commit ported into b24ui (oldest-first, manual cadence). sync_enabled stays false until Phase 2 (porter workflow #67 + CLAUDE_CODE_OAUTH_TOKEN) is wired and trusted. `processed` is maintained per port from now on (backfilled #68-#72 on 2026-06-09).",
   "stats": {
     "queue_depth": 0,
@@ -197,10 +197,16 @@
       "summary": "fix(ChatMessage): add `wrap-break-word` to content slot theme; regen ChatMessage/ChatMessages snapshots (nuxt+vue)"
     },
     "24b23fdfe81eeadf7ed07a946e7b92203800cf7c": {
+      "pr": 124,
+      "b24ui_sha": "b7a83b30",
+      "decision": "noop",
+      "summary": "chore(release): v4.8.0 — upstream @nuxt/ui version bump + CHANGELOG; n/a (b24ui has its own package name @bitrix24/b24ui-nuxt, version and changelog)"
+    },
+    "09f9cd0142275911ab4aa515c94ef56a9e7639e5": {
       "pr": null,
       "b24ui_sha": "pending-merge",
       "decision": "noop",
-      "summary": "chore(release): v4.8.0 — upstream @nuxt/ui version bump + CHANGELOG; n/a (b24ui has its own package name @bitrix24/b24ui-nuxt, version and changelog)"
+      "summary": "docs(content): update badges (Soon -> 4.8+, drop navigation.badge:New) — n/a: upstream version-label maintenance; b24ui versions independently, keeps its own Soon/New badges per its roadmap, and listbox/prompt targets don't match b24ui docs"
     }
   }
 }


### PR DESCRIPTION
Port of nuxt/ui [`09f9cd01`](https://github.com/nuxt/ui/commit/09f9cd0142275911ab4aa515c94ef56a9e7639e5) — _docs(content): update badges_.

## Decision: no-op
Upstream relabels doc section badges `:badge{label="Soon"}` → `:badge{label="4.8+"}` (features that shipped in its 4.8 release) and drops `navigation.badge: New` from `listbox.md` and `typography/prompt.md`.

Not applicable to b24ui:
- The `4.8+` label tracks **upstream's** version; b24ui (`@bitrix24/b24ui-nuxt`) versions independently and doesn't use upstream version numbers in badges.
- Of the 10 changed component pages, only `content-search.md` carries a `label="Soon"` badge here; the rest have none, and `listbox.md` doesn't exist in b24ui.
- b24ui's own `Soon` badges (radio-group, content-search, checkbox-group) reflect b24ui's roadmap and are left as-is until those features land here — a separate decision, not this cosmetic relabel.
- b24ui's `navigation.badge: New` markers are on different, b24-specific pages; the upstream removal targets don't match.

Ledger/cursor advanced only — no code or docs content touched.

https://claude.ai/code/session_01Qz7EXMncvEGiCj4WbmYgJo

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qz7EXMncvEGiCj4WbmYgJo)_