### PR TITLE
chore(sync): record pkg.pr.new org-guard as no-op

### DIFF
--- a/.sync/log/ad7b54e5371b7856ccabaf39308339052fa9ca1b.md
+++ b/.sync/log/ad7b54e5371b7856ccabaf39308339052fa9ca1b.md
@@ -1,0 +1,21 @@
+# Port: chore(github): guard pkg.pr.new publish to the nuxt org
+
+**Upstream:** `ad7b54e5371b7856ccabaf39308339052fa9ca1b` (nuxt/ui)
+**Decision:** no-op
+
+## Upstream change
+In `.github/workflows/module.yml`, tightens the `Publish` step condition
+from `matrix.os == 'ubuntu-latest'` to
+`matrix.os == 'ubuntu-latest' && github.repository_owner == 'nuxt'`, so the
+`pnpx pkg-pr-new publish` preview-package step only runs on the canonical
+`nuxt/ui` repo (and is skipped on forks, which would otherwise publish
+preview packages on fork PRs).
+
+## b24ui adaptation — n/a
+b24ui has no equivalent. Its `.github/workflows/` contains only `ci.yml`,
+`deploy.yml`, and `npm-publish.yml` — there is no `module.yml`, and **no
+`pkg-pr-new` / preview-publish step anywhere** in the repo. The upstream
+change guards a job b24ui doesn't have, so there is nothing to port.
+
+(If b24ui ever adds a pkg-pr-new preview publish, the equivalent guard would
+be `github.repository_owner == 'bitrix24'`.)

--- a/.sync/nuxt-ui.json
+++ b/.sync/nuxt-ui.json
@@ -2,7 +2,7 @@
   "upstream": "nuxt/ui",
   "branch": "v4",
   "sync_enabled": false,
-  "cursor": "be36fc37ceae066db292e71aa447622e7e59eba3",
+  "cursor": "ad7b54e5371b7856ccabaf39308339052fa9ca1b",
   "_cursor_note": "cursor = last upstream commit ported into b24ui (oldest-first, manual cadence). sync_enabled stays false until Phase 2 (porter workflow #67 + CLAUDE_CODE_OAUTH_TOKEN) is wired and trusted. `processed` is maintained per port from now on (backfilled #68-#72 on 2026-06-09).",
   "stats": {
     "queue_depth": 0,
@@ -341,10 +341,16 @@
       "summary": "chore(deps): update vue-tsc to ^3.3.3 (#6533) — vue-tsc ^3.3.0->^3.3.3 + vue-component-type-helpers ^3.3.0->^3.3.3 (root); vue-tsc bump in playgrounds nuxt/vue + demo (mirrored per invariant; repl pins neither); lockfile regen under gate (resolves 3.3.4)"
     },
     "be36fc37ceae066db292e71aa447622e7e59eba3": {
-      "pr": null,
-      "b24ui_sha": "pending-merge",
+      "pr": 151,
+      "b24ui_sha": "efa458ab",
       "decision": "port",
       "summary": "chore(deps): update devdependency vitest-environment-nuxt to v2 (#6534) — direct 1:1 major bump in root package.json (^1.0.1->^2.0.0), only manifest referencing it (no playground mirror needed); lockfile regen under gate (resolves 2.0.0); full test suite re-run green as it's the vitest nuxt env"
+    },
+    "ad7b54e5371b7856ccabaf39308339052fa9ca1b": {
+      "pr": null,
+      "b24ui_sha": "pending-merge",
+      "decision": "noop",
+      "summary": "chore(github): guard pkg.pr.new publish to the nuxt org — n/a: upstream tightens the module.yml Publish step to github.repository_owner=='nuxt'. b24ui has no module.yml and no pkg-pr-new/preview-publish step anywhere (workflows: ci.yml, deploy.yml, npm-publish.yml) — nothing to guard"
     }
   }
 }


### PR DESCRIPTION
Port of upstream nuxt/ui [`ad7b54e5`](https://github.com/nuxt/ui/commit/ad7b54e5371b7856ccabaf39308339052fa9ca1b) — `chore(github): guard pkg.pr.new publish to the nuxt org`.

## Decision: no-op

Upstream tightens the `Publish` step in `.github/workflows/module.yml` from `matrix.os == 'ubuntu-latest'` to `matrix.os == 'ubuntu-latest' && github.repository_owner == 'nuxt'`, so the `pkg-pr-new` preview-package publish only runs on the canonical repo and is skipped on forks.

**b24ui has no equivalent.** Its `.github/workflows/` contains only `ci.yml`, `deploy.yml`, and `npm-publish.yml` — there is no `module.yml` and **no `pkg-pr-new` / preview-publish step anywhere** in the repo. The upstream change guards a job b24ui doesn't have, so there is nothing to port.

(If b24ui ever adds a pkg-pr-new preview publish, the equivalent guard would be `github.repository_owner == 'bitrix24'`.)

## Changes
Bookkeeping only — `.sync/` ledger + log entry. Records the merge sha for the previous port (#151, `be36fc37`) and advances the sync cursor to `ad7b54e5`.

https://claude.ai/code/session_01Qz7EXMncvEGiCj4WbmYgJo

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qz7EXMncvEGiCj4WbmYgJo)_