### PR TITLE
fix(Form): support setting the `name` attribute

### DIFF
--- a/.sync/log/f8186e2d49472629cb0ea29ef1da468227bde677.md
+++ b/.sync/log/f8186e2d49472629cb0ea29ef1da468227bde677.md
@@ -1,0 +1,32 @@
+# Port: fix(Form): support setting the `name` attribute (#6539)
+
+**Upstream:** `f8186e2d49472629cb0ea29ef1da468227bde677` (nuxt/ui)
+**Decision:** port
+
+## Upstream change
+`src/runtime/components/Form.vue`:
+1. `name` prop loosened from `N extends true ? string : never` to plain
+   `name?: string` (+ doc comment: it's the form element's `name` attribute,
+   and for nested forms it doubles as the state path).
+2. Template root binds `:name="parentBus ? undefined : props.name"` — the
+   real `<form>` gets the attribute; the nested `<div>` form does not.
+3. `test/components/Form.spec.ts` expands `renderEach` cases (name, method,
+   id, class, ui, aria-label) + regenerated Form snapshots.
+
+## b24ui adaptation
+Same edits, b24ui-namespaced:
+- prop type + doc comment: identical change.
+- template: added `:name="parentBus ? undefined : props.name"` above the
+  existing `method="post"` (ported in #137). The `N` generic stays (still
+  used by `state?: N extends false ? ...`).
+- spec: same new cases, with the `ui` case renamed to `b24ui`
+  (`b24ui: { base: 'rounded-lg' }`) per b24ui's prop naming.
+- regenerated both snapshot projects (Form.spec.ts.snap + Form-vue.spec.ts.snap):
+  12 new snapshots (6 cases × nuxt/vue). Confirmed `name="contact"` renders on
+  the form, `method="get"` overrides the hardcoded `post` via attr fallthrough.
+
+## Verification (pnpm 11.5.0, gate ON)
+frozen install · dev:prepare · lint · typecheck · test (4984 passed, 6
+skipped — +12 new Form tests) · module build — all green.
+
+Platform note: b24ui CI is `ubuntu-latest` only.

--- a/.sync/nuxt-ui.json
+++ b/.sync/nuxt-ui.json
@@ -2,7 +2,7 @@
   "upstream": "nuxt/ui",
   "branch": "v4",
   "sync_enabled": false,
-  "cursor": "ad7b54e5371b7856ccabaf39308339052fa9ca1b",
+  "cursor": "f8186e2d49472629cb0ea29ef1da468227bde677",
   "_cursor_note": "cursor = last upstream commit ported into b24ui (oldest-first, manual cadence). sync_enabled stays false until Phase 2 (porter workflow #67 + CLAUDE_CODE_OAUTH_TOKEN) is wired and trusted. `processed` is maintained per port from now on (backfilled #68-#72 on 2026-06-09).",
   "stats": {
     "queue_depth": 0,
@@ -347,10 +347,16 @@
       "summary": "chore(deps): update devdependency vitest-environment-nuxt to v2 (#6534) — direct 1:1 major bump in root package.json (^1.0.1->^2.0.0), only manifest referencing it (no playground mirror needed); lockfile regen under gate (resolves 2.0.0); full test suite re-run green as it's the vitest nuxt env"
     },
     "ad7b54e5371b7856ccabaf39308339052fa9ca1b": {
-      "pr": null,
-      "b24ui_sha": "pending-merge",
+      "pr": 152,
+      "b24ui_sha": "ab563e45",
       "decision": "noop",
       "summary": "chore(github): guard pkg.pr.new publish to the nuxt org — n/a: upstream tightens the module.yml Publish step to github.repository_owner=='nuxt'. b24ui has no module.yml and no pkg-pr-new/preview-publish step anywhere (workflows: ci.yml, deploy.yml, npm-publish.yml) — nothing to guard"
+    },
+    "f8186e2d49472629cb0ea29ef1da468227bde677": {
+      "pr": null,
+      "b24ui_sha": "pending-merge",
+      "decision": "port",
+      "summary": "fix(Form): support setting the name attribute (#6539) — Form.vue name prop N extends true?string:never -> string (now the form element's name attr + nested-form state path); template binds :name=\"parentBus?undefined:props.name\"; spec adds name/method/id/class/b24ui/aria-label cases (ui->b24ui), +12 regenerated snapshots (nuxt+vue)"
     }
   }
 }

--- a/src/runtime/components/Form.vue
+++ b/src/runtime/components/Form.vue
@@ -32,10 +32,10 @@ export type FormProps<S extends FormSchema, T extends boolean = true, N extends 
   disabled?: boolean
 
   /**
-   * Path of the form's state within it's parent form.
-   * Used for nesting forms. Only available if `nested` is true.
+   * The `name` attribute of the form element.
+   * For nested forms (`nested` is true), this is also used as the path of the form's state within its parent form.
    */
