### PR TITLE
fix(module): revert `tagPriority` to `-2` for inline style tag

### DIFF
--- a/.sync/log/2dac77803466b79a12a2c806c90a6b48b75a5a63.md
+++ b/.sync/log/2dac77803466b79a12a2c806c90a6b48b75a5a63.md
@@ -1,0 +1,21 @@
+# Port: fix(module): revert `tagPriority` to `-2` for inline style tag
+
+**Upstream:** `2dac77803466b79a12a2c806c90a6b48b75a5a63` (nuxt/ui)
+**Decision:** port
+
+## Upstream change
+In `src/runtime/plugins/colors.ts`, revert the injected color-variables
+`<style>` tag's `tagPriority` from `'critical'` back to `-2`, so the inline
+style is ordered before other head styles instead of being forced last.
+
+## b24ui adaptation
+b24ui has the identical plugin and code (only the tag `id` differs:
+`bitrix24-ui-colors`). Direct 1:1 change:
+- `src/runtime/plugins/colors.ts`: `tagPriority: 'critical'` → `tagPriority: -2`.
+
+## Verification (pnpm 11.3.0, gate ON)
+frozen install · dev:prepare · lint · typecheck · test (4972 passed, 6 skipped)
+· module build — all green.
+
+Platform note: b24ui CI is `ubuntu-latest` only; OS-independent (a single
+head-tag priority value).

--- a/.sync/nuxt-ui.json
+++ b/.sync/nuxt-ui.json
@@ -2,7 +2,7 @@
   "upstream": "nuxt/ui",
   "branch": "v4",
   "sync_enabled": false,
-  "cursor": "5b9a9c90e7799ade73faa72e8e419ab3192aab66",
+  "cursor": "2dac77803466b79a12a2c806c90a6b48b75a5a63",
   "_cursor_note": "cursor = last upstream commit ported into b24ui (oldest-first, manual cadence). sync_enabled stays false until Phase 2 (porter workflow #67 + CLAUDE_CODE_OAUTH_TOKEN) is wired and trusted. `processed` is maintained per port from now on (backfilled #68-#72 on 2026-06-09).",
   "stats": {
     "queue_depth": 0,
@@ -251,10 +251,16 @@
       "summary": "docs(showcase): add Pitchwall (#6510) — n/a: another nuxt/ui showcase-gallery entry (site built with nuxt/ui) + screenshot; b24ui keeps its own 'built with Bitrix24 UI' showcase (same rationale as #128)"
     },
     "5b9a9c90e7799ade73faa72e8e419ab3192aab66": {
-      "pr": null,
-      "b24ui_sha": "pending-merge",
+      "pr": 133,
+      "b24ui_sha": "2e5594c0",
       "decision": "noop",
       "summary": "chore(repl): use Vue-compatible component overrides for Icon and Link — already covered centrally: b24ui's vite plugin (src/plugins/components.ts) resolves Link to vue/overrides/none/Link.vue when router:false (REPL uses bitrix24UIPluginVite({router:false})); Icon part n/a (b24ui has no Icon.vue). Upstream's manual per-REPL resolveId override is redundant"
+    },
+    "2dac77803466b79a12a2c806c90a6b48b75a5a63": {
+      "pr": null,
+      "b24ui_sha": "pending-merge",
+      "decision": "port",
+      "summary": "fix(module): revert tagPriority to -2 for inline style tag — direct 1:1 in src/runtime/plugins/colors.ts (tagPriority 'critical' -> -2; id bitrix24-ui-colors)"
     }
   }
 }

--- a/src/runtime/plugins/colors.ts
+++ b/src/runtime/plugins/colors.ts
@@ -51,7 +51,7 @@ export default defineNuxtPlugin(() => {
   const headData: UseHeadInput = {
     style: [{
       innerHTML: root,
-      tagPriority: 'critical',
+      tagPriority: -2,
       id: 'bitrix24-ui-colors'
     }]
   }


### PR DESCRIPTION
Port of nuxt/ui [`2dac7780`](https://github.com/nuxt/ui/commit/2dac77803466b79a12a2c806c90a6b48b75a5a63) — _fix(module): revert `tagPriority` to `-2` for inline style tag_.

## What
In `src/runtime/plugins/colors.ts`, revert the injected color-variables `<style>` tag's `tagPriority` from `'critical'` back to `-2`, so the inline style is ordered before other head styles rather than forced last.

b24ui has the identical plugin/code (only the tag `id` differs: `bitrix24-ui-colors`), so this is a direct 1:1 change.

## Verification
Under pnpm 11.3.0 with the `minimumReleaseAge` gate ON: frozen install · `dev:prepare` · lint · typecheck · test (**4972 passed**, 6 skipped) · module build — all green.

Platform: b24ui CI is `ubuntu-latest` only; OS-independent (a single head-tag priority value).

https://claude.ai/code/session_01Qz7EXMncvEGiCj4WbmYgJo

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qz7EXMncvEGiCj4WbmYgJo)_