### PR TITLE
fix(docs): resolve prerender payload 204 and build warnings

### DIFF
--- a/docs/app/assets/css/main.css
+++ b/docs/app/assets/css/main.css
@@ -2,6 +2,13 @@
 @import "@bitrix24/b24ui-nuxt";
 
 @source "../../../content/**/*";
+/*
+ * Exclude the upstream-sync notes from Tailwind's class scanning. The root
+ * `source("../../../..")` above scans the whole repo, and `.sync/log/*.md`
+ * contains illustrative class strings with placeholders (e.g.
+ * `--reka-*-content-available-height`) that produce invalid CSS during build.
+ */
+@source not "../../../../.sync";
 
 @theme static {
 

--- a/docs/nuxt.config.ts
+++ b/docs/nuxt.config.ts
@@ -383,7 +383,16 @@ export default defineNuxtConfig({
         ...pagesService
       ],
       crawlLinks: true,
-      autoSubfolderIndex: false
+      autoSubfolderIndex: false,
+      // The homepage payload (`/_payload.json` and `<baseURL>/_payload.json`)
+      // returns 204 during prerender — a Nuxt 4.4 payloadExtraction + baseURL
+      // quirk that surfaced after the dependency bump (the page itself renders
+      // fine; only its extracted payload is empty). Skip just those root-level
+      // payloads so the build doesn't fail; per-page doc payloads are untouched
+      // and the homepage payload is fetched on hydration instead.
+      ignore: [
+        new RegExp(`^(?:${baseUrl})?/_payload\\.json(?:\\?.*)?$`)
+      ]
     }
   },
 

--- a/docs/server/utils/transformMDC.ts
+++ b/docs/server/utils/transformMDC.ts
@@ -62,10 +62,15 @@ const B24_DOCS = {
 function getComponentMeta(componentName: string) {
   const pascalCaseName = componentName.charAt(0).toUpperCase() + componentName.slice(1)
 
+  // Strip an already-present `B24`/`Prose` prefix before re-prefixing, so a name
+  // that already carries one (e.g. a doc titled `ProseCallout`) is not doubled
+  // into `ProseProseCallout`. `pascalCaseName` is returned unchanged for naming.
+  const baseName = pascalCaseName.replace(/^(?:B24|Prose)/, '')
+
   const strategies = [
-    `B24${pascalCaseName}`,
-    `Prose${pascalCaseName}`,
-    pascalCaseName
+    `B24${baseName}`,
+    `Prose${baseName}`,
+    baseName
   ]
 
   let componentMeta: any


### PR DESCRIPTION
## Context

Follow-up to #143 (raised the Node heap to stop the docs prerender OOM). With the
OOM gone, `nuxt generate` ran to completion and exposed three previously-hidden
issues in the **Deploy to Pages** build. This PR fixes all three.

## Fixes

1. **Prerender abort on homepage payload 204** (`docs/nuxt.config.ts`)
   `nuxt generate` failed with `Exiting due to prerender errors` because
   `/_payload.json` and `<baseURL>/_payload.json` return `204` — a Nuxt 4.4
   `payloadExtraction` + `baseURL` quirk surfaced by the dependency bump (the
   page HTML prerenders fine; only its extracted payload is empty). Added a
   targeted `prerender.ignore` for just those root-level payload routes. Per-page
   doc payloads are untouched; the homepage payload is fetched on hydration.

2. **`ProseProseCallout` / `ProseProseCard` metadata warnings** (`docs/server/utils/transformMDC.ts`)
   Docs titled `ProseCallout`/`ProseCard`/`ProseCardGroup` (renamed in #111) fed
   an already-prefixed name into `getComponentMeta`, which re-prepended `Prose`
   and looked up the non-existent `ProseProseCallout`. Now strip an existing
   `B24`/`Prose` prefix before re-prefixing. `pascalCaseName` is returned
   unchanged, so generated interface names (`ProseCalloutSlots`, …) are intact.

3. **Invalid CSS from `.sync/` notes** (`docs/app/assets/css/main.css`)
   The root `source("../../../..")` made Tailwind scan the whole repo, including
   `.sync/log/*.md`, whose illustrative class strings (`--reka-*-content-available-height`)
   produced `Unexpected token Delim('*')` while optimizing CSS. Excluded `.sync/`
   via `@source not`.

## Validation

Local `nuxt generate` (with the deploy env + heap flag) builds client and server
with **0 CSS optimize warnings** (confirms #3). The `ProseProse` prefix logic is
unit-checked. Full prerender (#1, #2 end-to-end) can't run in the sandbox (4096
fd cap → `EMFILE`); final confirmation comes from the deploy runner.

https://claude.ai/code/session_01LX8Th82NJaCHPXZWyYPsWr

---
_Generated by [Claude Code](https://claude.ai/code/session_01LX8Th82NJaCHPXZWyYPsWr)_