-  name?: N extends true ? string : never
+  name?: string
 
   /**
    * Delay in milliseconds before validating the form on input events.
@@ -462,6 +462,7 @@ defineExpose(api)
     :is="parentBus ? 'div' : 'form'"
     :id="formId"
     ref="formRef"
+    :name="parentBus ? undefined : props.name"
     method="post"
     :class="b24ui({ class: [props.b24ui?.base, props.class] })"
     @submit.prevent="onSubmitWrapper"

--- a/test/components/Form.spec.ts
+++ b/test/components/Form.spec.ts
@@ -12,9 +12,20 @@ import { renderForm } from '../utils/form'
 import { B24Form } from '#components'
 
 describe('Form', () => {
+  const props = { state: {} }
+
   renderEach(B24Form, [
-    ['with state', { props: { state: {} } }],
-    ['with default slot', { props: { state: {} }, slots: { default: () => 'Form slot' } }]
+    // Props
+    ['with state', { props }],
+    ['with name', { props: { ...props, name: 'contact' } }],
+    ['with method', { props: { ...props, method: 'get' } }],
+    ['with id', { props: { ...props, id: 'id' } }],
+    ['with class', { props: { ...props, class: 'gap-4' } }],
+    ['with b24ui', { props: { ...props, b24ui: { base: 'rounded-lg' } } }],
+    // Attrs
+    ['with aria-label', { props, attrs: { 'aria-label': 'Contact form' } }],
+    // Slots
+    ['with default slot', { props, slots: { default: () => 'Form slot' } }]
   ])
 
   it('passes accessibility tests', async () => {

--- a/test/components/__snapshots__/Form-vue.spec.ts.snap
+++ b/test/components/__snapshots__/Form-vue.spec.ts.snap
@@ -144,7 +144,19 @@ exports[`Form > joi validation works > without error 1`] = `
 </form>"
 `;
 
+exports[`Form > renders with aria-label correctly 1`] = `"<form id="v-0" method="post" class="" aria-label="Contact form"></form>"`;
+
+exports[`Form > renders with b24ui correctly 1`] = `"<form id="v-0" method="post" class="rounded-lg"></form>"`;
+
+exports[`Form > renders with class correctly 1`] = `"<form id="v-0" method="post" class="gap-4"></form>"`;
+
 exports[`Form > renders with default slot correctly 1`] = `"<form id="v-0" method="post" class="">Form slot</form>"`;
+
+exports[`Form > renders with id correctly 1`] = `"<form id="id" method="post" class=""></form>"`;
+
+exports[`Form > renders with method correctly 1`] = `"<form id="v-0" method="get" class=""></form>"`;
+
+exports[`Form > renders with name correctly 1`] = `"<form id="v-0" name="contact" method="post" class=""></form>"`;
 
 exports[`Form > renders with state correctly 1`] = `"<form id="v-0" method="post" class=""></form>"`;
 

--- a/test/components/__snapshots__/Form.spec.ts.snap
+++ b/test/components/__snapshots__/Form.spec.ts.snap
@@ -144,7 +144,19 @@ exports[`Form > joi validation works > without error 1`] = `
 </form>"
 `;
 
+exports[`Form > renders with aria-label correctly 1`] = `"<form id="v-0-0" method="post" class="" aria-label="Contact form"></form>"`;
+
+exports[`Form > renders with b24ui correctly 1`] = `"<form id="v-0-0" method="post" class="rounded-lg"></form>"`;
+
+exports[`Form > renders with class correctly 1`] = `"<form id="v-0-0" method="post" class="gap-4"></form>"`;
+
 exports[`Form > renders with default slot correctly 1`] = `"<form id="v-0-0" method="post" class="">Form slot</form>"`;
+
+exports[`Form > renders with id correctly 1`] = `"<form id="id" method="post" class=""></form>"`;
+
+exports[`Form > renders with method correctly 1`] = `"<form id="v-0-0" method="get" class=""></form>"`;
+
+exports[`Form > renders with name correctly 1`] = `"<form id="v-0-0" name="contact" method="post" class=""></form>"`;
 
 exports[`Form > renders with state correctly 1`] = `"<form id="v-0-0" method="post" class=""></form>"`;
 


### PR DESCRIPTION
Port of upstream nuxt/ui [`f8186e2d`](https://github.com/nuxt/ui/commit/f8186e2d49472629cb0ea29ef1da468227bde677) — `fix(Form): support setting the `name` attribute (#6539)`.

## Changes
- **`Form.vue`**: `name` prop loosened from `N extends true ? string : never` to plain `name?: string`. It's now the form element's `name` attribute and, for nested forms (`nested` true), doubles as the state path within the parent form. The `N` generic stays (still used by `state?: N extends false ? …`).
- **`Form.vue` template**: binds `:name="parentBus ? undefined : props.name"` — the real `<form>` gets the attribute; the nested `<div>` form does not.
- **`Form.spec.ts`**: expand `renderEach` with name/method/id/class/b24ui/aria-label cases. Upstream's `ui` case is adapted to b24ui's `b24ui` prop (`b24ui: { base: 'rounded-lg' }`).
- Regenerated both snapshot projects (`Form.spec.ts.snap` + `Form-vue.spec.ts.snap`) — **+12 snapshots** (6 cases × nuxt/vue). Confirms `name="contact"` renders on the form, `method="get"` overrides the hardcoded `post` via attr fallthrough, and `b24ui.base` applies.

## Verification (pnpm 11.5.0, gate ON)
frozen install · dev:prepare · lint · typecheck · test (**4984 passed**, 6 skipped — +12 new Form tests) · module build — all green.

Ledger: records the merge sha for the previous port (#152, `ad7b54e5`) and advances the sync cursor to `f8186e2d`.

https://claude.ai/code/session_01Qz7EXMncvEGiCj4WbmYgJo

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qz7EXMncvEGiCj4WbmYgJo)_