### PR TITLE
docs(search): improve relevance and tooltip behavior

### DIFF
--- a/.sync/log/80bd0cc05e64bc1932fe9b421bf7bc255019f689.md
+++ b/.sync/log/80bd0cc05e64bc1932fe9b421bf7bc255019f689.md
@@ -1,0 +1,33 @@
+# Port: docs(search): improve relevance and tooltip behavior (#6521)
+
+**Upstream:** `80bd0cc05e64bc1932fe9b421bf7bc255019f689` (nuxt/ui)
+**Decision:** port (partial — docs-app UX bits; branding rewrites skipped)
+
+## Upstream change (docs site)
+- `header/Header.vue`: move the search button before the AI button; give both
+  tooltips keyboard hints (`:kbds`) and `ignore-non-keyboard-focus`; AI tooltip
+  text `Ask AI for help → Ask AI` with `⌘I`.
+- `search/Search.vue`: pass `:transition="false"` to the ContentSearch.
+- `composables/useSearch.ts`: reword the nav-entry descriptions to be
+  product-agnostic (drop "Nuxt UI").
+
+## b24ui adaptation
+b24ui has its own customized docs app; applied the parts that map:
+- **`Search.vue`**: added `:transition="false"` on `B24ContentSearch`.
+- **`Header.vue`**: wrapped `B24ContentSearchButton` in a
+  `B24Tooltip text="Search" :kbds="['meta','K']" ignore-non-keyboard-focus` and
+  moved it before the AI button; the AI tooltip becomes `text="Ask AI"
+  :kbds="['meta','I']" ignore-non-keyboard-focus` (kept b24ui's `air-selection`
+  button, `AiStarsIcon`, `v-if="isAssistantEnabled"`, aria-label and memo
+  comments). `B24Tooltip` already supports `kbds` / `ignoreNonKeyboardFocus`.
+
+## Skipped
+- **`useSearch.ts` description rewrites** — upstream genericizes "Nuxt UI"; b24ui
+  intentionally brands these "Bitrix24 UI" and has a divergent nav set
+  (Framework/AI/GitHub vs Blog/Figma/Team), so its copy stays as-is.
+
+## Verification (pnpm 11.3.0, gate ON)
+frozen install · dev:prepare · lint · typecheck · test (4972 passed, 6 skipped)
+· module build — all green.
+
+Platform note: b24ui CI is `ubuntu-latest` only; docs-app SFC change.

--- a/.sync/nuxt-ui.json
+++ b/.sync/nuxt-ui.json
@@ -2,7 +2,7 @@
   "upstream": "nuxt/ui",
   "branch": "v4",
   "sync_enabled": false,
-  "cursor": "ffaf163f77601015e4fa9e29bc18a33ca7dcb93d",
+  "cursor": "80bd0cc05e64bc1932fe9b421bf7bc255019f689",
   "_cursor_note": "cursor = last upstream commit ported into b24ui (oldest-first, manual cadence). sync_enabled stays false until Phase 2 (porter workflow #67 + CLAUDE_CODE_OAUTH_TOKEN) is wired and trusted. `processed` is maintained per port from now on (backfilled #68-#72 on 2026-06-09).",
   "stats": {
     "queue_depth": 0,
@@ -293,10 +293,16 @@
       "summary": "docs: fix missing CSS variables on prerendered pages (#6519) — colors.ts tagPriority -2 -> 'critical' (re-reverts #134); docs/nuxt.config.ts move asyncContext:true from experimental into nitro.experimental"
     },
     "ffaf163f77601015e4fa9e29bc18a33ca7dcb93d": {
+      "pr": 140,
+      "b24ui_sha": "44065b9f",
+      "decision": "port",
+      "summary": "fix(module): expose component theme keys in AppConfig type (#6520) — add DeepRequired (utils.ts), rewrite ComponentAppConfig to Omit<A,'b24ui'>&{b24ui:...} (tv.ts, infer B24UI), templates.ts AppConfig augmentation with AppConfigRuntimeUI=DeepRequired<Pick<AppConfigUI,'tv'>>&Omit<...> (b24ui has no colors/icons, only tv), module.ts cast. Naming ui->b24ui, UI->B24UI"
+    },
+    "80bd0cc05e64bc1932fe9b421bf7bc255019f689": {
       "pr": null,
       "b24ui_sha": "pending-merge",
       "decision": "port",
-      "summary": "fix(module): expose component theme keys in AppConfig type (#6520) — add DeepRequired (utils.ts), rewrite ComponentAppConfig to Omit<A,'b24ui'>&{b24ui:...} (tv.ts), templates.ts AppConfig augmentation with AppConfigRuntimeUI=DeepRequired<Pick<AppConfigUI,'tv'>>&Omit<...> (b24ui has no colors/icons, only tv), module.ts cast. Naming ui->b24ui"
+      "summary": "docs(search): improve relevance and tooltip behavior (#6521) — partial: Search.vue :transition=false; Header.vue search button wrapped in tooltip (meta+K) moved before AI, AI tooltip meta+I, both ignore-non-keyboard-focus. Skipped useSearch.ts description rewrites (b24ui keeps 'Bitrix24 UI' branding + own nav)"
     }
   }
 }

