### PR TITLE
fix(Form): add `method="post"` to prevent credential leaking via GET

### DIFF
--- a/.sync/log/7a0825ad6a17627ce4c6dd860df3cebb7cf1d813.md
+++ b/.sync/log/7a0825ad6a17627ce4c6dd860df3cebb7cf1d813.md
@@ -1,0 +1,26 @@
+# Port: fix(Form): add `method="post"` to prevent credential leaking via GET
+
+**Upstream:** `7a0825ad6a17627ce4c6dd860df3cebb7cf1d813` (nuxt/ui)
+**Decision:** port
+
+## Upstream change
+Add `method="post"` to the `<form>` root in `Form.vue`. Without it, a native
+submit (e.g. if `@submit.prevent` is ever bypassed) defaults to GET and would
+append field values — including passwords — to the URL. Plus snapshot regen.
+
+## b24ui adaptation
+b24ui's `Form.vue` root is structurally identical
+(`:is="parentBus ? 'div' : 'form'"`, `:id`, `ref="formRef"`,
+`@submit.prevent`). Added `method="post"` on the same element; it applies only
+to the top-level `<form>` (nested forms render as `<div>` via `parentBus`).
+- `src/runtime/components/Form.vue`: + `method="post"`.
+- Regenerated `Form.spec.ts.snap` / `Form-vue.spec.ts.snap` (28 snapshots).
+  b24ui has no AuthForm snapshot file (unlike upstream), so only the Form
+  snapshots changed; the full suite stays green.
+
+## Verification (pnpm 11.3.0, gate ON)
+frozen install · lint · typecheck · test (4972 passed, 6 skipped) · module
+build — all green.
+
+Platform note: b24ui CI is `ubuntu-latest` only; OS-independent (a static form
+attribute + snapshots).

--- a/.sync/nuxt-ui.json
+++ b/.sync/nuxt-ui.json
@@ -2,7 +2,7 @@
   "upstream": "nuxt/ui",
   "branch": "v4",
   "sync_enabled": false,
-  "cursor": "fc6295b233bb46c90715f36f4a3838dcd8dcf063",
+  "cursor": "7a0825ad6a17627ce4c6dd860df3cebb7cf1d813",
   "_cursor_note": "cursor = last upstream commit ported into b24ui (oldest-first, manual cadence). sync_enabled stays false until Phase 2 (porter workflow #67 + CLAUDE_CODE_OAUTH_TOKEN) is wired and trusted. `processed` is maintained per port from now on (backfilled #68-#72 on 2026-06-09).",
   "stats": {
     "queue_depth": 0,
@@ -269,10 +269,16 @@
       "summary": "chore: add .cursor to .gitignore — added .cursor under the Misc section (after .DS_Store), matching upstream"
     },
     "fc6295b233bb46c90715f36f4a3838dcd8dcf063": {
-      "pr": null,
-      "b24ui_sha": "pending-merge",
+      "pr": 136,
+      "b24ui_sha": "2c160526",
       "decision": "noop",
       "summary": "chore(playground): update vite optimizeDeps include list — upstream only alphabetizes its include[] (no add/remove, zero runtime effect); b24ui's playgrounds/nuxt list is a superset (same 9 + many @bitrix24/b24icons-vue entries) with its own grouping, so the cosmetic reorder doesn't map"
+    },
+    "7a0825ad6a17627ce4c6dd860df3cebb7cf1d813": {
+      "pr": null,
+      "b24ui_sha": "pending-merge",
+      "decision": "port",
+      "summary": "fix(Form): add method=\"post\" to the <form> root in Form.vue (prevents GET-submit leaking field values into the URL); regen Form snapshots (nuxt+vue). b24ui has no AuthForm snapshot so only Form snaps changed"
     }
   }
 }

--- a/src/runtime/components/Form.vue
+++ b/src/runtime/components/Form.vue
@@ -462,6 +462,7 @@ defineExpose(api)
     :is="parentBus ? 'div' : 'form'"
     :id="formId"
     ref="formRef"
