### PR TITLE
docs(toast): add `duration` prop

### DIFF
--- a/.sync/log/9afaeb2dc6ad0813d865d89da1521081b531931c.md
+++ b/.sync/log/9afaeb2dc6ad0813d865d89da1521081b531931c.md
@@ -1,0 +1,34 @@
+# Port: docs(toast): add `duration` prop (#6540)
+
+**Upstream:** `9afaeb2dc6ad0813d865d89da1521081b531931c` (nuxt/ui)
+**Decision:** port
+
+## Upstream change
+Documents the toast `duration` field, and along the way makes `duration` an
+explicit prop instead of a passthrough from `ToastRootProps`:
+1. `Toast.vue`: drop `'duration'` from `Pick<ToastRootProps, …>`; add an
+   explicit `duration?: number` prop (doc: ms before auto-close, overrides
+   global `toaster.duration`, `0` = stay open, default 5000).
+2. `Toast.vue` template: rename the `v-slot` destructured `duration` to
+   `duration: totalDuration` (avoids shadowing the new prop) and update the
+   progress-bar refs (`remaining / totalDuration * 100`).
+3. docs: new `ToastDurationExample.vue` + a "Duration" section in `toast.md`.
+
+## b24ui adaptation
+- `Toast.vue`: identical prop + template edits (b24ui uses `B24Progress`;
+  `remaining / totalDuration * 100` updated the same way).
+- docs `toast.md`: added the "Duration" section (with the `0`-keeps-open tip
+  and the `component-example` block, options 0/1000/3000/5000) before
+  "### Progress", matching upstream ordering. Progress link kept b24ui's
+  trailing-slash form `/docs/components/progress/`.
+- example `ToastDurationExample.vue`: same logic, but using `<B24Button
+  label="Show toast" @click="showToast" />` (b24ui's auto-imported button,
+  matching its other Toast examples) instead of upstream's
+  `UButton color="neutral" variant="outline"`.
+
+## Verification (pnpm 11.5.0, gate ON)
+frozen install · dev:prepare · lint · typecheck · test (4988 passed, 6
+skipped) · module build — all green. The v-slot rename is internal (no
+rendered-output change → no snapshot churn).
+
+Platform note: b24ui CI is `ubuntu-latest` only.

--- a/.sync/nuxt-ui.json
+++ b/.sync/nuxt-ui.json
@@ -2,7 +2,7 @@
   "upstream": "nuxt/ui",
   "branch": "v4",
   "sync_enabled": false,
-  "cursor": "0414dd0d1ba694962562efdabfb60c135ab742ad",
+  "cursor": "9afaeb2dc6ad0813d865d89da1521081b531931c",
   "_cursor_note": "cursor = last upstream commit ported into b24ui (oldest-first, manual cadence). sync_enabled stays false until Phase 2 (porter workflow #67 + CLAUDE_CODE_OAUTH_TOKEN) is wired and trusted. `processed` is maintained per port from now on (backfilled #68-#72 on 2026-06-09).",
   "stats": {
     "queue_depth": 0,
@@ -359,10 +359,16 @@
       "summary": "fix(Form): support setting the name attribute (#6539) — Form.vue name prop N extends true?string:never -> string (now the form element's name attr + nested-form state path); template binds :name=\"parentBus?undefined:props.name\"; spec adds name/method/id/class/b24ui/aria-label cases (ui->b24ui), +12 regenerated snapshots (nuxt+vue)"
     },
     "0414dd0d1ba694962562efdabfb60c135ab742ad": {
+      "pr": 155,
+      "b24ui_sha": "b43da08f",
+      "decision": "port",
+      "summary": "fix(InputMenu/SelectMenu): re-highlight first item when items change (#6538) — both components: import ref (+watch/nextTick in SelectMenu), isOpen ref set in onUpdateOpen, comboboxRootRef + watch(props.items,{flush:'post'}) calling highlightFirstItem while open, ref on Component.Root/ComboboxRoot; +create-item test in both specs (+4 tests across nuxt/vue). Fixes stale highlight with create-item + async items"
+    },
+    "9afaeb2dc6ad0813d865d89da1521081b531931c": {
       "pr": null,
       "b24ui_sha": "pending-merge",
       "decision": "port",
-      "summary": "fix(InputMenu/SelectMenu): re-highlight first item when items change (#6538) — both components: import ref (+watch/nextTick in SelectMenu), isOpen ref set in onUpdateOpen, comboboxRootRef + watch(props.items,{flush:'post'}) calling highlightFirstItem while open, ref on Component.Root/ComboboxRoot; +create-item test in both specs (+4 tests across nuxt/vue). Fixes stale highlight with create-item + async items"
+      "summary": "docs(toast): add duration prop (#6540) — Toast.vue: drop 'duration' from Pick<ToastRootProps>, add explicit duration?:number prop (override global toaster.duration, 0=stay open, default 5000); v-slot duration -> duration: totalDuration (+ B24Progress model-value uses totalDuration); docs toast.md +Duration section; +ToastDurationExample.vue (B24Button, not UButton color/variant)"
     }
   }
 }

