### PR TITLE
chore(release): v2.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,54 @@
 # Changelog
 
+## [2.9.0](https://github.com/bitrix24/b24ui/compare/v2.8.0...v2.9.0) (2026-06-16)
+
+### Features
+
+* **ContentSearch:** add async search support via `search` / `searchStatus`
+* **ChatMessage:** add `body` slot and improve actions alignment
+
+### Bug Fixes
+
+* **InputMenu/SelectMenu:** re-highlight first item when items change
+* **Form:** support setting the `name` attribute
+* **Form:** add `method="post"` to prevent credential leaking via GET
+* **module:** merge custom variants into AppConfig type
+* **module:** expose component theme keys in AppConfig type
+* **module:** revert `tagPriority` to `-2` for inline style tag
+* **module:** ship stripped `#build/b24ui.css` fallback for tooling
+* **ChatMessage:** add `wrap-break-word` to content slot
+* **ContentSearch:** preserve intermediate ancestors in breadcrumb prefix
+* **components:** apply `theme.prefix` to hardcoded utility classes
+* **InputMenu/Select/SelectMenu:** respect `trailing: false` over default `trailingIcon`
+* **ProseKbd:** add default slot and make `value` optional
+* **Textarea:** autoresize on mount with pre-filled value
+* **ContentToc:** apply `b24ui.trigger` prop to trigger elements
+* **FileUpload:** pass `disabled` attribute to button variant
+
+### Docs
+
+* **search:** improve relevance and tooltip behavior
+* **toast:** remove misleading AppConfig notes from examples
+* fix missing CSS variables on prerendered pages
+* resolve prerender payload 204 and build warnings
+* drop redundant homepage payload prerender ignore
+
+### CI
+
+* **deploy:** raise Node heap limit to fix docs prerender OOM
+
+### Chore
+
+* **deps:** update Nuxt framework to `^4.4.6`
+* **deps:** update Tiptap to `^3.24.0`
+* **deps:** update reka-ui to `v2.9.8`
+* **deps:** update Vite, vue-tsc to `^3.3.3`, vitest-environment-nuxt to v2
+* **deps:** update pnpm to v11, pnpm/action-setup to v6
+* **deps:** several non-major dependency refreshes
+* **repl:** expose composables subpath in the playground
+* sync with nuxt/ui upstream (no-op syncs)
+* add `.cursor` to `.gitignore`
+
 ## [2.8.0](https://github.com/bitrix24/b24ui/compare/v2.7.1...v2.8.0) (2026-05-20)
 
 ### Features

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bitrix24/b24ui-nuxt",
   "description": "Bitrix24 UI-Kit for developing web applications REST API for NUXT & VUE",
-  "version": "2.8.0",
+  "version": "2.9.0",
   "packageManager": "pnpm@11.5.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

Minor release **v2.9.0** — bumps `package.json` to `2.9.0` and documents 50 commits landed since `v2.8.0` (2 features, 15 fixes, lots of dependency refreshes and upstream syncs).

### Features
- **ContentSearch** — async search via `search` / `searchStatus`
- **ChatMessage** — `body` slot and improved actions alignment

### Bug Fixes
- **Form** — `name` attribute support; `method="post"` to prevent credential leaking via GET
- **module** — AppConfig type covers custom variants and component theme keys; `tagPriority` reverted to `-2` for inline style tag; ship stripped `#build/b24ui.css` fallback
- **ChatMessage** — `wrap-break-word` on content slot
- **ContentSearch** — keep intermediate ancestors in breadcrumb prefix
- **components** — apply `theme.prefix` to hardcoded utility classes
- **InputMenu/Select/SelectMenu** — respect `trailing: false` over default `trailingIcon`
- **ProseKbd** — default slot, optional `value`
- **Textarea** — autoresize on mount with pre-filled value
- **ContentToc** — apply `b24ui.trigger` prop to trigger elements
- **FileUpload** — pass `disabled` to button variant

### Docs / CI / Chore
- docs search relevance & tooltip behavior; missing CSS variables on prerendered pages; prerender payload 204 / build warnings; toast example cleanup
- deploy workflow: raise Node heap limit to fix docs prerender OOM
- deps: Nuxt `^4.4.6`, Tiptap `^3.24.0`, reka-ui `v2.9.8`, Vite, vue-tsc `^3.3.3`, vitest-environment-nuxt v2, pnpm v11, pnpm/action-setup v6, plus non-major refreshes
- repl: expose composables subpath; upstream nuxt/ui no-op syncs; `.cursor` in `.gitignore`

## Test plan
- [ ] CI green (lint / typecheck / test / build)
- [ ] `CHANGELOG.md` 2.9.0 section reads correctly
- [ ] `package.json` version is `2.9.0`

https://claude.ai/code/session_01ReWfWJcdNVZNYH5p5VpoJa

---
_Generated by [Claude Code](https://claude.ai/code/session_01ReWfWJcdNVZNYH5p5VpoJa)_