### PR TITLE
docs: fix missing CSS variables on prerendered pages

### DIFF
--- a/.sync/log/c9fc7a41838f15c87872d93636886ef149755405.md
+++ b/.sync/log/c9fc7a41838f15c87872d93636886ef149755405.md
@@ -1,0 +1,31 @@
+# Port: docs: fix missing CSS variables on prerendered pages (#6519)
+
+**Upstream:** `c9fc7a41838f15c87872d93636886ef149755405` (nuxt/ui)
+**Decision:** port
+
+## Upstream change
+Two parts:
+1. `src/runtime/plugins/colors.ts`: revert the color-vars `<style>`
+   `tagPriority` back to `'critical'` (from `-2`). At `-2` the inline style was
+   ordered too early and got dropped on prerendered pages, leaving CSS
+   variables missing; `'critical'` keeps it.
+2. `docs/nuxt.config.ts`: move `asyncContext: true` out of the top-level
+   `experimental` block into `nitro.experimental` (where Nitro reads it during
+   prerender).
+
+This effectively re-reverts the previous `2dac7780` (b24ui #134, which had set
+`-2`); net colors.ts is back to `'critical'`.
+
+## b24ui adaptation
+Both files exist with identical structure:
+- `src/runtime/plugins/colors.ts`: `tagPriority: -2 → 'critical'`
+  (id `bitrix24-ui-colors`).
+- `docs/nuxt.config.ts`: removed `asyncContext: true` from `experimental`,
+  added `experimental: { asyncContext: true }` at the top of the `nitro` block.
+
+## Verification (pnpm 11.3.0, gate ON)
+frozen install · dev:prepare · lint · typecheck · test (4972 passed, 6 skipped)
+· module build — all green.
+
+Platform note: b24ui CI is `ubuntu-latest` only; OS-independent (a head-tag
+priority value + a Nuxt config option relocation).

--- a/.sync/nuxt-ui.json
+++ b/.sync/nuxt-ui.json
@@ -2,7 +2,7 @@
   "upstream": "nuxt/ui",
   "branch": "v4",
   "sync_enabled": false,
-  "cursor": "564adbfcb46486d5f80fd1663a4b37c0d762390c",
+  "cursor": "c9fc7a41838f15c87872d93636886ef149755405",
   "_cursor_note": "cursor = last upstream commit ported into b24ui (oldest-first, manual cadence). sync_enabled stays false until Phase 2 (porter workflow #67 + CLAUDE_CODE_OAUTH_TOKEN) is wired and trusted. `processed` is maintained per port from now on (backfilled #68-#72 on 2026-06-09).",
   "stats": {
     "queue_depth": 0,
@@ -281,10 +281,16 @@
       "summary": "fix(Form): add method=\"post\" to the <form> root in Form.vue (prevents GET-submit leaking field values into the URL); regen Form snapshots (nuxt+vue). b24ui has no AuthForm snapshot so only Form snaps changed"
     },
     "564adbfcb46486d5f80fd1663a4b37c0d762390c": {
+      "pr": 138,
+      "b24ui_sha": "253d9d9f",
+      "decision": "port",
+      "summary": "docs(toast): remove misleading AppConfig notes — removed the 4 ::note blocks claiming the position/duration/max/expand examples use AppConfig (they use props directly) from docs/content/docs/2.components/toast.md; b24ui had the same notes (pointing at b24ui app.config.ts)"
+    },
+    "c9fc7a41838f15c87872d93636886ef149755405": {
       "pr": null,
       "b24ui_sha": "pending-merge",
       "decision": "port",
-      "summary": "docs(toast): remove misleading AppConfig notes — removed the 4 ::note blocks claiming the position/duration/max/expand examples use AppConfig (they use props directly) from docs/content/docs/2.components/toast.md; b24ui had the same notes (pointing at b24ui app.config.ts)"
+      "summary": "docs: fix missing CSS variables on prerendered pages (#6519) — colors.ts tagPriority -2 -> 'critical' (re-reverts #134); docs/nuxt.config.ts move asyncContext:true from experimental into nitro.experimental"
     }
   }
 }

--- a/docs/nuxt.config.ts
+++ b/docs/nuxt.config.ts
@@ -358,7 +358,6 @@ export default defineNuxtConfig({
   },
 
   experimental: {
-    asyncContext: true,
     defaults: {
       nuxtLink: {
         externalRelAttribute: 'noopener'
@@ -369,6 +368,9 @@ export default defineNuxtConfig({
   compatibilityDate: '2026-01-14',
 
   nitro: {
+    experimental: {
+      asyncContext: true
+    },
     publicAssets: [{
       dir: resolve('../skills'),
       baseURL: '/.well-known/skills',

--- a/src/runtime/plugins/colors.ts
+++ b/src/runtime/plugins/colors.ts
@@ -51,7 +51,7 @@ export default defineNuxtPlugin(() => {
   const headData: UseHeadInput = {
     style: [{
       innerHTML: root,
-      tagPriority: -2,
+      tagPriority: 'critical',
       id: 'bitrix24-ui-colors'
     }]
   }


### PR DESCRIPTION
Port of nuxt/ui [`c9fc7a41`](https://github.com/nuxt/ui/commit/c9fc7a41838f15c87872d93636886ef149755405) — _docs: fix missing CSS variables on prerendered pages (#6519)_.

## What
1. **`src/runtime/plugins/colors.ts`**: revert the color-vars `<style>` `tagPriority` back to `'critical'` (from `-2`). At `-2` the inline style ordered too early and got dropped on prerendered pages, leaving CSS variables missing.
2. **`docs/nuxt.config.ts`**: move `asyncContext: true` out of the top-level `experimental` block into `nitro.experimental`, where Nitro reads it during prerender.

b24ui has both files with identical structure; applied 1:1.

## Note
This **re-reverts** the `tagPriority` change from #134 (`2dac7780`, which set `-2`). Net effect on `colors.ts` across the two PRs is back to `'critical'` — both are faithful sequential ports of the upstream history.

## Verification
Under pnpm 11.3.0 with the gate ON: frozen install · `dev:prepare` · lint · typecheck · test (**4972 passed**, 6 skipped) · module build — all green.

Platform: b24ui CI is `ubuntu-latest` only; OS-independent.

https://claude.ai/code/session_01Qz7EXMncvEGiCj4WbmYgJo

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qz7EXMncvEGiCj4WbmYgJo)_