+    method="post"
     :class="b24ui({ class: [props.b24ui?.base, props.class] })"
     @submit.prevent="onSubmitWrapper"
   >

--- a/test/components/__snapshots__/Form-vue.spec.ts.snap
+++ b/test/components/__snapshots__/Form-vue.spec.ts.snap
@@ -1,7 +1,7 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`Form > custom validation works > with error 1`] = `
-"<form id="42" class="">
+"<form id="42" method="post" class="">
   <div data-orientation="vertical" data-slot="root" class="font-[family-name:var(--ui-font-family-system)] font-(--ui-font-weight-regular) text-(length:--ui-font-size-sm)" id="emailField">
     <div data-slot="wrapper" class="leading-(--ui-font-line-height-reset) mb-[10px]">
       <!--v-if-->
@@ -40,7 +40,7 @@ exports[`Form > custom validation works > with error 1`] = `
 `;
 
 exports[`Form > custom validation works > without error 1`] = `
-"<form id="42" class="">
+"<form id="42" method="post" class="">
   <div data-orientation="vertical" data-slot="root" class="font-[family-name:var(--ui-font-family-system)] font-(--ui-font-weight-regular) text-(length:--ui-font-size-sm)" id="emailField">
     <div data-slot="wrapper" class="leading-(--ui-font-line-height-reset) mb-[10px]">
       <!--v-if-->
@@ -73,7 +73,7 @@ exports[`Form > custom validation works > without error 1`] = `
 `;
 
 exports[`Form > joi validation works > with error 1`] = `
-"<form id="42" class="">
+"<form id="42" method="post" class="">
   <div data-orientation="vertical" data-slot="root" class="font-[family-name:var(--ui-font-family-system)] font-(--ui-font-weight-regular) text-(length:--ui-font-size-sm)" id="emailField">
     <div data-slot="wrapper" class="leading-(--ui-font-line-height-reset) mb-[10px]">
       <!--v-if-->
@@ -112,7 +112,7 @@ exports[`Form > joi validation works > with error 1`] = `
 `;
 
 exports[`Form > joi validation works > without error 1`] = `
-"<form id="42" class="">
+"<form id="42" method="post" class="">
   <div data-orientation="vertical" data-slot="root" class="font-[family-name:var(--ui-font-family-system)] font-(--ui-font-weight-regular) text-(length:--ui-font-size-sm)" id="emailField">
     <div data-slot="wrapper" class="leading-(--ui-font-line-height-reset) mb-[10px]">
       <!--v-if-->
@@ -144,12 +144,12 @@ exports[`Form > joi validation works > without error 1`] = `
 </form>"
 `;
 
-exports[`Form > renders with default slot correctly 1`] = `"<form id="v-0" class="">Form slot</form>"`;
+exports[`Form > renders with default slot correctly 1`] = `"<form id="v-0" method="post" class="">Form slot</form>"`;
 
-exports[`Form > renders with state correctly 1`] = `"<form id="v-0" class=""></form>"`;
+exports[`Form > renders with state correctly 1`] = `"<form id="v-0" method="post" class=""></form>"`;
 
 exports[`Form > superstruct validation works > with error 1`] = `
-"<form id="42" class="">
+"<form id="42" method="post" class="">
   <div data-orientation="vertical" data-slot="root" class="font-[family-name:var(--ui-font-family-system)] font-(--ui-font-weight-regular) text-(length:--ui-font-size-sm)" id="emailField">
     <div data-slot="wrapper" class="leading-(--ui-font-line-height-reset) mb-[10px]">
       <!--v-if-->
@@ -188,7 +188,7 @@ exports[`Form > superstruct validation works > with error 1`] = `
 `;
 
 exports[`Form > superstruct validation works > without error 1`] = `
-"<form id="42" class="">
+"<form id="42" method="post" class="">
   <div data-orientation="vertical" data-slot="root" class="font-[family-name:var(--ui-font-family-system)] font-(--ui-font-weight-regular) text-(length:--ui-font-size-sm)" id="emailField">
     <div data-slot="wrapper" class="leading-(--ui-font-line-height-reset) mb-[10px]">
       <!--v-if-->
