### PR TITLE
chore(deps): update reka-ui to v2.9.8

### DIFF
--- a/.sync/log/17a9d04f30f25908f7bdafc1ff39b1d9d56301fb.md
+++ b/.sync/log/17a9d04f30f25908f7bdafc1ff39b1d9d56301fb.md
@@ -1,0 +1,24 @@
+# Port: chore(deps): update dependency reka-ui to v2.9.8 (#6485)
+
+**Upstream:** `17a9d04f30f25908f7bdafc1ff39b1d9d56301fb` (nuxt/ui, renovate)
+**Decision:** port
+
+## Upstream change
+Single dependency bump: `reka-ui 2.9.7 → 2.9.8` (exact pin) + lockfile regen.
+
+## b24ui adaptation
+b24ui pins `reka-ui` at the same exact version (`2.9.7`), so this is a direct
+1:1 bump:
+- `package.json`: `reka-ui 2.9.7 → 2.9.8`.
+- Lockfile regenerated under pnpm 11.3.0 with the `minimumReleaseAge` gate ON
+  (2.9.8 dates from 2026-05-26 — aged, no pin needed).
+
+reka-ui is the headless primitive layer behind every b24ui component, so the
+full suite was exercised.
+
+## Verification (pnpm 11.3.0, gate ON)
+frozen install · dev:prepare · lint · typecheck · test (4972 passed, 6 skipped)
+· module build — all green.
+
+Platform note: b24ui CI is `ubuntu-latest` only; OS-independent (dependency +
+lockfile).

--- a/.sync/nuxt-ui.json
+++ b/.sync/nuxt-ui.json
@@ -2,7 +2,7 @@
   "upstream": "nuxt/ui",
   "branch": "v4",
   "sync_enabled": false,
