### PR TITLE
chore(sync): record Thai locale improvement as no-op

### DIFF
--- a/.sync/log/5d82418c56e956a9f1b684b48f9bf40197cdf3aa.md
+++ b/.sync/log/5d82418c56e956a9f1b684b48f9bf40197cdf3aa.md
@@ -1,0 +1,27 @@
+# Port: fix(locale): improve Thai translation accuracy and consistency (#6509)
+
+**Upstream:** `5d82418c56e956a9f1b684b48f9bf40197cdf3aa` (nuxt/ui)
+**Decision:** no-op
+
+## Upstream change
+Two edits to `src/runtime/locale/th.ts`:
+1. Moves the `chatReasoning` message block from after `chatPromptSubmit` to
+   after `prose` (reorder, no text change).
+2. `pricingTable.caption`: `การเปรียบเทียบราคาสินค้า` → `การเปรียบเทียบราคา`
+   (drops the redundant "สินค้า").
+
+## Why no-op for b24ui
+b24ui's `th.ts` is independently translated and already diverges at exactly
+these spots:
+- `chatReasoning` is **already** positioned after `prose` (matches upstream's
+  target ordering).
+- `pricingTable.caption` is b24ui's own wording `เปรียบเทียบแผนราคา`
+  ("compare pricing plans") — not upstream's pre-fix string, so upstream's edit
+  has nothing to apply to.
+- (`chatReasoning.thoughtFor` also differs: b24ui `ใช้เวลาคิด{duration}` vs
+  upstream `คิดเป็นเวลา {duration}` — another independent choice.)
+
+No upstream-changed string is shared verbatim with b24ui, so there is no
+matching target to port; substituting upstream's phrasing for b24ui's
+deliberate translations isn't a faithful port and needs a Thai-speaker call.
+Ledger/cursor advanced only.

--- a/.sync/nuxt-ui.json
+++ b/.sync/nuxt-ui.json
@@ -2,7 +2,7 @@
   "upstream": "nuxt/ui",
   "branch": "v4",
   "sync_enabled": false,
-  "cursor": "f4d7cbe71f3cb62eaf8b92a4da73f115324fcf6a",
+  "cursor": "5d82418c56e956a9f1b684b48f9bf40197cdf3aa",
   "_cursor_note": "cursor = last upstream commit ported into b24ui (oldest-first, manual cadence). sync_enabled stays false until Phase 2 (porter workflow #67 + CLAUDE_CODE_OAUTH_TOKEN) is wired and trusted. `processed` is maintained per port from now on (backfilled #68-#72 on 2026-06-09).",
   "stats": {
     "queue_depth": 0,
@@ -233,10 +233,16 @@
       "summary": "chore(deps): update tiptap to ^3.23.6 (#6498) — all @tiptap/* ^3.22.4->^3.23.6 across 5 manifests (root 17, docs/nuxt/vue/demo 2 each; demo mirrored per invariant), lockfile regen under gate"
     },
     "f4d7cbe71f3cb62eaf8b92a4da73f115324fcf6a": {
+      "pr": 130,
+      "b24ui_sha": "94b66669",
+      "decision": "noop",
+      "summary": "fix(Select/SelectMenu/InputMenu): add fallback for max-height (#6503) — already present in b24ui: all three themes use max-h-[min(40rem,var(--reka-*-content-available-height,100vh))] (b24ui's own 40rem cap + 100vh fallback). The fix's fallback intent is satisfied; matching upstream's 15rem would regress b24ui sizing"
+    },
+    "5d82418c56e956a9f1b684b48f9bf40197cdf3aa": {
       "pr": null,
       "b24ui_sha": "pending-merge",
       "decision": "noop",
-      "summary": "fix(Select/SelectMenu/InputMenu): add fallback for max-height (#6503) — already present in b24ui: all three themes use max-h-[min(40rem,var(--reka-*-content-available-height,100vh))] (b24ui's own 40rem cap + 100vh fallback). The fix's fallback intent is satisfied; matching upstream's 15rem would regress b24ui sizing"
+      "summary": "fix(locale): improve Thai translation (#6509) — n/a: upstream reorders chatReasoning (already after prose in b24ui) and trims its own pricingTable.caption; b24ui's th.ts is independently translated with different wording (caption 'เปรียบเทียบแผนราคา', thoughtFor 'ใช้เวลาคิด{duration}'), so upstream's specific string edits have no matching target"
     }
   }
 }


### PR DESCRIPTION
Port of nuxt/ui [`5d82418c`](https://github.com/nuxt/ui/commit/5d82418c56e956a9f1b684b48f9bf40197cdf3aa) — _fix(locale): improve Thai translation accuracy and consistency (#6509)_.

## Decision: no-op
Upstream edits `src/runtime/locale/th.ts`: (1) moves the `chatReasoning` block after `prose` (reorder), and (2) trims `pricingTable.caption` `การเปรียบเทียบราคาสินค้า → การเปรียบเทียบราคา`.

b24ui's `th.ts` is independently translated and already diverges at these spots:
- `chatReasoning` is **already** after `prose` (matches upstream's target ordering).
- `pricingTable.caption` is b24ui's own wording `เปรียบเทียบแผนราคา`, not upstream's pre-fix string — so the edit has no matching target.
- `chatReasoning.thoughtFor` also differs (`ใช้เวลาคิด{duration}` vs `คิดเป็นเวลา {duration}`).

No upstream-changed string is shared verbatim, so there's nothing to port faithfully; swapping b24ui's deliberate translations for upstream's phrasing would be a Thai-speaker editorial call, not a sync. Ledger/cursor advanced only.

https://claude.ai/code/session_01Qz7EXMncvEGiCj4WbmYgJo

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qz7EXMncvEGiCj4WbmYgJo)_