### PR TITLE
docs(toast): remove misleading AppConfig notes from examples

### DIFF
--- a/.sync/log/564adbfcb46486d5f80fd1663a4b37c0d762390c.md
+++ b/.sync/log/564adbfcb46486d5f80fd1663a4b37c0d762390c.md
@@ -1,0 +1,18 @@
+# Port: docs(toast): remove misleading AppConfig notes from examples
+
+**Upstream:** `564adbfcb46486d5f80fd1663a4b37c0d762390c` (nuxt/ui)
+**Decision:** port
+
+## Upstream change
+Removes four `::note{…}` callouts from `docs/content/docs/2.components/toast.md`
+that claimed the *Change global position / duration / max / expand* examples
+configure the `Toaster` via `AppConfig`. They're misleading — those examples
+set the props directly, not through `AppConfig`.
+
+## b24ui adaptation
+b24ui's `toast.md` carried the same four notes (with the link pointing at
+`bitrix24/b24ui/.../app.config.ts`). Removed all four, each together with its
+trailing blank line, leaving clean single-blank separation before the next
+`###`. The unrelated note at the top (`to="/docs/components/app/"`) is kept.
+
+Docs-content only; no component/test/build impact.

--- a/.sync/nuxt-ui.json
+++ b/.sync/nuxt-ui.json
@@ -2,7 +2,7 @@
   "upstream": "nuxt/ui",
   "branch": "v4",
   "sync_enabled": false,
-  "cursor": "7a0825ad6a17627ce4c6dd860df3cebb7cf1d813",
+  "cursor": "564adbfcb46486d5f80fd1663a4b37c0d762390c",
   "_cursor_note": "cursor = last upstream commit ported into b24ui (oldest-first, manual cadence). sync_enabled stays false until Phase 2 (porter workflow #67 + CLAUDE_CODE_OAUTH_TOKEN) is wired and trusted. `processed` is maintained per port from now on (backfilled #68-#72 on 2026-06-09).",
   "stats": {
     "queue_depth": 0,
@@ -275,10 +275,16 @@
       "summary": "chore(playground): update vite optimizeDeps include list — upstream only alphabetizes its include[] (no add/remove, zero runtime effect); b24ui's playgrounds/nuxt list is a superset (same 9 + many @bitrix24/b24icons-vue entries) with its own grouping, so the cosmetic reorder doesn't map"
     },
     "7a0825ad6a17627ce4c6dd860df3cebb7cf1d813": {
+      "pr": 137,
+      "b24ui_sha": "c2affeb3",
+      "decision": "port",
+      "summary": "fix(Form): add method=\"post\" to the <form> root in Form.vue (prevents GET-submit leaking field values into the URL); regen Form snapshots (nuxt+vue). b24ui has no AuthForm snapshot so only Form snaps changed"
+    },
+    "564adbfcb46486d5f80fd1663a4b37c0d762390c": {
       "pr": null,
       "b24ui_sha": "pending-merge",
       "decision": "port",
-      "summary": "fix(Form): add method=\"post\" to the <form> root in Form.vue (prevents GET-submit leaking field values into the URL); regen Form snapshots (nuxt+vue). b24ui has no AuthForm snapshot so only Form snaps changed"
+      "summary": "docs(toast): remove misleading AppConfig notes — removed the 4 ::note blocks claiming the position/duration/max/expand examples use AppConfig (they use props directly) from docs/content/docs/2.components/toast.md; b24ui had the same notes (pointing at b24ui app.config.ts)"
     }
   }
 }

--- a/docs/content/docs/2.components/toast.md
+++ b/docs/content/docs/2.components/toast.md
@@ -207,10 +207,6 @@ name: 'toast-example'
 :toaster-position-example
 ::
 
-::note{to="https://github.com/bitrix24/b24ui/blob/main/docs/app/app.config.ts#L3"}
-In this example, we use the `AppConfig` to configure the `position` prop of the `Toaster` component globally.
-::
-
 ### Change global duration
 
 Change the `toaster.duration` prop on the [App](/docs/components/app/#props) component to change the duration of the toasts.
@@ -237,10 +233,6 @@ name: 'toast-example'
 :toaster-duration-example
 ::
 
-::note{to="https://github.com/bitrix24/b24ui/blob/main/docs/app/app.config.ts#L4"}
-In this example, we use the `AppConfig` to configure the `duration` prop of the `Toaster` component globally.
-::
-
 ### Change global max
 
 Change the `toaster.max` prop on the [App](/docs/components/app/#props) component to change the max number of toasts displayed at once.
@@ -265,10 +257,6 @@ name: 'toast-example'
 
 #options
 :toaster-max-example
-::
-
-::note{to="https://github.com/bitrix24/b24ui/blob/main/docs/app/app.config.ts#L5"}
-In this example, we use the `AppConfig` to configure the `max` prop of the `Toaster` component globally.
 ::
 
 ### Stacked toasts
@@ -299,10 +287,6 @@ name: 'toast-example'
 
 #options
 :toaster-expand-example
-::
-
-::note{to="https://github.com/bitrix24/b24ui/blob/main/docs/app/app.config.ts#L6"}
-In this example, we use the `AppConfig` to configure the `expand` prop of the `Toaster` component globally.
 ::
 
 ### Deduplicated toasts


### PR DESCRIPTION
Port of nuxt/ui [`564adbfc`](https://github.com/nuxt/ui/commit/564adbfcb46486d5f80fd1663a4b37c0d762390c) — _docs(toast): remove misleading AppConfig notes from examples_.

## What
Removes four `::note{…}` callouts in `docs/content/docs/2.components/toast.md` that claimed the *Change global position / duration / max / expand* examples configure the `Toaster` via `AppConfig` — those examples set the props directly, so the notes are misleading.

b24ui carried the same four notes (linking to b24ui's `app.config.ts`); removed all four. The unrelated app-config doc link at the top of the page is kept.

Docs-content only — no component/test/build impact.

https://claude.ai/code/session_01Qz7EXMncvEGiCj4WbmYgJo

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qz7EXMncvEGiCj4WbmYgJo)_