### PR TITLE
chore(deps): update vue-tsc to ^3.3.3

### DIFF
--- a/.sync/log/e99a61bc0be2bee92a3062fc1c3e3701075e06e4.md
+++ b/.sync/log/e99a61bc0be2bee92a3062fc1c3e3701075e06e4.md
@@ -1,0 +1,28 @@
+# Port: chore(deps): update vue-tsc to ^3.3.3 (#6533)
+
+**Upstream:** `e99a61bc0be2bee92a3062fc1c3e3701075e06e4` (nuxt/ui)
+**Decision:** port
+
+## Upstream change
+Renovate bump across 3 manifests:
+- root `package.json`: `vue-component-type-helpers` ^3.3.0 → ^3.3.3,
+  `vue-tsc` ^3.3.0 → ^3.3.3.
+- `playgrounds/nuxt/package.json`, `playgrounds/vue/package.json`:
+  `vue-tsc` ^3.3.0 → ^3.3.3.
+- lockfile regen.
+
+## b24ui adaptation
+Same bump, plus the playground-mirroring invariant (PORTING.md §2):
+b24ui has a 4th `playgrounds/demo` with no upstream counterpart that also
+pins `vue-tsc ^3.3.0`, so it is mirrored to ^3.3.3 as well.
+- root `package.json`: `vue-component-type-helpers` ^3.3.0 → ^3.3.3,
+  `vue-tsc` ^3.3.0 → ^3.3.3.
+- `playgrounds/nuxt`, `playgrounds/vue`, `playgrounds/demo`: `vue-tsc` ^3.3.0 → ^3.3.3.
+- `playgrounds/repl` pins neither → untouched.
+- lockfile regen under the active minimumReleaseAge gate (resolves to aged `3.3.4`).
+
+## Verification (pnpm 11.5.0, gate ON)
+frozen install · dev:prepare · lint · typecheck · test (4972 passed, 6
+skipped) · module build — all green.
+
+Platform note: b24ui CI is `ubuntu-latest` only; dev-tooling dep bump.

--- a/.sync/nuxt-ui.json
+++ b/.sync/nuxt-ui.json
@@ -2,7 +2,7 @@
   "upstream": "nuxt/ui",
   "branch": "v4",
   "sync_enabled": false,
-  "cursor": "f0571c3786cdddb54712bb89154f8482e0c3c62e",
+  "cursor": "e99a61bc0be2bee92a3062fc1c3e3701075e06e4",
   "_cursor_note": "cursor = last upstream commit ported into b24ui (oldest-first, manual cadence). sync_enabled stays false until Phase 2 (porter workflow #67 + CLAUDE_CODE_OAUTH_TOKEN) is wired and trusted. `processed` is maintained per port from now on (backfilled #68-#72 on 2026-06-09).",
   "stats": {
     "queue_depth": 0,
@@ -329,10 +329,16 @@
       "summary": "docs(mcp): add github copilot cli (#6526) — n/a: edits docs/.../7.ai/1.mcp.md (nuxt/ui MCP editor-setup guide, ui.nuxt.com/mcp). b24ui's 7.ai/ has no 1.mcp.md (only 2.llms-txt, 3.skills) — no MCP setup page to update"
     },
     "f0571c3786cdddb54712bb89154f8482e0c3c62e": {
+      "pr": 149,
+      "b24ui_sha": "a76dc5ee",
+      "decision": "port",
+      "summary": "fix(module): merge custom variants into AppConfig type (#6531) — follow-up to #140 in templates.ts: AppConfigRuntimeUI Omit<AppConfigUI,'tv'> -> typeof b24ui (merges actual theme/custom variants); interface AppConfig -> CustomAppConfig"
+    },
+    "e99a61bc0be2bee92a3062fc1c3e3701075e06e4": {
       "pr": null,
       "b24ui_sha": "pending-merge",
       "decision": "port",
-      "summary": "fix(module): merge custom variants into AppConfig type (#6531) — follow-up to #140 in templates.ts: AppConfigRuntimeUI Omit<AppConfigUI,'tv'> -> typeof b24ui (merges actual theme/custom variants); interface AppConfig -> CustomAppConfig"
+      "summary": "chore(deps): update vue-tsc to ^3.3.3 (#6533) — vue-tsc ^3.3.0->^3.3.3 + vue-component-type-helpers ^3.3.0->^3.3.3 (root); vue-tsc bump in playgrounds nuxt/vue + demo (mirrored per invariant; repl pins neither); lockfile regen under gate (resolves 3.3.4)"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -200,7 +200,7 @@
     "unplugin-auto-import": "^21.0.0",
     "unplugin-vue-components": "^32.1.0",
     "vaul-vue": "0.4.1",
-    "vue-component-type-helpers": "^3.3.0"
+    "vue-component-type-helpers": "^3.3.3"
   },
   "devDependencies": {
     "@nuxt/eslint-config": "^1.15.2",
@@ -219,7 +219,7 @@
     "vitest-axe": "^0.1.0",
     "vitest-environment-nuxt": "^1.0.1",
     "vue": "^3.5.34",
-    "vue-tsc": "^3.3.0",
+    "vue-tsc": "^3.3.3",
     "@types/canvas-confetti": "^1.9.0",
     "@types/node": "^25.3.0"
   },

