### PR TITLE
ci(deploy): raise Node heap limit to fix docs prerender OOM

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,6 +24,9 @@ jobs:
 
     env:
       # FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+      # Raise V8 heap limit: docs prerender (nuxt generate) otherwise hits the
+      # default ~4GB cap and OOMs (exit 134). Runner has 16GB RAM available.
+      NODE_OPTIONS: --max-old-space-size=8192
       NUXT_PUBLIC_USE_AI: false
       NUXT_PUBLIC_SITE_URL: https://bitrix24.github.io
       NUXT_PUBLIC_BASE_URL: /b24ui


### PR DESCRIPTION
## Problem

The **Deploy to Pages 📰** workflow fails at the **Generate Docs** step
(`pnpm run docs:full:generate` → `nuxt generate docs`) with:

```
FATAL ERROR: Ineffective mark-compacts near heap limit
Allocation failed - JavaScript heap out of memory   (exit code 134)
```

Client and server bundles build fine; the OOM happens during the **Nitro
prerender** phase. The default V8 heap cap (~4 GB) is exceeded while
prerendering the full docs site. `ci.yml` stays green because it only runs
`pnpm build` and never prerenders the docs.

## When it started

Bisected the deploy run history:

| Run | Commit | Result |
|-----|--------|--------|
| #427 | update nuxt 4.4.6 | ✅ |
| #428 | update vite (#118) | ✅ |
| #429 | noop transformMDC | ✅ |
| **#430** | **`update pnpm to v11 (#120)`** | ❌ first failure |
| #431…#450 | all subsequent | ❌ |

The pnpm v11 update (#120) regenerated the lockfile and shifted the transitive
dependency tree, pushing prerender memory past the borderline ~4 GB limit.

## Fix

Set `NODE_OPTIONS=--max-old-space-size=8192` on the `build` job. The
`ubuntu-latest` runner has 16 GB RAM available, so this gives prerender ample
headroom without touching dependencies.

https://claude.ai/code/session_01LX8Th82NJaCHPXZWyYPsWr

---
_Generated by [Claude Code](https://claude.ai/code/session_01LX8Th82NJaCHPXZWyYPsWr)_