--- a/docs/app/components/header/Header.vue
+++ b/docs/app/components/header/Header.vue
@@ -52,8 +52,12 @@ defineShortcuts({
     />
 
     <template #right>
+      <B24Tooltip text="Search" :kbds="['meta', 'K']" ignore-non-keyboard-focus>
+        <B24ContentSearchButton />
+      </B24Tooltip>
+
       <!-- @memo @memo this for NUXT.UI.docs -->
-      <B24Tooltip text="Ask AI for help">
+      <B24Tooltip text="Ask AI" :kbds="['meta', 'I']" ignore-non-keyboard-focus>
         <B24Button
           v-if="isAssistantEnabled"
           color="air-selection"
@@ -64,7 +68,6 @@ defineShortcuts({
       </B24Tooltip>
       <!-- @memo this for docus -->
       <!-- AssistantChat v-if="isAssistantEnabled" / -->
-      <B24ContentSearchButton />
 
       <B24ColorModeButton />
 

--- a/docs/app/components/search/Search.vue
+++ b/docs/app/components/search/Search.vue
@@ -46,5 +46,6 @@ watchDebounced(searchTerm, (term) => {
     :search-status="status"
     :color-mode="false"
     :fuse="fuse"
+    :transition="false"
   />
 </template>


### PR DESCRIPTION
Port of nuxt/ui [`80bd0cc0`](https://github.com/nuxt/ui/commit/80bd0cc05e64bc1932fe9b421bf7bc255019f689) — _docs(search): improve relevance and tooltip behavior (#6521)_.

## What (partial port — docs-app)
- **`Search.vue`**: pass `:transition="false"` to `B24ContentSearch`.
- **`Header.vue`**: wrap the search button in a tooltip (`⌘K`) and move it before the AI button; AI tooltip becomes `Ask AI` (`⌘I`); both use `ignore-non-keyboard-focus`. (`B24Tooltip` already supports `kbds`/`ignoreNonKeyboardFocus`; kept b24ui's `air-selection` button, icon, `v-if="isAssistantEnabled"`, aria-label.)

## Skipped
- **`useSearch.ts` description rewrites** — upstream genericizes "Nuxt UI"; b24ui intentionally brands these "Bitrix24 UI" and has its own nav set (Framework/AI/GitHub vs Blog/Figma/Team), so its copy stays as-is.

## Verification
Under pnpm 11.3.0 with the gate ON: frozen install · `dev:prepare` · lint · typecheck · test (**4972 passed**, 6 skipped) · module build — all green.

Platform: b24ui CI is `ubuntu-latest` only; docs-app SFC change.

https://claude.ai/code/session_01Qz7EXMncvEGiCj4WbmYgJo

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qz7EXMncvEGiCj4WbmYgJo)_