--- a/playgrounds/demo/package.json
+++ b/playgrounds/demo/package.json
@@ -29,6 +29,6 @@
   },
   "devDependencies": {
     "typescript": "^6.0.3",
-    "vue-tsc": "^3.3.0"
+    "vue-tsc": "^3.3.3"
   }
 }

--- a/playgrounds/nuxt/package.json
+++ b/playgrounds/nuxt/package.json
@@ -29,6 +29,6 @@
   },
   "devDependencies": {
     "typescript": "^6.0.3",
-    "vue-tsc": "^3.3.0"
+    "vue-tsc": "^3.3.3"
   }
 }

--- a/playgrounds/vue/package.json
+++ b/playgrounds/vue/package.json
@@ -25,6 +25,6 @@
     "@vitejs/plugin-vue": "^6.0.7",
     "typescript": "^6.0.3",
     "vite": "^7.3.3",
-    "vue-tsc": "^3.3.0"
+    "vue-tsc": "^3.3.3"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -227,7 +227,7 @@ importers:
         specifier: 0.4.1
         version: 0.4.1(reka-ui@2.9.8(vue@3.5.38(typescript@6.0.3)))(vue@3.5.38(typescript@6.0.3))
       vue-component-type-helpers:
-        specifier: ^3.3.0
+        specifier: ^3.3.3
         version: 3.3.4
       vue-router:
         specifier: ^4.5.0 || ^5.0.0
@@ -294,7 +294,7 @@ importers:
         specifier: ^3.5.34
         version: 3.5.38(typescript@6.0.3)
       vue-tsc:
-        specifier: ^3.3.0
+        specifier: ^3.3.3
         version: 3.3.4(typescript@6.0.3)
 
   cli:
@@ -512,7 +512,7 @@ importers:
         specifier: ^6.0.3
         version: 6.0.3
       vue-tsc:
-        specifier: ^3.3.0
+        specifier: ^3.3.3
         version: 3.3.4(typescript@6.0.3)
 
   playgrounds/nuxt:
@@ -567,7 +567,7 @@ importers:
         specifier: ^6.0.3
         version: 6.0.3
       vue-tsc:
-        specifier: ^3.3.0
+        specifier: ^3.3.3
         version: 3.3.4(typescript@6.0.3)
 
   playgrounds/repl:
@@ -635,7 +635,7 @@ importers:
         specifier: ^7.3.3
         version: 7.3.5(@types/node@25.6.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.1)(yaml@2.9.0)
       vue-tsc:
-        specifier: ^3.3.0
+        specifier: ^3.3.3
         version: 3.3.4(typescript@6.0.3)
 
 packages:


### PR DESCRIPTION
Port of upstream nuxt/ui [`e99a61bc`](https://github.com/nuxt/ui/commit/e99a61bc0be2bee92a3062fc1c3e3701075e06e4) — `chore(deps): update vue-tsc to ^3.3.3 (#6533)`.

## Changes
- **root `package.json`**: `vue-tsc` ^3.3.0 → ^3.3.3, `vue-component-type-helpers` ^3.3.0 → ^3.3.3
- **`playgrounds/nuxt`, `playgrounds/vue`, `playgrounds/demo`**: `vue-tsc` ^3.3.0 → ^3.3.3
  - `playgrounds/demo` has no upstream counterpart and is mirrored per the playground-mirroring invariant (PORTING.md §2); `playgrounds/repl` pins neither dep and is untouched.
- **`pnpm-lock.yaml`**: regenerated under the active `minimumReleaseAge` gate (resolves to aged `3.3.4`).

## Verification (pnpm 11.5.0, gate ON)
frozen install · dev:prepare · lint · typecheck · test (**4972 passed**, 6 skipped) · module build — all green.

Ledger: records the merge sha for the previous port (#149, `f0571c37`) and advances the sync cursor to `e99a61bc`.

https://claude.ai/code/session_01Qz7EXMncvEGiCj4WbmYgJo

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qz7EXMncvEGiCj4WbmYgJo)_