### PR TITLE
chore(sync): record repl Vue-compatible Icon/Link overrides as no-op

### DIFF
--- a/.sync/log/5b9a9c90e7799ade73faa72e8e419ab3192aab66.md
+++ b/.sync/log/5b9a9c90e7799ade73faa72e8e419ab3192aab66.md
@@ -1,0 +1,30 @@
+# Port: chore(repl): use Vue-compatible component overrides for Icon and Link
+
+**Upstream:** `5b9a9c90e7799ade73faa72e8e419ab3192aab66` (nuxt/ui)
+**Decision:** no-op (already covered by b24ui's vite plugin)
+
+## Upstream change
+In the REPL playground, swap the Nuxt-flavored `Icon`/`Link` for their
+Vue-compatible variants so they work in the pure-Vue bundle:
+- `playgrounds/repl/src/entry.ts`: exclude `Icon.vue`/`Link.vue` from the
+  components glob and register `src/runtime/vue/components/Icon.vue` +
+  `src/runtime/vue/overrides/none/Link.vue` instead.
+- `playgrounds/repl/vite.config.bundle.ts`: add a `resolveId` plugin that
+  redirects any in-runtime `Icon.vue`/`Link.vue` import to those overrides.
+
+## Why no-op for b24ui
+b24ui already solves this **centrally** in its own vite plugin
+(`src/plugins/components.ts`), which is what the REPL uses:
+- It defines `routerOverrides` for `vue-router` / `inertia` / `none` and a
+  `resolveId` hook that redirects component `.vue` imports to the selected
+  override source (comment in source: "Vue-compatible replacements for Icon and
+  Link").
+- The REPL builds with `bitrix24UIPluginVite({ router: false, … })`;
+  `resolveRouterMode` maps `router: false → 'none'`, so `Link.vue` already
+  resolves to `src/runtime/vue/overrides/none/Link.vue`.
+- The `Icon` half is **n/a**: b24ui has no `Icon.vue` (it uses
+  `@bitrix24/b24icons-vue` components), as already recorded for PR #69.
+
+So the fix's effect (Vue-compatible Link in the REPL bundle) is already in
+place, and a manual per-REPL `resolveId` override would just duplicate the
+plugin. Ledger/cursor advanced only.

--- a/.sync/nuxt-ui.json
+++ b/.sync/nuxt-ui.json
@@ -2,7 +2,7 @@
   "upstream": "nuxt/ui",
   "branch": "v4",
   "sync_enabled": false,
-  "cursor": "78cc1ce5e96afa3f7a0f1456f17b1b179b9c5327",
+  "cursor": "5b9a9c90e7799ade73faa72e8e419ab3192aab66",
   "_cursor_note": "cursor = last upstream commit ported into b24ui (oldest-first, manual cadence). sync_enabled stays false until Phase 2 (porter workflow #67 + CLAUDE_CODE_OAUTH_TOKEN) is wired and trusted. `processed` is maintained per port from now on (backfilled #68-#72 on 2026-06-09).",
   "stats": {
     "queue_depth": 0,
@@ -245,10 +245,16 @@
       "summary": "fix(locale): improve Thai translation (#6509) — n/a: upstream reorders chatReasoning (already after prose in b24ui) and trims its own pricingTable.caption; b24ui's th.ts is independently translated with different wording (caption 'เปรียบเทียบแผนราคา', thoughtFor 'ใช้เวลาคิด{duration}'), so upstream's specific string edits have no matching target"
     },
     "78cc1ce5e96afa3f7a0f1456f17b1b179b9c5327": {
+      "pr": 132,
+      "b24ui_sha": "61fc0f72",
+      "decision": "noop",
+      "summary": "docs(showcase): add Pitchwall (#6510) — n/a: another nuxt/ui showcase-gallery entry (site built with nuxt/ui) + screenshot; b24ui keeps its own 'built with Bitrix24 UI' showcase (same rationale as #128)"
+    },
+    "5b9a9c90e7799ade73faa72e8e419ab3192aab66": {
       "pr": null,
       "b24ui_sha": "pending-merge",
       "decision": "noop",
-      "summary": "docs(showcase): add Pitchwall (#6510) — n/a: another nuxt/ui showcase-gallery entry (site built with nuxt/ui) + screenshot; b24ui keeps its own 'built with Bitrix24 UI' showcase (same rationale as #128)"
+      "summary": "chore(repl): use Vue-compatible component overrides for Icon and Link — already covered centrally: b24ui's vite plugin (src/plugins/components.ts) resolves Link to vue/overrides/none/Link.vue when router:false (REPL uses bitrix24UIPluginVite({router:false})); Icon part n/a (b24ui has no Icon.vue). Upstream's manual per-REPL resolveId override is redundant"
     }
   }
 }


### PR DESCRIPTION
Port of nuxt/ui [`5b9a9c90`](https://github.com/nuxt/ui/commit/5b9a9c90e7799ade73faa72e8e419ab3192aab66) — _chore(repl): use Vue-compatible component overrides for Icon and Link_.

## Decision: no-op (already covered)
Upstream patches the REPL playground (`entry.ts` + `vite.config.bundle.ts`) to swap the Nuxt-flavored `Icon`/`Link` for Vue-compatible variants via a manual `resolveId` override.

b24ui already does this **centrally** in its own vite plugin (`src/plugins/components.ts`):
- It has `routerOverrides` (`vue-router`/`inertia`/`none`) and a `resolveId` hook that redirects component `.vue` imports to the selected override (source comment: "Vue-compatible replacements for Icon and Link").
- The REPL builds with `bitrix24UIPluginVite({ router: false })`, and `resolveRouterMode` maps `router: false → 'none'`, so `Link.vue` already resolves to `src/runtime/vue/overrides/none/Link.vue`.
- The `Icon` half is **n/a** — b24ui has no `Icon.vue` (uses `@bitrix24/b24icons-vue`), as recorded for PR #69.

The fix's effect is already in place; a manual per-REPL override would just duplicate the plugin. Ledger/cursor advanced only.

https://claude.ai/code/session_01Qz7EXMncvEGiCj4WbmYgJo

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qz7EXMncvEGiCj4WbmYgJo)_