@@ -221,7 +221,7 @@ exports[`Form > superstruct validation works > without error 1`] = `
 `;
 
 exports[`Form > valibot validation works > with error 1`] = `
-"<form id="42" class="">
+"<form id="42" method="post" class="">
   <div data-orientation="vertical" data-slot="root" class="font-[family-name:var(--ui-font-family-system)] font-(--ui-font-weight-regular) text-(length:--ui-font-size-sm)" id="emailField">
     <div data-slot="wrapper" class="leading-(--ui-font-line-height-reset) mb-[10px]">
       <!--v-if-->
@@ -260,7 +260,7 @@ exports[`Form > valibot validation works > with error 1`] = `
 `;
 
 exports[`Form > valibot validation works > without error 1`] = `
-"<form id="42" class="">
+"<form id="42" method="post" class="">
   <div data-orientation="vertical" data-slot="root" class="font-[family-name:var(--ui-font-family-system)] font-(--ui-font-weight-regular) text-(length:--ui-font-size-sm)" id="emailField">
     <div data-slot="wrapper" class="leading-(--ui-font-line-height-reset) mb-[10px]">
       <!--v-if-->
@@ -293,7 +293,7 @@ exports[`Form > valibot validation works > without error 1`] = `
 `;
 
 exports[`Form > yup validation works > with error 1`] = `
-"<form id="42" class="">
+"<form id="42" method="post" class="">
   <div data-orientation="vertical" data-slot="root" class="font-[family-name:var(--ui-font-family-system)] font-(--ui-font-weight-regular) text-(length:--ui-font-size-sm)" id="emailField">
     <div data-slot="wrapper" class="leading-(--ui-font-line-height-reset) mb-[10px]">
       <!--v-if-->
@@ -371,7 +371,7 @@ exports[`Form > yup validation works > with error 2`] = `
 `;
 
 exports[`Form > yup validation works > without error 1`] = `
-"<form id="42" class="">
+"<form id="42" method="post" class="">
   <div data-orientation="vertical" data-slot="root" class="font-[family-name:var(--ui-font-family-system)] font-(--ui-font-weight-regular) text-(length:--ui-font-size-sm)" id="emailField">
     <div data-slot="wrapper" class="leading-(--ui-font-line-height-reset) mb-[10px]">
       <!--v-if-->
@@ -437,7 +437,7 @@ exports[`Form > yup validation works > without error 2`] = `
 `;
 
 exports[`Form > zod validation works > with error 1`] = `
-"<form id="42" class="">
+"<form id="42" method="post" class="">
   <div data-orientation="vertical" data-slot="root" class="font-[family-name:var(--ui-font-family-system)] font-(--ui-font-weight-regular) text-(length:--ui-font-size-sm)" id="emailField">
     <div data-slot="wrapper" class="leading-(--ui-font-line-height-reset) mb-[10px]">
       <!--v-if-->
@@ -476,7 +476,7 @@ exports[`Form > zod validation works > with error 1`] = `
 `;
 
 exports[`Form > zod validation works > without error 1`] = `
-"<form id="42" class="">
+"<form id="42" method="post" class="">
   <div data-orientation="vertical" data-slot="root" class="font-[family-name:var(--ui-font-family-system)] font-(--ui-font-weight-regular) text-(length:--ui-font-size-sm)" id="emailField">
     <div data-slot="wrapper" class="leading-(--ui-font-line-height-reset) mb-[10px]">
       <!--v-if-->

--- a/test/components/__snapshots__/Form.spec.ts.snap
+++ b/test/components/__snapshots__/Form.spec.ts.snap
@@ -1,7 +1,7 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`Form > custom validation works > with error 1`] = `
-"<form id="42" class="">
+"<form id="42" method="post" class="">
   <div data-orientation="vertical" data-slot="root" class="font-[family-name:var(--ui-font-family-system)] font-(--ui-font-weight-regular) text-(length:--ui-font-size-sm)" id="emailField">
     <div data-slot="wrapper" class="leading-(--ui-font-line-height-reset) mb-[10px]">
       <!--v-if-->
@@ -40,7 +40,7 @@ exports[`Form > custom validation works > with error 1`] = `
 `;
 
 exports[`Form > custom validation works > without error 1`] = `
