### PR TITLE
chore(sync): record nuxt/ui showcase Pitchwall addition as no-op

### DIFF
--- a/.sync/log/78cc1ce5e96afa3f7a0f1456f17b1b179b9c5327.md
+++ b/.sync/log/78cc1ce5e96afa3f7a0f1456f17b1b179b9c5327.md
@@ -1,0 +1,14 @@
+# Port: docs(showcase): add Pitchwall to showcase section (#6510)
+
+**Upstream:** `78cc1ce5e96afa3f7a0f1456f17b1b179b9c5327` (nuxt/ui)
+**Decision:** no-op
+
+## Upstream change
+Adds "Pitchwall" (https://pitchwall.co/) to `docs/content/showcase.yml` and a
+screenshot asset under `docs/public/assets/showcase/`.
+
+## Why no-op for b24ui
+Same rationale as #128 (`d0cfc2b1`): the showcase is a gallery of sites built
+with the library. Pitchwall is a `nuxt/ui` site; b24ui maintains its own
+"built with Bitrix24 UI" showcase and doesn't mirror upstream's entries or
+their screenshots. Ledger/cursor advanced only.

--- a/.sync/nuxt-ui.json
+++ b/.sync/nuxt-ui.json
@@ -2,7 +2,7 @@
   "upstream": "nuxt/ui",
   "branch": "v4",
   "sync_enabled": false,
-  "cursor": "5d82418c56e956a9f1b684b48f9bf40197cdf3aa",
+  "cursor": "78cc1ce5e96afa3f7a0f1456f17b1b179b9c5327",
   "_cursor_note": "cursor = last upstream commit ported into b24ui (oldest-first, manual cadence). sync_enabled stays false until Phase 2 (porter workflow #67 + CLAUDE_CODE_OAUTH_TOKEN) is wired and trusted. `processed` is maintained per port from now on (backfilled #68-#72 on 2026-06-09).",
   "stats": {
     "queue_depth": 0,
@@ -239,10 +239,16 @@
       "summary": "fix(Select/SelectMenu/InputMenu): add fallback for max-height (#6503) — already present in b24ui: all three themes use max-h-[min(40rem,var(--reka-*-content-available-height,100vh))] (b24ui's own 40rem cap + 100vh fallback). The fix's fallback intent is satisfied; matching upstream's 15rem would regress b24ui sizing"
     },
     "5d82418c56e956a9f1b684b48f9bf40197cdf3aa": {
+      "pr": 131,
+      "b24ui_sha": "777fedc1",
+      "decision": "noop",
+      "summary": "fix(locale): improve Thai translation (#6509) — n/a: upstream reorders chatReasoning (already after prose in b24ui) and trims its own pricingTable.caption; b24ui's th.ts is independently translated with different wording (caption 'เปรียบเทียบแผนราคา', thoughtFor 'ใช้เวลาคิด{duration}'), so upstream's specific string edits have no matching target"
+    },
+    "78cc1ce5e96afa3f7a0f1456f17b1b179b9c5327": {
       "pr": null,
       "b24ui_sha": "pending-merge",
       "decision": "noop",
-      "summary": "fix(locale): improve Thai translation (#6509) — n/a: upstream reorders chatReasoning (already after prose in b24ui) and trims its own pricingTable.caption; b24ui's th.ts is independently translated with different wording (caption 'เปรียบเทียบแผนราคา', thoughtFor 'ใช้เวลาคิด{duration}'), so upstream's specific string edits have no matching target"
+      "summary": "docs(showcase): add Pitchwall (#6510) — n/a: another nuxt/ui showcase-gallery entry (site built with nuxt/ui) + screenshot; b24ui keeps its own 'built with Bitrix24 UI' showcase (same rationale as #128)"
     }
   }
 }


### PR DESCRIPTION
Port of nuxt/ui [`78cc1ce5`](https://github.com/nuxt/ui/commit/78cc1ce5e96afa3f7a0f1456f17b1b179b9c5327) — _docs(showcase): add Pitchwall to showcase section (#6510)_.

## Decision: no-op
Adds "Pitchwall" to upstream's showcase gallery (`showcase.yml`) + screenshot. Same rationale as #128: the showcase lists sites built with the library; Pitchwall is a nuxt/ui site, and b24ui keeps its own "built with Bitrix24 UI" showcase. Ledger/cursor advanced only.

https://claude.ai/code/session_01Qz7EXMncvEGiCj4WbmYgJo

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qz7EXMncvEGiCj4WbmYgJo)_