### PR TITLE
chore(sync): record nuxt/ui showcase update as no-op

### DIFF
--- a/.sync/log/d0cfc2b1b23ea0c93c6579eeb7de1f6f0ed6e138.md
+++ b/.sync/log/d0cfc2b1b23ea0c93c6579eeb7de1f6f0ed6e138.md
@@ -1,0 +1,19 @@
+# Port: docs(showcase): add croix-rouge (#6502)
+
+**Upstream:** `d0cfc2b1b23ea0c93c6579eeb7de1f6f0ed6e138` (nuxt/ui)
+**Decision:** no-op
+
+## Upstream change
+Edits `docs/content/showcase.yml` — adds "Croix-Rouge française – Devenir
+bénévole" (with screenshot cookie options), removes "Details", "NuxtStart" and
+"Passionate People", and swaps the corresponding screenshot PNGs under
+`docs/public/assets/showcase/`.
+
+## Why no-op for b24ui
+The showcase is a **curated gallery of sites built with the library**. Upstream
+lists sites built with `nuxt/ui` (CodeSnap, Croix-Rouge, …). b24ui maintains
+its **own** `docs/content/showcase.yml` ("projects built with Bitrix24 UI"),
+which shares none of those entries. Adding a site built with nuxt/ui — and its
+screenshot asset — to b24ui's gallery would be incorrect.
+
+b24ui's showcase content is curated independently; ledger/cursor advanced only.

--- a/.sync/nuxt-ui.json
+++ b/.sync/nuxt-ui.json
@@ -2,7 +2,7 @@
   "upstream": "nuxt/ui",
   "branch": "v4",
   "sync_enabled": false,
-  "cursor": "17a9d04f30f25908f7bdafc1ff39b1d9d56301fb",
+  "cursor": "d0cfc2b1b23ea0c93c6579eeb7de1f6f0ed6e138",
   "_cursor_note": "cursor = last upstream commit ported into b24ui (oldest-first, manual cadence). sync_enabled stays false until Phase 2 (porter workflow #67 + CLAUDE_CODE_OAUTH_TOKEN) is wired and trusted. `processed` is maintained per port from now on (backfilled #68-#72 on 2026-06-09).",
   "stats": {
     "queue_depth": 0,
@@ -215,10 +215,16 @@
       "summary": "chore(deps): update all non-major dependencies (#6497) — selective: shared deps in root/docs/playground manifests incl. playgrounds/demo (ai/@ai-sdk, vitest, tanstack-virtual, unplugin-vue-components, regle, takumi, valibot, vue-component-meta, mcp-toolkit), c12 override ^3.3.4, pnpm 11.1.3->11.3.0, lockfile regen under gate; +PORTING.md playground-mirroring invariant"
     },
     "17a9d04f30f25908f7bdafc1ff39b1d9d56301fb": {
-      "pr": null,
-      "b24ui_sha": "pending-merge",
+      "pr": 127,
+      "b24ui_sha": "ca6082b1",
       "decision": "port",
       "summary": "chore(deps): update dependency reka-ui to v2.9.8 (#6485) — direct 1:1 bump (b24ui pins same exact version), lockfile regen under gate"
+    },
+    "d0cfc2b1b23ea0c93c6579eeb7de1f6f0ed6e138": {
+      "pr": null,
+      "b24ui_sha": "pending-merge",
+      "decision": "noop",
+      "summary": "docs(showcase): add croix-rouge (#6502) — n/a: upstream curates nuxt/ui showcase sites (Croix-Rouge etc., built with nuxt/ui); b24ui maintains its own 'built with Bitrix24 UI' showcase, so upstream entries + screenshot assets don't apply"
     }
   }
 }


### PR DESCRIPTION
Port of nuxt/ui [`d0cfc2b1`](https://github.com/nuxt/ui/commit/d0cfc2b1b23ea0c93c6579eeb7de1f6f0ed6e138) — _docs(showcase): add croix-rouge (#6502)_.

## Decision: no-op
Upstream edits its showcase gallery (`docs/content/showcase.yml`): adds "Croix-Rouge française – Devenir bénévole", removes Details / NuxtStart / Passionate People, and swaps the screenshot assets.

The showcase is a curated gallery of **sites built with the library**. Upstream lists sites built with `nuxt/ui`; b24ui maintains its own `showcase.yml` ("projects built with Bitrix24 UI") that shares none of those entries — so a nuxt/ui site (and its screenshot) doesn't belong in b24ui's gallery.

Ledger/cursor advanced only — no docs content touched.

https://claude.ai/code/session_01Qz7EXMncvEGiCj4WbmYgJo

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qz7EXMncvEGiCj4WbmYgJo)_