### PR TITLE
fix(module): merge custom variants into AppConfig type

### DIFF
--- a/.sync/log/f0571c3786cdddb54712bb89154f8482e0c3c62e.md
+++ b/.sync/log/f0571c3786cdddb54712bb89154f8482e0c3c62e.md
@@ -1,0 +1,28 @@
+# Port: fix(module): merge custom variants into AppConfig type (#6531)
+
+**Upstream:** `f0571c3786cdddb54712bb89154f8482e0c3c62e` (nuxt/ui)
+**Decision:** port
+
+## Upstream change
+Follow-up to #6520 (b24ui #140), in `src/templates.ts`:
+1. `AppConfigRuntimeUI = DeepRequired<Pick<AppConfigUI,'colors'|'icons'|'tv'>>
+   & Omit<AppConfigUI,'colors'|'icons'|'tv'>` → `… & typeof ui`. Using the raw
+   theme module (`typeof ui`) instead of the `TVConfig` override shape merges
+   the **actual component definitions and any custom variants** into the
+   runtime `AppConfig` type.
+2. `interface AppConfig` → `interface CustomAppConfig` (the correct Nuxt schema
+   interface for the resolved runtime app config).
+
+## b24ui adaptation
+Same two edits, b24ui-namespaced (`ui → b24ui`; b24ui has no `colors`/`icons`,
+so its Pick is just `'tv'`):
+- `DeepRequired<Pick<AppConfigUI, 'tv'>> & Omit<AppConfigUI, 'tv'>`
+  → `DeepRequired<Pick<AppConfigUI, 'tv'>> & typeof b24ui`
+  (`b24ui` = `import * as b24ui from '#build/b24ui'`).
+- `interface AppConfig { b24ui }` → `interface CustomAppConfig { b24ui }`.
+
+## Verification (pnpm 11.5.0, gate ON)
+frozen install · dev:prepare · lint · **typecheck** · test (4972 passed, 6
+skipped) · module build — all green.
+
+Platform note: b24ui CI is `ubuntu-latest` only; type-only change.

--- a/.sync/nuxt-ui.json
+++ b/.sync/nuxt-ui.json
@@ -2,7 +2,7 @@
   "upstream": "nuxt/ui",
   "branch": "v4",
   "sync_enabled": false,
-  "cursor": "be67bf9275fd06f528e71aaba686e245ccd32659",
+  "cursor": "f0571c3786cdddb54712bb89154f8482e0c3c62e",
   "_cursor_note": "cursor = last upstream commit ported into b24ui (oldest-first, manual cadence). sync_enabled stays false until Phase 2 (porter workflow #67 + CLAUDE_CODE_OAUTH_TOKEN) is wired and trusted. `processed` is maintained per port from now on (backfilled #68-#72 on 2026-06-09).",
   "stats": {
     "queue_depth": 0,
@@ -323,10 +323,16 @@
       "summary": "chore(deps): update tiptap to ^3.24.0 (#6532) — all @tiptap/* ^3.23.6->^3.24.0 across 5 manifests (root 17, docs/nuxt/vue/demo 2 each), lockfile regen under gate (resolves 3.26.1)"
     },
     "be67bf9275fd06f528e71aaba686e245ccd32659": {
-      "pr": null,
-      "b24ui_sha": "pending-merge",
+      "pr": 146,
+      "b24ui_sha": "5a23f626",
       "decision": "noop",
       "summary": "docs(mcp): add github copilot cli (#6526) — n/a: edits docs/.../7.ai/1.mcp.md (nuxt/ui MCP editor-setup guide, ui.nuxt.com/mcp). b24ui's 7.ai/ has no 1.mcp.md (only 2.llms-txt, 3.skills) — no MCP setup page to update"
+    },
+    "f0571c3786cdddb54712bb89154f8482e0c3c62e": {
+      "pr": null,
+      "b24ui_sha": "pending-merge",
+      "decision": "port",
+      "summary": "fix(module): merge custom variants into AppConfig type (#6531) — follow-up to #140 in templates.ts: AppConfigRuntimeUI Omit<AppConfigUI,'tv'> -> typeof b24ui (merges actual theme/custom variants); interface AppConfig -> CustomAppConfig"
     }
   }
 }

--- a/src/templates.ts
+++ b/src/templates.ts
@@ -264,7 +264,7 @@ type AppConfigUI = {
   tv?: typeof defaultConfig
 } & TVConfig<typeof b24ui>
 
-type AppConfigRuntimeUI = DeepRequired<Pick<AppConfigUI, 'tv'>> & Omit<AppConfigUI, 'tv'>
+type AppConfigRuntimeUI = DeepRequired<Pick<AppConfigUI, 'tv'>> & typeof b24ui
 
 declare module '@nuxt/schema' {
   interface AppConfigInput {
@@ -274,7 +274,7 @@ declare module '@nuxt/schema' {
      */
     b24ui?: AppConfigUI
   }
-  interface AppConfig {
+  interface CustomAppConfig {
     b24ui: AppConfigRuntimeUI
   }
 }


### PR DESCRIPTION
Port of nuxt/ui [`f0571c37`](https://github.com/nuxt/ui/commit/f0571c3786cdddb54712bb89154f8482e0c3c62e) — _fix(module): merge custom variants into AppConfig type (#6531)_.

## What
Follow-up to #140 (`ffaf163f`), in `src/templates.ts`:
- `AppConfigRuntimeUI`: replace `Omit<AppConfigUI, 'tv'>` with `typeof b24ui` — using the raw theme module (instead of the `TVConfig` override shape) merges the actual component definitions and any **custom variants** into the runtime `AppConfig` type.
- Augment `interface CustomAppConfig` instead of `interface AppConfig` (the correct Nuxt schema interface for the resolved runtime config).

b24ui-namespaced (`ui → b24ui`; b24ui has no `colors`/`icons`, so the `Pick` stays `'tv'`).

## Verification
Under pnpm 11.5.0 with the gate ON: frozen install · `dev:prepare` · lint · **typecheck** · test (**4972 passed**, 6 skipped) · module build — all green.

Platform: b24ui CI is `ubuntu-latest` only; type-only change.

https://claude.ai/code/session_01Qz7EXMncvEGiCj4WbmYgJo

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qz7EXMncvEGiCj4WbmYgJo)_