### PR TITLE
chore(deps): update vitest-environment-nuxt to v2

### DIFF
--- a/.sync/log/be36fc37ceae066db292e71aa447622e7e59eba3.md
+++ b/.sync/log/be36fc37ceae066db292e71aa447622e7e59eba3.md
@@ -1,0 +1,24 @@
+# Port: chore(deps): update devdependency vitest-environment-nuxt to v2 (#6534)
+
+**Upstream:** `be36fc37ceae066db292e71aa447622e7e59eba3` (nuxt/ui)
+**Decision:** port
+
+## Upstream change
+Renovate major bump in root `package.json`:
+`vitest-environment-nuxt` ^1.0.1 → ^2.0.0 + lockfile regen.
+
+## b24ui adaptation
+Direct 1:1 bump — b24ui pins the same dep at the same range in root
+`package.json` only (no playground/docs manifest references it, so the
+playground-mirroring invariant doesn't apply here).
+- root `package.json`: `vitest-environment-nuxt` ^1.0.1 → ^2.0.0.
+- lockfile regen under the active minimumReleaseAge gate (resolves to `2.0.0`).
+
+Major bump of the Nuxt test environment used by the vitest `nuxt` project —
+full test suite re-run is the key verification.
+
+## Verification (pnpm 11.5.0, gate ON)
+frozen install · dev:prepare · lint · typecheck · test (4972 passed, 6
+skipped) · module build — all green.
+
+Platform note: b24ui CI is `ubuntu-latest` only; dev-tooling dep bump.

--- a/.sync/nuxt-ui.json
+++ b/.sync/nuxt-ui.json
@@ -2,7 +2,7 @@
   "upstream": "nuxt/ui",
   "branch": "v4",
   "sync_enabled": false,
-  "cursor": "e99a61bc0be2bee92a3062fc1c3e3701075e06e4",
+  "cursor": "be36fc37ceae066db292e71aa447622e7e59eba3",
   "_cursor_note": "cursor = last upstream commit ported into b24ui (oldest-first, manual cadence). sync_enabled stays false until Phase 2 (porter workflow #67 + CLAUDE_CODE_OAUTH_TOKEN) is wired and trusted. `processed` is maintained per port from now on (backfilled #68-#72 on 2026-06-09).",
   "stats": {
     "queue_depth": 0,
@@ -335,10 +335,16 @@
       "summary": "fix(module): merge custom variants into AppConfig type (#6531) — follow-up to #140 in templates.ts: AppConfigRuntimeUI Omit<AppConfigUI,'tv'> -> typeof b24ui (merges actual theme/custom variants); interface AppConfig -> CustomAppConfig"
     },
     "e99a61bc0be2bee92a3062fc1c3e3701075e06e4": {
+      "pr": 150,
+      "b24ui_sha": "4f421916",
+      "decision": "port",
+      "summary": "chore(deps): update vue-tsc to ^3.3.3 (#6533) — vue-tsc ^3.3.0->^3.3.3 + vue-component-type-helpers ^3.3.0->^3.3.3 (root); vue-tsc bump in playgrounds nuxt/vue + demo (mirrored per invariant; repl pins neither); lockfile regen under gate (resolves 3.3.4)"
+    },
+    "be36fc37ceae066db292e71aa447622e7e59eba3": {
       "pr": null,
       "b24ui_sha": "pending-merge",
       "decision": "port",
-      "summary": "chore(deps): update vue-tsc to ^3.3.3 (#6533) — vue-tsc ^3.3.0->^3.3.3 + vue-component-type-helpers ^3.3.0->^3.3.3 (root); vue-tsc bump in playgrounds nuxt/vue + demo (mirrored per invariant; repl pins neither); lockfile regen under gate (resolves 3.3.4)"
+      "summary": "chore(deps): update devdependency vitest-environment-nuxt to v2 (#6534) — direct 1:1 major bump in root package.json (^1.0.1->^2.0.0), only manifest referencing it (no playground mirror needed); lockfile regen under gate (resolves 2.0.0); full test suite re-run green as it's the vitest nuxt env"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -217,7 +217,7 @@
     "unbuild": "^3.6.1",
     "vitest": "^4.1.7",
     "vitest-axe": "^0.1.0",
-    "vitest-environment-nuxt": "^1.0.1",
+    "vitest-environment-nuxt": "^2.0.0",
     "vue": "^3.5.34",
     "vue-tsc": "^3.3.3",
     "@types/canvas-confetti": "^1.9.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -288,8 +288,8 @@ importers:
         specifier: ^0.1.0
         version: 0.1.0(vitest@4.1.8(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(happy-dom@20.9.0)(vite@7.3.5(@types/node@25.6.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.1)(yaml@2.9.0)))
       vitest-environment-nuxt:
-        specifier: ^1.0.1
-        version: 1.0.1(@vue/test-utils@2.4.10(@vue/compiler-dom@3.5.38)(@vue/server-renderer@3.5.38(vue@3.5.38(typescript@6.0.3)))(vue@3.5.38(typescript@6.0.3)))(crossws@0.4.5(srvx@0.11.15))(happy-dom@20.9.0)(magicast@0.5.3)(typescript@6.0.3)(vite@7.3.5(@types/node@25.6.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.1)(yaml@2.9.0))(vitest@4.1.8(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(happy-dom@20.9.0)(vite@7.3.5(@types/node@25.6.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.1)(yaml@2.9.0)))
+        specifier: ^2.0.0
+        version: 2.0.0(@vue/test-utils@2.4.10(@vue/compiler-dom@3.5.38)(@vue/server-renderer@3.5.38(vue@3.5.38(typescript@6.0.3)))(vue@3.5.38(typescript@6.0.3)))(crossws@0.4.5(srvx@0.11.15))(happy-dom@20.9.0)(magicast@0.5.3)(typescript@6.0.3)(vite@7.3.5(@types/node@25.6.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.1)(yaml@2.9.0))(vitest@4.1.8(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(happy-dom@20.9.0)(vite@7.3.5(@types/node@25.6.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.1)(yaml@2.9.0)))
       vue:
         specifier: ^3.5.34
         version: 3.5.38(typescript@6.0.3)
@@ -8143,9 +8143,6 @@ packages:
     resolution: {integrity: sha512-jvtXxeQPg8R/2ANTY8QicA5pvvdRP4F0FsVUAHANJ46YCDASie/cuhlSzu0DGcLmZvGBSBNsNuK3HqfaeknyvA==}
     peerDependencies:
       vitest: '>=0.16.0'
-
-  vitest-environment-nuxt@1.0.1:
-    resolution: {integrity: sha512-eBCwtIQriXW5/M49FjqNKfnlJYlG2LWMSNFsRVKomc8CaMqmhQPBS5LZ9DlgYL9T8xIVsiA6RZn2lk7vxov3Ow==}
 
   vitest-environment-nuxt@2.0.0:
     resolution: {integrity: sha512-zEGFRiCAaRR3fHnqISHKMNTRvCzkQEI1XyFeqNgR2IBD0oYkfZ1rUHwi7C+h3Cns3KPykfB0av1B3MtLEbChDw==}
@@ -17098,25 +17095,6 @@ snapshots:
       lodash-es: 4.18.1
       redent: 3.0.0
       vitest: 4.1.8(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(happy-dom@20.9.0)(vite@7.3.5(@types/node@25.6.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.1)(yaml@2.9.0))
-
-  vitest-environment-nuxt@1.0.1(@vue/test-utils@2.4.10(@vue/compiler-dom@3.5.38)(@vue/server-renderer@3.5.38(vue@3.5.38(typescript@6.0.3)))(vue@3.5.38(typescript@6.0.3)))(crossws@0.4.5(srvx@0.11.15))(happy-dom@20.9.0)(magicast@0.5.3)(typescript@6.0.3)(vite@7.3.5(@types/node@25.6.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.1)(yaml@2.9.0))(vitest@4.1.8(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(happy-dom@20.9.0)(vite@7.3.5(@types/node@25.6.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.1)(yaml@2.9.0))):
-    dependencies:
-      '@nuxt/test-utils': 4.0.2(@vue/test-utils@2.4.10(@vue/compiler-dom@3.5.38)(@vue/server-renderer@3.5.38(vue@3.5.38(typescript@6.0.3)))(vue@3.5.38(typescript@6.0.3)))(crossws@0.4.5(srvx@0.11.15))(happy-dom@20.9.0)(magicast@0.5.3)(typescript@6.0.3)(vite@7.3.5(@types/node@25.6.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.1)(yaml@2.9.0))(vitest@4.1.8(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(happy-dom@20.9.0)(vite@7.3.5(@types/node@25.6.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.1)(yaml@2.9.0)))
-    transitivePeerDependencies:
-      - '@cucumber/cucumber'
-      - '@jest/globals'
-      - '@playwright/test'
-      - '@testing-library/vue'
-      - '@vitest/ui'
-      - '@vue/test-utils'
-      - crossws
-      - happy-dom
-      - jsdom
-      - magicast
-      - playwright-core
-      - typescript
-      - vite
-      - vitest
 
   vitest-environment-nuxt@2.0.0(@vue/test-utils@2.4.10(@vue/compiler-dom@3.5.38)(@vue/server-renderer@3.5.38(vue@3.5.38(typescript@6.0.3)))(vue@3.5.38(typescript@6.0.3)))(crossws@0.4.5(srvx@0.11.15))(happy-dom@20.9.0)(magicast@0.5.3)(typescript@6.0.3)(vite@7.3.5(@types/node@25.6.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.1)(yaml@2.9.0))(vitest@4.1.8(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(happy-dom@20.9.0)(vite@7.3.5(@types/node@25.6.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.1)(yaml@2.9.0))):
     dependencies:


### PR DESCRIPTION
Port of upstream nuxt/ui [`be36fc37`](https://github.com/nuxt/ui/commit/be36fc37ceae066db292e71aa447622e7e59eba3) — `chore(deps): update devdependency vitest-environment-nuxt to v2 (#6534)`.

## Changes
- **root `package.json`**: `vitest-environment-nuxt` ^1.0.1 → ^2.0.0
  - Only manifest referencing this dep — no playground/docs counterpart, so the playground-mirroring invariant doesn't apply.
- **`pnpm-lock.yaml`**: regenerated under the active `minimumReleaseAge` gate (resolves to `2.0.0`).

Major bump of the Nuxt vitest environment used by the `nuxt` test project, so the full suite re-run is the key signal.

## Verification (pnpm 11.5.0, gate ON)
frozen install · dev:prepare · lint · typecheck · test (**4972 passed**, 6 skipped) · module build — all green.

Ledger: records the merge sha for the previous port (#150, `e99a61bc`) and advances the sync cursor to `be36fc37`.

https://claude.ai/code/session_01Qz7EXMncvEGiCj4WbmYgJo

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qz7EXMncvEGiCj4WbmYgJo)_