### PR TITLE
fix(docs): drop redundant homepage payload prerender ignore

### DIFF
--- a/docs/nuxt.config.ts
+++ b/docs/nuxt.config.ts
@@ -383,16 +383,7 @@ export default defineNuxtConfig({
         ...pagesService
       ],
       crawlLinks: true,
-      autoSubfolderIndex: false,
-      // The homepage payload (`/_payload.json` and `<baseURL>/_payload.json`)
-      // returns 204 during prerender — a Nuxt 4.4 payloadExtraction + baseURL
-      // quirk that surfaced after the dependency bump (the page itself renders
-      // fine; only its extracted payload is empty). Skip just those root-level
-      // payloads so the build doesn't fail; per-page doc payloads are untouched
-      // and the homepage payload is fetched on hydration instead.
-      ignore: [
-        new RegExp(`^(?:${baseUrl})?/_payload\\.json(?:\\?.*)?$`)
-      ]
+      autoSubfolderIndex: false
     }
   },
 


### PR DESCRIPTION
## Context

Cleanup follow-up to #147. The `_payload.json` 204 prerender error that #147
worked around was actually resolved upstream by the non-major dependency bump
(deploy run #454, commit `22ce5a7c`) — deploys #454/#455 went green **without**
any workaround.

That makes the `prerender.ignore` I added in #147 redundant. Worse, it keeps the
homepage payload out of static generation (the page would refetch its data on
hydration instead of using the prerendered `_payload.json`).

## Change

Remove the `prerender.ignore` block from `docs/nuxt.config.ts`. The other two
#147 fixes (ProseProse prefix, `.sync/` Tailwind exclusion) stay in place.

## Validation

Deploy runs #454/#455 already prerendered successfully with no payload ignore,
so removing it is safe. Final confirmation comes from the deploy run after merge.

https://claude.ai/code/session_01LX8Th82NJaCHPXZWyYPsWr

---
_Generated by [Claude Code](https://claude.ai/code/session_01LX8Th82NJaCHPXZWyYPsWr)_