--- a/docs/app/components/content/examples/toast/ToastDurationExample.vue
+++ b/docs/app/components/content/examples/toast/ToastDurationExample.vue
@@ -1,0 +1,19 @@
+<script setup lang="ts">
+const toast = useToast()
+
+const props = defineProps<{
+  duration: number
+}>()
+
+function showToast() {
+  toast.add({
+    title: 'Uh oh! Something went wrong.',
+    description: 'There was a problem with your request.',
+    duration: props.duration
+  })
+}
+</script>
+
+<template>
+  <B24Button label="Show toast" @click="showToast" />
+</template>

--- a/docs/content/docs/2.components/toast.md
+++ b/docs/content/docs/2.components/toast.md
@@ -144,6 +144,29 @@ name: 'toast-actions-example'
 ---
 ::
 
+### Duration
+
+Pass a `duration` field to the `toast.add` method to change how long the Toast remains visible (in milliseconds). Defaults to `5000`.
+
+::tip
+Set the `duration` field to `0` to keep the Toast open until it's manually closed.
+::
+
+::component-example
+---
+options:
+  - name: 'duration'
+    label: 'duration'
+    default: 0
+    items:
+      - 0
+      - 1000
+      - 3000
+      - 5000
+name: 'toast-duration-example'
+---
+::
+
 ### Progress
 
 Pass a `progress` field to customize or hide the [Progress](/docs/components/progress/) bar (with `false` value).

--- a/src/runtime/components/Toast.vue
+++ b/src/runtime/components/Toast.vue
@@ -9,7 +9,7 @@ import type { ComponentConfig } from '../types/tv'
 
 type Toast = ComponentConfig<typeof theme, AppConfig, 'toast'>
 
-export interface ToastProps extends Pick<ToastRootProps, 'defaultOpen' | 'open' | 'type' | 'duration'> {
+export interface ToastProps extends Pick<ToastRootProps, 'defaultOpen' | 'open' | 'type'> {
   /**
    * The element or component this component should render as.
    * @defaultValue 'li'
@@ -50,6 +50,13 @@ export interface ToastProps extends Pick<ToastRootProps, 'defaultOpen' | 'open' 
    * `{ size: 'sm' }`{lang="ts"}
    */
   actions?: ButtonProps[]
+  /**
+   * The time in milliseconds before the toast automatically closes. Overrides the global `toaster.duration`.
+   *
+   * Set to `0` to keep the toast open until it's manually closed.
+   * @defaultValue 5000
+   */
+  duration?: number
   /**
    * Display a progress bar showing the toast's remaining duration.
    * `{ size: 'sm' }`{lang="ts"}
@@ -126,7 +133,7 @@ defineExpose({
 <template>
   <ToastRoot
     ref="rootRef"
-    v-slot="{ remaining, duration, open }"
+    v-slot="{ remaining, duration: totalDuration, open }"
     v-bind="rootProps"
     :data-orientation="props.orientation"
     data-slot="root"
@@ -199,8 +206,8 @@ defineExpose({
     </div>
 
     <B24Progress
-      v-if="props.progress && open && remaining > 0 && duration"
-      :model-value="remaining / duration * 100"
+      v-if="props.progress && open && remaining > 0 && totalDuration"
+      :model-value="remaining / totalDuration * 100"
       :color="props.color"
       v-bind="(typeof props.progress === 'object' ? props.progress as Partial<ProgressProps> : {})"
       size="sm"


### PR DESCRIPTION
Port of upstream nuxt/ui [`9afaeb2d`](https://github.com/nuxt/ui/commit/9afaeb2dc6ad0813d865d89da1521081b531931c) — `docs(toast): add `duration` prop` (resolves nuxt/ui#6540).

## Changes
- **`Toast.vue`** (source): make `duration` an **explicit prop** (`duration?: number` — ms before auto-close, overrides the global `toaster.duration`, `0` keeps it open, default `5000`) instead of a passthrough from `ToastRootProps`. Rename the `v-slot` destructured `duration` → `totalDuration` to avoid shadowing the new prop, and update the progress bar (`remaining / totalDuration * 100`, using b24ui's `B24Progress`).
- **`toast.md`**: add a "Duration" section (with the `0`-keeps-it-open tip and a `component-example` with options 0/1000/3000/5000), placed before "Progress" to match upstream ordering.
- **`ToastDurationExample.vue`**: new example. Uses b24ui's auto-imported `<B24Button label="Show toast" …>` (matching the other Toast examples) rather than upstream's `UButton color="neutral" variant="outline"`.

## Verification (pnpm 11.5.0, gate ON)
frozen install · dev:prepare · lint · typecheck · test (**4988 passed**, 6 skipped) · module build — all green. The v-slot rename is internal (no rendered-output change → no snapshot churn).

Ledger: records the merge sha for the previous port (#155, `0414dd0d`) and advances the sync cursor to `9afaeb2d`.

https://claude.ai/code/session_01Qz7EXMncvEGiCj4WbmYgJo

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qz7EXMncvEGiCj4WbmYgJo)_