-"<form id="42" class="">
+"<form id="42" method="post" class="">
   <div data-orientation="vertical" data-slot="root" class="font-[family-name:var(--ui-font-family-system)] font-(--ui-font-weight-regular) text-(length:--ui-font-size-sm)" id="emailField">
     <div data-slot="wrapper" class="leading-(--ui-font-line-height-reset) mb-[10px]">
       <!--v-if-->
@@ -73,7 +73,7 @@ exports[`Form > custom validation works > without error 1`] = `
 `;
 
 exports[`Form > joi validation works > with error 1`] = `
-"<form id="42" class="">
+"<form id="42" method="post" class="">
   <div data-orientation="vertical" data-slot="root" class="font-[family-name:var(--ui-font-family-system)] font-(--ui-font-weight-regular) text-(length:--ui-font-size-sm)" id="emailField">
     <div data-slot="wrapper" class="leading-(--ui-font-line-height-reset) mb-[10px]">
       <!--v-if-->
@@ -112,7 +112,7 @@ exports[`Form > joi validation works > with error 1`] = `
 `;
 
 exports[`Form > joi validation works > without error 1`] = `
-"<form id="42" class="">
+"<form id="42" method="post" class="">
   <div data-orientation="vertical" data-slot="root" class="font-[family-name:var(--ui-font-family-system)] font-(--ui-font-weight-regular) text-(length:--ui-font-size-sm)" id="emailField">
     <div data-slot="wrapper" class="leading-(--ui-font-line-height-reset) mb-[10px]">
       <!--v-if-->
@@ -144,12 +144,12 @@ exports[`Form > joi validation works > without error 1`] = `
 </form>"
 `;
 
-exports[`Form > renders with default slot correctly 1`] = `"<form id="v-0-0" class="">Form slot</form>"`;
+exports[`Form > renders with default slot correctly 1`] = `"<form id="v-0-0" method="post" class="">Form slot</form>"`;
 
-exports[`Form > renders with state correctly 1`] = `"<form id="v-0-0" class=""></form>"`;
+exports[`Form > renders with state correctly 1`] = `"<form id="v-0-0" method="post" class=""></form>"`;
 
 exports[`Form > superstruct validation works > with error 1`] = `
-"<form id="42" class="">
+"<form id="42" method="post" class="">
   <div data-orientation="vertical" data-slot="root" class="font-[family-name:var(--ui-font-family-system)] font-(--ui-font-weight-regular) text-(length:--ui-font-size-sm)" id="emailField">
     <div data-slot="wrapper" class="leading-(--ui-font-line-height-reset) mb-[10px]">
       <!--v-if-->
@@ -188,7 +188,7 @@ exports[`Form > superstruct validation works > with error 1`] = `
 `;
 
 exports[`Form > superstruct validation works > without error 1`] = `
-"<form id="42" class="">
+"<form id="42" method="post" class="">
   <div data-orientation="vertical" data-slot="root" class="font-[family-name:var(--ui-font-family-system)] font-(--ui-font-weight-regular) text-(length:--ui-font-size-sm)" id="emailField">
     <div data-slot="wrapper" class="leading-(--ui-font-line-height-reset) mb-[10px]">
       <!--v-if-->
@@ -221,7 +221,7 @@ exports[`Form > superstruct validation works > without error 1`] = `
 `;
 
 exports[`Form > valibot validation works > with error 1`] = `
-"<form id="42" class="">
+"<form id="42" method="post" class="">
   <div data-orientation="vertical" data-slot="root" class="font-[family-name:var(--ui-font-family-system)] font-(--ui-font-weight-regular) text-(length:--ui-font-size-sm)" id="emailField">
     <div data-slot="wrapper" class="leading-(--ui-font-line-height-reset) mb-[10px]">
       <!--v-if-->
@@ -260,7 +260,7 @@ exports[`Form > valibot validation works > with error 1`] = `
 `;
 
 exports[`Form > valibot validation works > without error 1`] = `
