### PR TITLE
chore(sync): record Select/InputMenu max-height fallback as no-op

### DIFF
--- a/.sync/log/f4d7cbe71f3cb62eaf8b92a4da73f115324fcf6a.md
+++ b/.sync/log/f4d7cbe71f3cb62eaf8b92a4da73f115324fcf6a.md
@@ -1,0 +1,28 @@
+# Port: fix(Select/SelectMenu/InputMenu): add fallback for `max-height` (#6503)
+
+**Upstream:** `f4d7cbe71f3cb62eaf8b92a4da73f115324fcf6a` (nuxt/ui)
+**Decision:** no-op (already implemented in b24ui)
+
+## Upstream change
+Adds a fallback to the menu-height CSS var in the `content` slot of three
+themes, so the dropdown doesn't collapse to 0 when reka's available-height var
+is unset:
+`max-h-[min(15rem,var(--reka-*-content-available-height))]` →
+`max-h-[min(15rem,var(--reka-*-content-available-height,15rem))]`
+(input-menu / select-menu → `--reka-combobox-*`, select → `--reka-select-*`),
+plus regenerated snapshots.
+
+## Why no-op for b24ui
+b24ui already ships this fallback in all three themes — with its own, larger
+values:
+- `input-menu.ts` / `select-menu.ts`:
+  `max-h-[min(40rem,var(--reka-combobox-content-available-height,100vh))]`
+- `select.ts`:
+  `max-h-[min(40rem,var(--reka-select-content-available-height,100vh))]`
+
+The fix's intent (a non-empty fallback for the available-height var) is already
+satisfied. b24ui deliberately uses a `40rem` cap and a `100vh` fallback (taller
+menus than upstream's `15rem`); copying upstream's exact `15rem` would regress
+b24ui's sizing. No theme or snapshot change needed.
+
+Ledger/cursor advanced only.

--- a/.sync/nuxt-ui.json
+++ b/.sync/nuxt-ui.json
@@ -2,7 +2,7 @@
   "upstream": "nuxt/ui",
   "branch": "v4",
   "sync_enabled": false,
-  "cursor": "595ba8b043d6df1fa03ff2c05e540c4ed4ed1e01",
+  "cursor": "f4d7cbe71f3cb62eaf8b92a4da73f115324fcf6a",
   "_cursor_note": "cursor = last upstream commit ported into b24ui (oldest-first, manual cadence). sync_enabled stays false until Phase 2 (porter workflow #67 + CLAUDE_CODE_OAUTH_TOKEN) is wired and trusted. `processed` is maintained per port from now on (backfilled #68-#72 on 2026-06-09).",
   "stats": {
     "queue_depth": 0,
@@ -227,10 +227,16 @@
       "summary": "docs(showcase): add croix-rouge (#6502) — n/a: upstream curates nuxt/ui showcase sites (Croix-Rouge etc., built with nuxt/ui); b24ui maintains its own 'built with Bitrix24 UI' showcase, so upstream entries + screenshot assets don't apply"
     },
     "595ba8b043d6df1fa03ff2c05e540c4ed4ed1e01": {
-      "pr": null,
-      "b24ui_sha": "pending-merge",
+      "pr": 129,
+      "b24ui_sha": "373021b3",
       "decision": "port",
       "summary": "chore(deps): update tiptap to ^3.23.6 (#6498) — all @tiptap/* ^3.22.4->^3.23.6 across 5 manifests (root 17, docs/nuxt/vue/demo 2 each; demo mirrored per invariant), lockfile regen under gate"
+    },
+    "f4d7cbe71f3cb62eaf8b92a4da73f115324fcf6a": {
+      "pr": null,
+      "b24ui_sha": "pending-merge",
+      "decision": "noop",
+      "summary": "fix(Select/SelectMenu/InputMenu): add fallback for max-height (#6503) — already present in b24ui: all three themes use max-h-[min(40rem,var(--reka-*-content-available-height,100vh))] (b24ui's own 40rem cap + 100vh fallback). The fix's fallback intent is satisfied; matching upstream's 15rem would regress b24ui sizing"
     }
   }
 }


### PR DESCRIPTION
Port of nuxt/ui [`f4d7cbe7`](https://github.com/nuxt/ui/commit/f4d7cbe71f3cb62eaf8b92a4da73f115324fcf6a) — _fix(Select/SelectMenu/InputMenu): add fallback for `max-height` (#6503)_.

## Decision: no-op (already implemented)
Upstream adds a fallback to the menu-height CSS var in the `content` slot so the dropdown doesn't collapse when reka's available-height var is unset: `…available-height))` → `…available-height,15rem))`.

b24ui already ships this fallback in all three themes, with its own larger values:
- `input-menu.ts` / `select-menu.ts`: `max-h-[min(40rem,var(--reka-combobox-content-available-height,100vh))]`
- `select.ts`: `max-h-[min(40rem,var(--reka-select-content-available-height,100vh))]`

The fix's intent (a non-empty fallback) is already satisfied; b24ui deliberately uses a `40rem` cap and `100vh` fallback (taller menus than upstream's `15rem`), so copying upstream's exact value would regress b24ui sizing. No theme or snapshot change needed — ledger/cursor advanced only.

https://claude.ai/code/session_01Qz7EXMncvEGiCj4WbmYgJo

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qz7EXMncvEGiCj4WbmYgJo)_