### PR TITLE
fix(InputMenu/SelectMenu): re-highlight first item when items change

### DIFF
--- a/.sync/log/0414dd0d1ba694962562efdabfb60c135ab742ad.md
+++ b/.sync/log/0414dd0d1ba694962562efdabfb60c135ab742ad.md
@@ -1,0 +1,33 @@
+# Port: fix(InputMenu/SelectMenu): re-highlight first item when items change (#6538)
+
+**Upstream:** `0414dd0d1ba694962562efdabfb60c135ab742ad` (nuxt/ui)
+**Decision:** port
+
+## Upstream change
+`InputMenu.vue` + `SelectMenu.vue`: when `create-item` is on, reka-ui's
+collection never goes empty→non-empty (the create item is always registered),
+so the first-item highlight stays stale when async `items` load. Fix:
+1. import `ref` (InputMenu) / `ref`, `watch`, `nextTick` (SelectMenu).
+2. add `const isOpen = ref(false)` and set `isOpen.value = value` at the top
+   of `onUpdateOpen`.
+3. add a `comboboxRootRef` template ref + a `watch(() => props.items, ...,
+   { flush: 'post' })` that, while open, awaits a tick and calls
+   `comboboxRootRef.value?.highlightFirstItem?.()`.
+4. add `ref="comboboxRootRef"` to `<Component.Root>` (InputMenu) /
+   `<ComboboxRoot>` (SelectMenu).
+5. tests: a `create-item` describe block in both specs.
+
+## b24ui adaptation
+Identical edits — both components share the same reka-ui structure in b24ui
+(InputMenu uses the namespaced `Component.Root`; SelectMenu uses
+`ComboboxRoot` with `:id="id"` first). Same imports, `isOpen` flag, watcher,
+and template refs. Tests copied verbatim into b24ui's specs (which already
+import `mount`/`flushPromises`); the components are imported under the same
+local names so `findComponent({ name: 'ComboboxRoot' })` resolves.
+
+## Verification (pnpm 11.5.0, gate ON)
+frozen install · dev:prepare · lint · typecheck · test (4988 passed, 6
+skipped — +4: re-highlight test × InputMenu/SelectMenu × nuxt/vue) · module
+build — all green. Focused InputMenu+SelectMenu run: 308 passed.
+
+Platform note: b24ui CI is `ubuntu-latest` only.

--- a/.sync/nuxt-ui.json
+++ b/.sync/nuxt-ui.json
@@ -2,7 +2,7 @@
   "upstream": "nuxt/ui",
   "branch": "v4",
   "sync_enabled": false,
-  "cursor": "f8186e2d49472629cb0ea29ef1da468227bde677",
+  "cursor": "0414dd0d1ba694962562efdabfb60c135ab742ad",
   "_cursor_note": "cursor = last upstream commit ported into b24ui (oldest-first, manual cadence). sync_enabled stays false until Phase 2 (porter workflow #67 + CLAUDE_CODE_OAUTH_TOKEN) is wired and trusted. `processed` is maintained per port from now on (backfilled #68-#72 on 2026-06-09).",
   "stats": {
     "queue_depth": 0,
@@ -353,10 +353,16 @@
       "summary": "chore(github): guard pkg.pr.new publish to the nuxt org — n/a: upstream tightens the module.yml Publish step to github.repository_owner=='nuxt'. b24ui has no module.yml and no pkg-pr-new/preview-publish step anywhere (workflows: ci.yml, deploy.yml, npm-publish.yml) — nothing to guard"
     },
     "f8186e2d49472629cb0ea29ef1da468227bde677": {
+      "pr": 153,
+      "b24ui_sha": "6c129a9b",
+      "decision": "port",
+      "summary": "fix(Form): support setting the name attribute (#6539) — Form.vue name prop N extends true?string:never -> string (now the form element's name attr + nested-form state path); template binds :name=\"parentBus?undefined:props.name\"; spec adds name/method/id/class/b24ui/aria-label cases (ui->b24ui), +12 regenerated snapshots (nuxt+vue)"
+    },
+    "0414dd0d1ba694962562efdabfb60c135ab742ad": {
       "pr": null,
       "b24ui_sha": "pending-merge",
       "decision": "port",
-      "summary": "fix(Form): support setting the name attribute (#6539) — Form.vue name prop N extends true?string:never -> string (now the form element's name attr + nested-form state path); template binds :name=\"parentBus?undefined:props.name\"; spec adds name/method/id/class/b24ui/aria-label cases (ui->b24ui), +12 regenerated snapshots (nuxt+vue)"
+      "summary": "fix(InputMenu/SelectMenu): re-highlight first item when items change (#6538) — both components: import ref (+watch/nextTick in SelectMenu), isOpen ref set in onUpdateOpen, comboboxRootRef + watch(props.items,{flush:'post'}) calling highlightFirstItem while open, ref on Component.Root/ComboboxRoot; +create-item test in both specs (+4 tests across nuxt/vue). Fixes stale highlight with create-item + async items"
     }
   }
 }