-"<form id="42" class="">
+"<form id="42" method="post" class="">
   <div data-orientation="vertical" data-slot="root" class="font-[family-name:var(--ui-font-family-system)] font-(--ui-font-weight-regular) text-(length:--ui-font-size-sm)" id="emailField">
     <div data-slot="wrapper" class="leading-(--ui-font-line-height-reset) mb-[10px]">
       <!--v-if-->
@@ -293,7 +293,7 @@ exports[`Form > valibot validation works > without error 1`] = `
 `;
 
 exports[`Form > yup validation works > with error 1`] = `
-"<form id="42" class="">
+"<form id="42" method="post" class="">
   <div data-orientation="vertical" data-slot="root" class="font-[family-name:var(--ui-font-family-system)] font-(--ui-font-weight-regular) text-(length:--ui-font-size-sm)" id="emailField">
     <div data-slot="wrapper" class="leading-(--ui-font-line-height-reset) mb-[10px]">
       <!--v-if-->
@@ -332,7 +332,7 @@ exports[`Form > yup validation works > with error 1`] = `
 `;
 
 exports[`Form > yup validation works > without error 1`] = `
-"<form id="42" class="">
+"<form id="42" method="post" class="">
   <div data-orientation="vertical" data-slot="root" class="font-[family-name:var(--ui-font-family-system)] font-(--ui-font-weight-regular) text-(length:--ui-font-size-sm)" id="emailField">
     <div data-slot="wrapper" class="leading-(--ui-font-line-height-reset) mb-[10px]">
       <!--v-if-->
@@ -365,7 +365,7 @@ exports[`Form > yup validation works > without error 1`] = `
 `;
 
 exports[`Form > zod validation works > with error 1`] = `
-"<form id="42" class="">
+"<form id="42" method="post" class="">
   <div data-orientation="vertical" data-slot="root" class="font-[family-name:var(--ui-font-family-system)] font-(--ui-font-weight-regular) text-(length:--ui-font-size-sm)" id="emailField">
     <div data-slot="wrapper" class="leading-(--ui-font-line-height-reset) mb-[10px]">
       <!--v-if-->
@@ -404,7 +404,7 @@ exports[`Form > zod validation works > with error 1`] = `
 `;
 
 exports[`Form > zod validation works > without error 1`] = `
-"<form id="42" class="">
+"<form id="42" method="post" class="">
   <div data-orientation="vertical" data-slot="root" class="font-[family-name:var(--ui-font-family-system)] font-(--ui-font-weight-regular) text-(length:--ui-font-size-sm)" id="emailField">
     <div data-slot="wrapper" class="leading-(--ui-font-line-height-reset) mb-[10px]">
       <!--v-if-->


### PR DESCRIPTION
Port of nuxt/ui [`7a0825ad`](https://github.com/nuxt/ui/commit/7a0825ad6a17627ce4c6dd860df3cebb7cf1d813) — _fix(Form): add `method="post"` to prevent credential leaking via GET_.

## What
Add `method="post"` to the `<form>` root in `Form.vue`. Without it, a native submit (if `@submit.prevent` is ever bypassed) defaults to **GET** and appends field values — including passwords — to the URL. b24ui's `Form.vue` root is structurally identical, so this is a direct 1:1 change.

- `src/runtime/components/Form.vue`: + `method="post"` (top-level form only; nested forms render as `<div>` via `parentBus`).
- Regenerated `Form.spec.ts.snap` / `Form-vue.spec.ts.snap`. b24ui has no AuthForm snapshot file (unlike upstream), so only the Form snapshots changed.

## Verification
Under pnpm 11.3.0 with the gate ON: frozen install · lint · typecheck · test (**4972 passed**, 6 skipped) · module build — all green.

Platform: b24ui CI is `ubuntu-latest` only; OS-independent (a static form attribute + snapshots).

https://claude.ai/code/session_01Qz7EXMncvEGiCj4WbmYgJo

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qz7EXMncvEGiCj4WbmYgJo)_