-  "cursor": "ca5accf3362eaf060e4d02e53daeab5272637880",
+  "cursor": "17a9d04f30f25908f7bdafc1ff39b1d9d56301fb",
   "_cursor_note": "cursor = last upstream commit ported into b24ui (oldest-first, manual cadence). sync_enabled stays false until Phase 2 (porter workflow #67 + CLAUDE_CODE_OAUTH_TOKEN) is wired and trusted. `processed` is maintained per port from now on (backfilled #68-#72 on 2026-06-09).",
   "stats": {
     "queue_depth": 0,
@@ -209,10 +209,16 @@
       "summary": "docs(content): update badges (Soon -> 4.8+, drop navigation.badge:New) — n/a: upstream version-label maintenance; b24ui versions independently, keeps its own Soon/New badges per its roadmap, and listbox/prompt targets don't match b24ui docs"
     },
     "ca5accf3362eaf060e4d02e53daeab5272637880": {
+      "pr": 126,
+      "b24ui_sha": "7b104055",
+      "decision": "port",
+      "summary": "chore(deps): update all non-major dependencies (#6497) — selective: shared deps in root/docs/playground manifests incl. playgrounds/demo (ai/@ai-sdk, vitest, tanstack-virtual, unplugin-vue-components, regle, takumi, valibot, vue-component-meta, mcp-toolkit), c12 override ^3.3.4, pnpm 11.1.3->11.3.0, lockfile regen under gate; +PORTING.md playground-mirroring invariant"
+    },
+    "17a9d04f30f25908f7bdafc1ff39b1d9d56301fb": {
       "pr": null,
       "b24ui_sha": "pending-merge",
       "decision": "port",
-      "summary": "chore(deps): update all non-major dependencies (#6497) — selective: shared deps in root/docs/playground manifests (ai/@ai-sdk, vitest, tanstack-virtual, unplugin-vue-components, regle, takumi, valibot, vue-component-meta, mcp-toolkit), c12 override ^3.3.4, pnpm 11.1.3->11.3.0, lockfile regen under gate"
+      "summary": "chore(deps): update dependency reka-ui to v2.9.8 (#6485) — direct 1:1 bump (b24ui pins same exact version), lockfile regen under gate"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -189,7 +189,7 @@
     "motion-v": "^2.2.1",
     "ohash": "^2.0.11",
     "pathe": "^2.0.3",
-    "reka-ui": "2.9.7",
+    "reka-ui": "2.9.8",
     "scule": "^1.3.0",
     "tailwind-merge": "^3.6.0",
     "tailwind-variants": "^3.2.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -185,8 +185,8 @@ importers:
         specifier: ^2.0.3
         version: 2.0.3
       reka-ui:
-        specifier: 2.9.7
-        version: 2.9.7(vue@3.5.38(typescript@6.0.3))
+        specifier: 2.9.8
+        version: 2.9.8(vue@3.5.38(typescript@6.0.3))
       scule:
         specifier: ^1.3.0
         version: 1.3.0
@@ -225,7 +225,7 @@ importers:
         version: 1.4.1(typescript@6.0.3)
       vaul-vue:
         specifier: 0.4.1
-        version: 0.4.1(reka-ui@2.9.7(vue@3.5.38(typescript@6.0.3)))(vue@3.5.38(typescript@6.0.3))
+        version: 0.4.1(reka-ui@2.9.8(vue@3.5.38(typescript@6.0.3)))(vue@3.5.38(typescript@6.0.3))
       vue-component-type-helpers:
         specifier: ^3.3.0
         version: 3.3.4
@@ -7158,8 +7158,8 @@ packages:
     peerDependencies:
       vue: '>= 3.4.0'
 
-  reka-ui@2.9.7:
-    resolution: {integrity: sha512-aX7foYYR20v4+majO58OJJdBNfLMm0eJb448l9N4JVy8JB7GXOr4H/S4a+J1pkcoxZH8Cb7YHpJ855+miAm7sA==}
+  reka-ui@2.9.8:
+    resolution: {integrity: sha512-7dxaBJ6nQ0zOQZXPV45219tTEgZPstmihBLS9ABPhSiPiJ8SiF0sacfZHFaBptS0v9N4tzsevq+8MNBpE4p5JQ==}
     peerDependencies:
       vue: '>= 3.4.0'
 
@@ -15920,7 +15920,7 @@ snapshots:
     transitivePeerDependencies:
       - '@vue/composition-api'
 
-  reka-ui@2.9.7(vue@3.5.38(typescript@6.0.3)):
+  reka-ui@2.9.8(vue@3.5.38(typescript@6.0.3)):
     dependencies:
       '@floating-ui/dom': 1.7.6
       '@floating-ui/vue': 1.1.11(vue@3.5.38(typescript@6.0.3))
@@ -16947,10 +16947,10 @@ snapshots:
     transitivePeerDependencies:
       - '@vue/composition-api'
 
-  vaul-vue@0.4.1(reka-ui@2.9.7(vue@3.5.38(typescript@6.0.3)))(vue@3.5.38(typescript@6.0.3)):
+  vaul-vue@0.4.1(reka-ui@2.9.8(vue@3.5.38(typescript@6.0.3)))(vue@3.5.38(typescript@6.0.3)):
     dependencies:
       '@vueuse/core': 10.11.1(vue@3.5.38(typescript@6.0.3))
-      reka-ui: 2.9.7(vue@3.5.38(typescript@6.0.3))
+      reka-ui: 2.9.8(vue@3.5.38(typescript@6.0.3))
       vue: 3.5.38(typescript@6.0.3)
     transitivePeerDependencies:
       - '@vue/composition-api'


### PR DESCRIPTION
Port of nuxt/ui [`17a9d04f`](https://github.com/nuxt/ui/commit/17a9d04f30f25908f7bdafc1ff39b1d9d56301fb) — _chore(deps): update dependency reka-ui to v2.9.8 (#6485)_.

## What
Direct 1:1 dependency bump — b24ui pins `reka-ui` at the same exact version as upstream:
- `package.json`: `reka-ui 2.9.7 → 2.9.8`
- Lockfile regenerated under pnpm 11.3.0 with the `minimumReleaseAge` gate ON (2.9.8 dates from 2026-05-26 — aged, no pin needed).

reka-ui is the headless primitive layer behind every b24ui component, so the full suite was exercised.

## Verification
Under pnpm 11.3.0 with the gate ON: frozen install · `dev:prepare` · lint · typecheck · test (**4972 passed**, 6 skipped) · module build — all green.

Platform: b24ui CI is `ubuntu-latest` only; OS-independent (dependency + lockfile).

https://claude.ai/code/session_01Qz7EXMncvEGiCj4WbmYgJo

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qz7EXMncvEGiCj4WbmYgJo)_