### PR TITLE
fix(module): expose component theme keys in AppConfig type

### DIFF
--- a/.sync/PORTING.md
+++ b/.sync/PORTING.md
@@ -26,6 +26,7 @@ material. Reproduce its *intent* in b24ui by editing files under `src/` only.
 |---|---|
 | `ui` prop / `ui?:` type | `b24ui` prop / `b24ui?:` type |
 | slot prop `{ ui }` | `{ b24ui }` |
+| `infer UI` / a `UI` type-var | `infer B24UI` / `B24UI` (rename the inferred type variable too) |
 | imports `#ui/...`, `@nuxt/ui` | b24ui equivalents under `src/runtime/...` |
 | iconify name `i-lucide-x` etc. | `b24-icons` component — see [`icon-map.json`](./icon-map.json) |
 | color token (`primary`, `neutral`, …) | `air-*` system — see [`color-map.json`](./color-map.json) |
@@ -115,3 +116,4 @@ History of the maps lives in git; no separate version field.
 - 2026-06-04 — _(seed)_ initial rules extracted from `.sync/PLAN.md` review. Last reviewed: 2026-06-04.
 - 2026-06-09 — port of `007b136a` (PR #72): added rule — match the reka **transform-origin / available-height CSS var namespace to the underlying primitive** (`--reka-combobox-*` for InputMenu/SelectMenu, `--reka-select-*` for Select, `--reka-dropdown-menu-*` / `--reka-context-menu-*` for menus); a `max-h` cap on `content` only takes effect when `content` is also `flex flex-col` (viewport scrolls via `flex-1`); do **not** add `overflow-hidden` to b24ui menu `content` — the arrow is rendered inside it and would be clipped. Last reviewed: 2026-06-09.
 - 2026-06-13 — port of `ca5accf3` (PR #126): added the **playground-manifest mirroring** invariant (§2). A `chore(deps)` port bumped `package.json`, `docs/package.json`, and `playgrounds/nuxt/package.json` but missed b24ui's extra `playgrounds/demo/package.json` (`ai`, `@ai-sdk/vue` drifted to old ranges); fixed in a follow-up. Always sweep `playgrounds/{nuxt,demo,vue,repl}` for shared deps before regenerating the lockfile. Last reviewed: 2026-06-13.
+- 2026-06-15 — port of `ffaf163f` (PR #140): added the §1 rewrite — **rename inferred type variables too**: when porting types that `infer UI` (or otherwise name a `UI` type-var), rename it to `B24UI`, consistent with `ui → b24ui`. Caught in review of the `ComponentAppConfig` rewrite (`A extends { b24ui: infer UI }` → `infer B24UI`). Last reviewed: 2026-06-15.

--- a/.sync/log/ffaf163f77601015e4fa9e29bc18a33ca7dcb93d.md
+++ b/.sync/log/ffaf163f77601015e4fa9e29bc18a33ca7dcb93d.md
@@ -1,0 +1,39 @@
+# Port: fix(module): expose component theme keys in AppConfig type (#6520)
+
+**Upstream:** `ffaf163f77601015e4fa9e29bc18a33ca7dcb93d` (nuxt/ui)
+**Decision:** port
+
+## Upstream change
+Type-only fix so the **runtime** `AppConfig.ui` exposes per-component theme keys
+(and the defu-filled defaults are non-optional), while `AppConfigInput.ui` stays
+partial:
+- `runtime/types/utils.ts`: add `DeepRequired<T>`.
+- `runtime/types/tv.ts`: rewrite `ComponentAppConfig` to `Omit<A,'ui'> & { ui: … }`
+  so component keys merge into `ui` instead of being a loose intersection.
+- `templates.ts`: import `DeepRequired`, add
+  `AppConfigRuntimeUI = DeepRequired<Pick<AppConfigUI,'colors'|'icons'|'tv'>> & Omit<…>`
+  and augment `interface AppConfig { ui: AppConfigRuntimeUI }`.
+- `module.ts`: cast the `appConfig.ui` defu result to its own type.
+
+## b24ui adaptation
+Naming: `ui → b24ui`, `@nuxt/ui → @bitrix24/b24ui-nuxt`, `#build/ui → #build/b24ui`.
+
+Key divergence — **`colors`/`icons` don't exist in b24ui's AppConfig**: b24ui
+uses the air design system, so its `getDefaultConfig` fills only `{ prefix, tv }`
+and `AppConfigUI` has just `prefix?` / `tv?` + `TVConfig<typeof b24ui>`. Upstream
+marks its default-filled config objects (`colors|icons|tv`) as `DeepRequired`;
+the only one of those b24ui has is `tv`, so:
+`AppConfigRuntimeUI = DeepRequired<Pick<AppConfigUI, 'tv'>> & Omit<AppConfigUI, 'tv'>`.
+
+- `runtime/types/utils.ts`: added `DeepRequired` (verbatim; re-exported via the
+  `./utils` barrel, so `@bitrix24/b24ui-nuxt` surfaces it for the template).
+- `runtime/types/tv.ts`: rewrote `ComponentAppConfig` with the `b24ui` key.
+- `templates.ts`: `import type { TVConfig, DeepRequired }`, added the
+  `AppConfigRuntimeUI` (Pick `'tv'` only) and `interface AppConfig { b24ui: … }`.
+- `module.ts`: `… getDefaultConfig(options.theme)) as typeof nuxt.options.appConfig.b24ui`.
+
+## Verification (pnpm 11.3.0, gate ON)
+frozen install · dev:prepare · lint · **typecheck** · test (4972 passed, 6
+skipped) · module build — all green.
+
+Platform note: b24ui CI is `ubuntu-latest` only; type-only change.

--- a/.sync/nuxt-ui.json
+++ b/.sync/nuxt-ui.json
@@ -2,7 +2,7 @@
   "upstream": "nuxt/ui",
   "branch": "v4",
   "sync_enabled": false,
-  "cursor": "c9fc7a41838f15c87872d93636886ef149755405",
+  "cursor": "ffaf163f77601015e4fa9e29bc18a33ca7dcb93d",
   "_cursor_note": "cursor = last upstream commit ported into b24ui (oldest-first, manual cadence). sync_enabled stays false until Phase 2 (porter workflow #67 + CLAUDE_CODE_OAUTH_TOKEN) is wired and trusted. `processed` is maintained per port from now on (backfilled #68-#72 on 2026-06-09).",
   "stats": {
     "queue_depth": 0,
@@ -287,10 +287,16 @@
       "summary": "docs(toast): remove misleading AppConfig notes — removed the 4 ::note blocks claiming the position/duration/max/expand examples use AppConfig (they use props directly) from docs/content/docs/2.components/toast.md; b24ui had the same notes (pointing at b24ui app.config.ts)"
     },
     "c9fc7a41838f15c87872d93636886ef149755405": {
+      "pr": 139,
+      "b24ui_sha": "acfda9fc",
+      "decision": "port",
+      "summary": "docs: fix missing CSS variables on prerendered pages (#6519) — colors.ts tagPriority -2 -> 'critical' (re-reverts #134); docs/nuxt.config.ts move asyncContext:true from experimental into nitro.experimental"
+    },
+    "ffaf163f77601015e4fa9e29bc18a33ca7dcb93d": {
       "pr": null,
       "b24ui_sha": "pending-merge",
       "decision": "port",
-      "summary": "docs: fix missing CSS variables on prerendered pages (#6519) — colors.ts tagPriority -2 -> 'critical' (re-reverts #134); docs/nuxt.config.ts move asyncContext:true from experimental into nitro.experimental"
+      "summary": "fix(module): expose component theme keys in AppConfig type (#6520) — add DeepRequired (utils.ts), rewrite ComponentAppConfig to Omit<A,'b24ui'>&{b24ui:...} (tv.ts), templates.ts AppConfig augmentation with AppConfigRuntimeUI=DeepRequired<Pick<AppConfigUI,'tv'>>&Omit<...> (b24ui has no colors/icons, only tv), module.ts cast. Naming ui->b24ui"
     }
   }
 }

--- a/src/module.ts
+++ b/src/module.ts
@@ -199,7 +199,7 @@ export default defineNuxtModule<ModuleOptions>({
     nuxt.options.alias['#b24ui'] = resolve('./runtime')
 
     nuxt.options.appConfig.version = version
-    nuxt.options.appConfig.b24ui = defu(nuxt.options.appConfig.b24ui || {}, getDefaultConfig(options.theme))
+    nuxt.options.appConfig.b24ui = defu(nuxt.options.appConfig.b24ui || {}, getDefaultConfig(options.theme)) as typeof nuxt.options.appConfig.b24ui
 
     nuxt.options.build.transpile.push('reka-ui')
 

--- a/src/runtime/types/tv.ts
+++ b/src/runtime/types/tv.ts
@@ -42,11 +42,17 @@ type ComponentAppConfig<
   A extends Record<string, any>,
   K extends string,
   U extends string = 'b24ui' | 'b24ui.prose'
-> = A & (
-  U extends 'b24ui.prose'
-    ? { b24ui?: { prose?: { [k in K]?: Partial<T> } } }
-    : { [key in Exclude<U, 'b24ui.prose'>]?: { [k in K]?: Partial<T> } }
-  )
+> = Omit<A, 'b24ui'> & {
+  b24ui: U extends 'b24ui.prose'
+    ? (A extends { b24ui: infer UI } ? Omit<UI, 'prose'> : Record<string, never>) & {
+      prose?: (A extends { b24ui: { prose?: infer P } } ? Omit<NonNullable<P>, K> : Record<string, never>) & {
+        [k in K]?: Partial<T>
+      }
+    }
+    : (A extends { b24ui: infer UI } ? Omit<UI, K> : Record<string, never>) & {
+      [k in K]?: Partial<T>
+    }
+}
 
 /**
  * Defines the configuration shape expected for a component.

--- a/src/runtime/types/tv.ts
+++ b/src/runtime/types/tv.ts
@@ -44,12 +44,12 @@ type ComponentAppConfig<
   U extends string = 'b24ui' | 'b24ui.prose'
 > = Omit<A, 'b24ui'> & {
   b24ui: U extends 'b24ui.prose'
-    ? (A extends { b24ui: infer UI } ? Omit<UI, 'prose'> : Record<string, never>) & {
+    ? (A extends { b24ui: infer B24UI } ? Omit<B24UI, 'prose'> : Record<string, never>) & {
       prose?: (A extends { b24ui: { prose?: infer P } } ? Omit<NonNullable<P>, K> : Record<string, never>) & {
         [k in K]?: Partial<T>
       }
     }
-    : (A extends { b24ui: infer UI } ? Omit<UI, K> : Record<string, never>) & {
+    : (A extends { b24ui: infer B24UI } ? Omit<B24UI, K> : Record<string, never>) & {
       [k in K]?: Partial<T>
     }
 }

--- a/src/runtime/types/utils.ts
+++ b/src/runtime/types/utils.ts
@@ -5,6 +5,10 @@ export type DeepPartial<T> = {
   [P in keyof T]?: T[P] extends object ? DeepPartial<T[P]> : T[P] | undefined
 }
 
+export type DeepRequired<T> = {
+  [P in keyof T]-?: NonNullable<T[P]> extends object ? DeepRequired<NonNullable<T[P]>> : NonNullable<T[P]>
+}
+
 export type DynamicSlotsKeys<Name extends string | undefined, Suffix extends string | undefined = undefined> = (
   Name extends string
     ? Suffix extends string

--- a/src/templates.ts
+++ b/src/templates.ts
@@ -256,13 +256,15 @@ ${themeBlocks}`
     filename: 'types/b24ui.d.ts',
     getContents: () => {
       return `import * as b24ui from '#build/b24ui'
-import type { TVConfig } from '@bitrix24/b24ui-nuxt'
+import type { TVConfig, DeepRequired } from '@bitrix24/b24ui-nuxt'
 import type { defaultConfig } from 'tailwind-variants'
 
 type AppConfigUI = {
   prefix?: string
   tv?: typeof defaultConfig
 } & TVConfig<typeof b24ui>
+
+type AppConfigRuntimeUI = DeepRequired<Pick<AppConfigUI, 'tv'>> & Omit<AppConfigUI, 'tv'>
 
 declare module '@nuxt/schema' {
   interface AppConfigInput {
@@ -271,6 +273,9 @@ declare module '@nuxt/schema' {
      * @see https://bitrix24.github.io/b24ui/docs/getting-started/theme/components/
      */
     b24ui?: AppConfigUI
+  }
+  interface AppConfig {
+    b24ui: AppConfigRuntimeUI
   }
 }
 


### PR DESCRIPTION
Port of nuxt/ui [`ffaf163f`](https://github.com/nuxt/ui/commit/ffaf163f77601015e4fa9e29bc18a33ca7dcb93d) — _fix(module): expose component theme keys in AppConfig type (#6520)_.

## What
Type-only fix so the **runtime** `AppConfig.b24ui` exposes per-component theme keys (and the defu-filled defaults are non-optional), while `AppConfigInput.b24ui` stays partial:
- `runtime/types/utils.ts`: add `DeepRequired<T>`.
- `runtime/types/tv.ts`: rewrite `ComponentAppConfig` to `Omit<A,'b24ui'> & { b24ui: … }` so component keys merge into `b24ui`.
- `templates.ts`: import `DeepRequired`, add `AppConfigRuntimeUI` and augment `interface AppConfig { b24ui }`.
- `module.ts`: cast the `appConfig.b24ui` defu result to its own type.

## Adaptation notes
- Naming: `ui → b24ui`, `@nuxt/ui → @bitrix24/b24ui-nuxt`, `#build/ui → #build/b24ui`.
- **`colors`/`icons` don't exist in b24ui's AppConfig** (air design system): b24ui's `getDefaultConfig` fills only `{ prefix, tv }`. Upstream marks its default config objects (`colors|icons|tv`) `DeepRequired`; the only one b24ui has is `tv`, so `AppConfigRuntimeUI = DeepRequired<Pick<AppConfigUI, 'tv'>> & Omit<AppConfigUI, 'tv'>`.
- `DeepRequired` is surfaced for the generated template via the existing `runtime/types/utils` barrel export.

## Verification
Under pnpm 11.3.0 with the gate ON: frozen install · `dev:prepare` · lint · **typecheck** · test (**4972 passed**, 6 skipped) · module build — all green.

Platform: b24ui CI is `ubuntu-latest` only; type-only change.

https://claude.ai/code/session_01Qz7EXMncvEGiCj4WbmYgJo

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qz7EXMncvEGiCj4WbmYgJo)_