--- a/src/runtime/components/InputMenu.vue
+++ b/src/runtime/components/InputMenu.vue
@@ -248,7 +248,7 @@ export interface InputMenuSlots<
 </script>
 
 <script setup lang="ts" generic="T extends ArrayOrNested<InputMenuItem>, VK extends GetItemKeys<T> | undefined = undefined, M extends boolean = false, Mod extends Omit<ModelModifiers, 'lazy'> = Omit<ModelModifiers, 'lazy'>, C extends boolean | object = false">
-import { computed, useTemplateRef, toRef, onMounted, toRaw, nextTick, watch } from 'vue'
+import { computed, ref, useTemplateRef, toRef, onMounted, toRaw, nextTick, watch } from 'vue'
 import { TagsInputRoot, TagsInputItem, TagsInputItemText, TagsInputItemDelete, TagsInputInput } from 'reka-ui'
 import { Combobox, Autocomplete } from 'reka-ui/namespaced'
 import { defu } from 'defu'
@@ -481,7 +481,10 @@ function onFocus(event: FocusEvent) {
   emitFormFocus()
 }
 
+const isOpen = ref(false)
 function onUpdateOpen(value: boolean) {
+  isOpen.value = value
+
   let timeoutId
 
   if (!value) {
@@ -552,6 +555,21 @@ function onClear() {
 }
 
 const viewportRef = useTemplateRef('viewportRef')
+
+const comboboxRootRef = useTemplateRef('comboboxRootRef')
+
+// reka-ui only re-highlights the first item when the list goes from empty to non-empty.
+// With `create-item`, the create item is always registered so the count never drops to 0,
+// leaving the highlight stale when async `items` load. Re-highlight when items change while open.
+// Wait an extra tick so freshly mounted items are registered in reka-ui's collection before highlighting.
+watch(() => props.items, async () => {
+  if (!isOpen.value) {
+    return
+  }
+
+  await nextTick()
+  comboboxRootRef.value?.highlightFirstItem?.()
+}, { flush: 'post' })
 
 defineExpose({
   inputRef: toRef(() => inputRef.value?.$el as HTMLInputElement),
@@ -655,6 +673,7 @@ defineExpose({
   </DefineItemTemplate>
 
   <Component.Root
+    ref="comboboxRootRef"
     v-slot="{ modelValue, open }"
     v-bind="rootProps"
     :name="name"

--- a/src/runtime/components/SelectMenu.vue
+++ b/src/runtime/components/SelectMenu.vue
@@ -250,7 +250,7 @@ export interface SelectMenuSlots<
 </script>
 
 <script setup lang="ts" generic="T extends ArrayOrNested<SelectMenuItem>, VK extends GetItemKeys<T> | undefined = undefined, M extends boolean = false, Mod extends Omit<ModelModifiers, 'lazy'> = Omit<ModelModifiers, 'lazy'>, C extends boolean | object = false">
-import { useTemplateRef, computed, onMounted, toRef, toRaw } from 'vue'
+import { useTemplateRef, computed, ref, onMounted, toRef, toRaw, watch, nextTick } from 'vue'
 // @memo we use Primitive
 import { Primitive, ComboboxRoot, ComboboxArrow, ComboboxAnchor, ComboboxInput, ComboboxTrigger, ComboboxCancel, ComboboxPortal, ComboboxContent, ComboboxEmpty, ComboboxGroup, ComboboxVirtualizer, ComboboxLabel, ComboboxSeparator, ComboboxItem, ComboboxItemIndicator, FocusScope } from 'reka-ui'
 import { defu } from 'defu'
@@ -460,7 +460,10 @@ function onUpdate(value: any) {
   }
 }
 
+const isOpen = ref(false)
 function onUpdateOpen(value: boolean) {
+  isOpen.value = value
+
   let timeoutId
 
   if (!value) {
@@ -522,6 +525,21 @@ function onClear() {
 }
 
 const viewportRef = useTemplateRef('viewportRef')
+
+const comboboxRootRef = useTemplateRef('comboboxRootRef')
+
+// reka-ui only re-highlights the first item when the list goes from empty to non-empty.
+// With `create-item`, the create item is always registered so the count never drops to 0,
+// leaving the highlight stale when async `items` load. Re-highlight when items change while open.
+// Wait an extra tick so freshly mounted items are registered in reka-ui's collection before highlighting.
+watch(() => props.items, async () => {
+  if (!isOpen.value) {
+    return
+  }
+
+  await nextTick()
+  comboboxRootRef.value?.highlightFirstItem?.()
+}, { flush: 'post' })
 
 defineExpose({
   triggerRef: toRef(() => triggerRef.value?.$el as HTMLButtonElement),
@@ -644,6 +662,7 @@ defineExpose({
   <Primitive as="div" data-slot="root" :class="b24ui.root({ addNew: true, class: [props.b24ui?.root] })">
     <ComboboxRoot
       :id="id"
+      ref="comboboxRootRef"
       v-slot="{ modelValue, open }"
       v-bind="{ ...rootProps as any, ...$attrs, ...ariaAttrs }"
       ignore-filter

--- a/test/components/InputMenu.spec.ts
+++ b/test/components/InputMenu.spec.ts
@@ -205,6 +205,44 @@ describe('InputMenu', () => {
     })
   })
 
+  describe('create-item', () => {
+    // With `create-item`, the create item is always registered so reka-ui's collection
+    // never goes from empty to non-empty, leaving the highlight stale when async items load.
+    test('re-highlights first item when items change while open', async () => {
+      const wrapper = mount(InputMenu, {
+        attachTo: document.body,
+        props: {
+          open: true,
+          portal: false,
+          ignoreFilter: true,
+          createItem: 'always',
+          multiple: true,
+          items: []
+        }
+      })
+
+      const root = wrapper.findComponent({ name: 'ComboboxRoot' })
+      // Track open state (the watcher only re-highlights while the menu is open)
+      await root.vm.$emit('update:open', true)
+      await flushPromises()
+
+      // `searchTerm` is reset on mount, so set it afterwards to render the create item.
+      // It becomes the only (highlighted) item, mirroring the autocomplete bug.
+      await wrapper.setProps({ searchTerm: 'a' })
+      await flushPromises()
+
+      // Items arrive asynchronously (e.g. fetched from a backend)
+      await wrapper.setProps({ items: ['Option 1', 'Option 2'] })
+      await flushPromises()
+
+      const highlighted = wrapper.find('[role="option"][data-highlighted]')
+      expect(highlighted.exists()).toBe(true)
+      expect(highlighted.text()).toContain('Option 1')
+
+      wrapper.unmount()
+    })
+  })
+
   describe('it should display correct label', () => {
     test.each([null, undefined, ''])('falsy model value %s should display placeholder', (modelValue) => {
       const wrapper = mount(InputMenu, {

--- a/test/components/SelectMenu.spec.ts
+++ b/test/components/SelectMenu.spec.ts
@@ -169,6 +169,43 @@ describe('SelectMenu', () => {
     })
   })
 
+  describe('create-item', () => {
+    // With `create-item`, the create item is always registered so reka-ui's collection
+    // never goes from empty to non-empty, leaving the highlight stale when async items load.
+    test('re-highlights first item when items change while open', async () => {
+      const wrapper = mount(SelectMenu, {
+        attachTo: document.body,
+        props: {
+          open: true,
+          portal: false,
+          ignoreFilter: true,
+          createItem: 'always',
+          multiple: true,
+          items: []
+        }
+      })
+
+      const root = wrapper.findComponent({ name: 'ComboboxRoot' })
+      // Track open state (the watcher only re-highlights while the menu is open)
+      await root.vm.$emit('update:open', true)
+      await flushPromises()
+
+      // Set the search term so the create item renders and becomes the only (highlighted) item.
+      await wrapper.setProps({ searchTerm: 'a' })
+      await flushPromises()
+
+      // Items arrive asynchronously (e.g. fetched from a backend)
+      await wrapper.setProps({ items: ['Option 1', 'Option 2'] })
+      await flushPromises()
+
+      const highlighted = wrapper.find('[role="option"][data-highlighted]')
+      expect(highlighted.exists()).toBe(true)
+      expect(highlighted.text()).toContain('Option 1')
+
+      wrapper.unmount()
+    })
+  })
+
   describe('it should display correct label', () => {
     test.each([null, undefined, ''])('falsy model value %s should display placeholder', (modelValue) => {
       const wrapper = mount(SelectMenu, {


### PR DESCRIPTION
Port of upstream nuxt/ui [`0414dd0d`](https://github.com/nuxt/ui/commit/0414dd0d1ba694962562efdabfb60c135ab742ad) — `fix(InputMenu/SelectMenu): re-highlight first item when items change (#6538)`.

## Problem
With `create-item`, reka-ui's collection never transitions empty → non-empty (the create item is always registered), so reka-ui's built-in "highlight first item" doesn't fire, leaving a **stale highlight** when async `items` load.

## Changes (both `InputMenu.vue` and `SelectMenu.vue`)
- import `ref` (InputMenu) / `ref`, `watch`, `nextTick` (SelectMenu)
- track open state: `const isOpen = ref(false)` set at the top of `onUpdateOpen`
- new `comboboxRootRef` template ref + `watch(() => props.items, …, { flush: 'post' })` that, **while open**, awaits a tick and calls `comboboxRootRef.value?.highlightFirstItem?.()`
- `ref="comboboxRootRef"` added to `<Component.Root>` (InputMenu) / `<ComboboxRoot>` (SelectMenu)
- new `create-item` re-highlight test in both specs

Edits are identical to upstream — both components share the same reka-ui structure in b24ui.

## Verification (pnpm 11.5.0, gate ON)
frozen install · dev:prepare · lint · typecheck · test (**4988 passed**, 6 skipped — +4: re-highlight × InputMenu/SelectMenu × nuxt/vue) · module build — all green. Focused InputMenu+SelectMenu run: 308 passed.

Ledger: records the merge sha for the previous port (#153, `f8186e2d`) and advances the sync cursor to `0414dd0d`.

https://claude.ai/code/session_01Qz7EXMncvEGiCj4WbmYgJo

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qz7EXMncvEGiCj4WbmYgJo)_