### PR TITLE
chore: add `.cursor` to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ logs
 
 # Misc
 .DS_Store
+.cursor
 .fleet
 .idea
 /@tmp

--- a/.sync/log/a4dfa9e6b6c87a6d104a86c4169ab9e30747c355.md
+++ b/.sync/log/a4dfa9e6b6c87a6d104a86c4169ab9e30747c355.md
@@ -1,0 +1,15 @@
+# Port: chore: add `.cursor` to `.gitignore`
+
+**Upstream:** `a4dfa9e6b6c87a6d104a86c4169ab9e30747c355` (nuxt/ui)
+**Decision:** port
+
+## Upstream change
+Adds `.cursor` (the Cursor editor's per-project dir) to `.gitignore`, in the
+Misc section between `.DS_Store` and `.fleet`.
+
+## b24ui adaptation
+Direct 1:1 — b24ui's `.gitignore` has the same Misc section
+(`.DS_Store` / `.fleet` / `.idea` …); added `.cursor` after `.DS_Store`.
+Confirmed with `git check-ignore .cursor` → ignored.
+
+Editor-tooling ignore, no build/runtime impact.

--- a/.sync/nuxt-ui.json
+++ b/.sync/nuxt-ui.json
@@ -2,7 +2,7 @@
   "upstream": "nuxt/ui",
   "branch": "v4",
   "sync_enabled": false,
-  "cursor": "2dac77803466b79a12a2c806c90a6b48b75a5a63",
+  "cursor": "a4dfa9e6b6c87a6d104a86c4169ab9e30747c355",
   "_cursor_note": "cursor = last upstream commit ported into b24ui (oldest-first, manual cadence). sync_enabled stays false until Phase 2 (porter workflow #67 + CLAUDE_CODE_OAUTH_TOKEN) is wired and trusted. `processed` is maintained per port from now on (backfilled #68-#72 on 2026-06-09).",
   "stats": {
     "queue_depth": 0,
@@ -257,10 +257,16 @@
       "summary": "chore(repl): use Vue-compatible component overrides for Icon and Link — already covered centrally: b24ui's vite plugin (src/plugins/components.ts) resolves Link to vue/overrides/none/Link.vue when router:false (REPL uses bitrix24UIPluginVite({router:false})); Icon part n/a (b24ui has no Icon.vue). Upstream's manual per-REPL resolveId override is redundant"
     },
     "2dac77803466b79a12a2c806c90a6b48b75a5a63": {
+      "pr": 134,
+      "b24ui_sha": "6f539d81",
+      "decision": "port",
+      "summary": "fix(module): revert tagPriority to -2 for inline style tag — direct 1:1 in src/runtime/plugins/colors.ts (tagPriority 'critical' -> -2; id bitrix24-ui-colors)"
+    },
+    "a4dfa9e6b6c87a6d104a86c4169ab9e30747c355": {
       "pr": null,
       "b24ui_sha": "pending-merge",
       "decision": "port",
-      "summary": "fix(module): revert tagPriority to -2 for inline style tag — direct 1:1 in src/runtime/plugins/colors.ts (tagPriority 'critical' -> -2; id bitrix24-ui-colors)"
+      "summary": "chore: add .cursor to .gitignore — added .cursor under the Misc section (after .DS_Store), matching upstream"
     }
   }
 }


### PR DESCRIPTION
Port of nuxt/ui [`a4dfa9e6`](https://github.com/nuxt/ui/commit/a4dfa9e6b6c87a6d104a86c4169ab9e30747c355) — _chore: add `.cursor` to `.gitignore`_.

## What
Ignore the Cursor editor's per-project `.cursor` directory. Direct 1:1 — added under b24ui's `.gitignore` Misc section after `.DS_Store` (same place as upstream). Verified with `git check-ignore .cursor`.

Editor-tooling ignore, no build/runtime impact.

https://claude.ai/code/session_01Qz7EXMncvEGiCj4WbmYgJo

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qz7EXMncvEGiCj4WbmYgJo)_