### PR TITLE
fix(InputNumber/InputDate/InputTime/Calendar): restore `locale` prop

### DIFF
--- a/.sync/log/ed2f955f092b6213ba2c3a4750260433f0edc2c6.md
+++ b/.sync/log/ed2f955f092b6213ba2c3a4750260433f0edc2c6.md
@@ -1,0 +1,31 @@
+# Port: fix(InputNumber/InputDate/InputTime/Calendar): restore `locale` prop (#6546)
+
+**Upstream:** `ed2f955f092b6213ba2c3a4750260433f0edc2c6` (nuxt/ui)
+**Decision:** port
+
+## Upstream change
+A prior refactor accidentally omitted `locale` from these components' props.
+Restored by un-omitting / re-picking it:
+- **Calendar.vue**: drop `'locale'` from both `_CalendarRootProps` /
+  `_RangeCalendarRootProps` Omit lists; use `props.locale ?? locale.code` in
+  `getWeekNumber`.
+- **InputDate.vue**: drop `'locale'` from `_DateFieldRootProps` /
+  `_RangeDateFieldRootProps` Omit lists.
+- **InputTime.vue**: drop `'locale'` from `_TimeFieldRootProps` /
+  `_TimeRangeFieldRootProps` Omit lists.
+- **InputNumber.vue**: add `'locale'` to the `Pick<NumberFieldRootProps, …>`
+  and to the `reactivePick(props, …)` forwarded as `rootProps`.
+
+## b24ui adaptation
+Same edits. One divergence: b24ui's **Calendar.vue** Omit lists **already
+lacked `'locale'`** (so `locale` was already a prop there) — only the
+`getWeekNumber(weekDates[0], props.locale ?? locale.code)` fix was needed for
+Calendar. The other three components matched upstream's pre-fix state and got
+the full edit. b24ui-namespaced theme imports (`#build/b24ui/…`) untouched.
+
+## Verification (pnpm 11.5.0, gate ON)
+frozen install · dev:prepare · lint · **typecheck** · test (4988 passed, 6
+skipped) · module build — all green. Type-only/prop-forwarding change; no
+rendered-output change → no snapshot churn.
+
+Platform note: b24ui CI is `ubuntu-latest` only.

--- a/.sync/nuxt-ui.json
+++ b/.sync/nuxt-ui.json
@@ -2,7 +2,7 @@
   "upstream": "nuxt/ui",
   "branch": "v4",
   "sync_enabled": false,
-  "cursor": "9afaeb2dc6ad0813d865d89da1521081b531931c",
+  "cursor": "ed2f955f092b6213ba2c3a4750260433f0edc2c6",
   "_cursor_note": "cursor = last upstream commit ported into b24ui (oldest-first, manual cadence). sync_enabled stays false until Phase 2 (porter workflow #67 + CLAUDE_CODE_OAUTH_TOKEN) is wired and trusted. `processed` is maintained per port from now on (backfilled #68-#72 on 2026-06-09).",
   "stats": {
     "queue_depth": 0,
@@ -365,10 +365,16 @@
       "summary": "fix(InputMenu/SelectMenu): re-highlight first item when items change (#6538) — both components: import ref (+watch/nextTick in SelectMenu), isOpen ref set in onUpdateOpen, comboboxRootRef + watch(props.items,{flush:'post'}) calling highlightFirstItem while open, ref on Component.Root/ComboboxRoot; +create-item test in both specs (+4 tests across nuxt/vue). Fixes stale highlight with create-item + async items"
     },
     "9afaeb2dc6ad0813d865d89da1521081b531931c": {
+      "pr": 156,
+      "b24ui_sha": "42028cf8",
+      "decision": "port",
+      "summary": "docs(toast): add duration prop (#6540) — Toast.vue: drop 'duration' from Pick<ToastRootProps>, add explicit duration?:number prop (override global toaster.duration, 0=stay open, default 5000); v-slot duration -> duration: totalDuration (+ B24Progress model-value uses totalDuration); docs toast.md +Duration section; +ToastDurationExample.vue (B24Button, not UButton color/variant)"
+    },
+    "ed2f955f092b6213ba2c3a4750260433f0edc2c6": {
       "pr": null,
       "b24ui_sha": "pending-merge",
       "decision": "port",
-      "summary": "docs(toast): add duration prop (#6540) — Toast.vue: drop 'duration' from Pick<ToastRootProps>, add explicit duration?:number prop (override global toaster.duration, 0=stay open, default 5000); v-slot duration -> duration: totalDuration (+ B24Progress model-value uses totalDuration); docs toast.md +Duration section; +ToastDurationExample.vue (B24Button, not UButton color/variant)"
+      "summary": "fix(InputNumber/InputDate/InputTime/Calendar): restore locale prop (#6546) — drop 'locale' from Omit lists in InputDate/InputTime (both root-prop types) and Calendar getWeekNumber uses props.locale??locale.code; InputNumber adds 'locale' to Pick<NumberFieldRootProps> + reactivePick rootProps. b24ui Calendar Omit lists already lacked 'locale' (only getWeekNumber edit needed there)"
     }
   }
 }

--- a/src/runtime/components/Calendar.vue
+++ b/src/runtime/components/Calendar.vue
@@ -238,7 +238,7 @@ const btnSize = computed(() => {
               data-slot="cellWeek"
               :class="b24ui.cellWeek({ class: props.b24ui?.cellWeek })"
             >
-              {{ getWeekNumber(weekDates[0], locale.code) }}
+              {{ getWeekNumber(weekDates[0], props.locale ?? locale.code) }}
             </td>
             <Calendar.Cell
               v-for="weekDate in weekDates"

--- a/src/runtime/components/InputDate.vue
+++ b/src/runtime/components/InputDate.vue
@@ -9,8 +9,8 @@ import theme from '#build/b24ui/input-date'
 
 type InputDate = ComponentConfig<typeof theme, AppConfig, 'inputDate'>
 
-type _DateFieldRootProps = Omit<DateFieldRootProps, 'as' | 'asChild' | 'modelValue' | 'defaultValue' | 'dir' | 'locale'>
-type _RangeDateFieldRootProps = Omit<DateRangeFieldRootProps, 'as' | 'asChild' | 'modelValue' | 'defaultValue' | 'dir' | 'locale'>
+type _DateFieldRootProps = Omit<DateFieldRootProps, 'as' | 'asChild' | 'modelValue' | 'defaultValue' | 'dir'>
+type _RangeDateFieldRootProps = Omit<DateRangeFieldRootProps, 'as' | 'asChild' | 'modelValue' | 'defaultValue' | 'dir'>
 
 type InputDateDefaultValue<R extends boolean = false> = R extends true ? DateRangeFieldRootProps['defaultValue'] : DateFieldRootProps['defaultValue']
 type InputDateModelValue<R extends boolean = false> = (R extends true ? DateRangeFieldRootProps['modelValue'] : DateFieldRootProps['modelValue']) | undefined

--- a/src/runtime/components/InputNumber.vue
+++ b/src/runtime/components/InputNumber.vue
@@ -16,7 +16,7 @@ type ApplyModifiers<T extends InputNumberValue, Mod extends Pick<ModelModifiers,
   = | T
     | (Mod extends { optional: true } ? undefined : never)
 
-export interface InputNumberProps<T extends InputNumberValue = InputNumberValue, Mod extends Pick<ModelModifiers, 'optional'> = Pick<ModelModifiers, 'optional'>> extends Pick<NumberFieldRootProps, | 'min' | 'max' | 'step' | 'stepSnapping' | 'disabled' | 'required' | 'id' | 'name' | 'formatOptions' | 'disableWheelChange' | 'invertWheelChange' | 'readonly' | 'focusOnChange'>, /** @vue-ignore */ Omit<InputHTMLAttributes, 'disabled' | 'min' | 'max' | 'readonly' | 'required' | 'step' | 'name' | 'placeholder' | 'type' | 'autofocus' | 'maxlength' | 'minlength' | 'pattern' | 'size'> {
+export interface InputNumberProps<T extends InputNumberValue = InputNumberValue, Mod extends Pick<ModelModifiers, 'optional'> = Pick<ModelModifiers, 'optional'>> extends Pick<NumberFieldRootProps, | 'min' | 'max' | 'step' | 'stepSnapping' | 'disabled' | 'required' | 'id' | 'name' | 'formatOptions' | 'disableWheelChange' | 'invertWheelChange' | 'readonly' | 'focusOnChange' | 'locale'>, /** @vue-ignore */ Omit<InputHTMLAttributes, 'disabled' | 'min' | 'max' | 'readonly' | 'required' | 'step' | 'name' | 'placeholder' | 'type' | 'autofocus' | 'maxlength' | 'minlength' | 'pattern' | 'size'> {
   /**
    * The element or component this component should render as.
    * @defaultValue 'div'
@@ -139,7 +139,7 @@ const modelValue = useVModel<InputNumberProps<T, Mod>, 'modelValue', 'update:mod
 const { t } = useLocale()
 const appConfig = useAppConfig() as InputNumber['AppConfig']
 
-const rootProps = useForwardProps(reactivePick(props, 'as', 'stepSnapping', 'formatOptions', 'disableWheelChange', 'invertWheelChange', 'required', 'readonly', 'focusOnChange'), emits)
+const rootProps = useForwardProps(reactivePick(props, 'as', 'stepSnapping', 'formatOptions', 'disableWheelChange', 'invertWheelChange', 'required', 'readonly', 'focusOnChange', 'locale'), emits)
 
 const { emitFormBlur, emitFormFocus, emitFormChange, emitFormInput, id, color, size: formFieldSize, name, highlight, disabled, ariaAttrs } = useFormField<InputNumberProps<T, Mod>>(_props)
 const { orientation, size: fieldGroupSize } = useFieldGroup<InputNumberProps<T, Mod>>(_props)

--- a/src/runtime/components/InputTime.vue
+++ b/src/runtime/components/InputTime.vue
@@ -17,8 +17,8 @@ type InputTimeModelValue<R extends boolean = false> = (R extends true
   ? TimeRangeFieldRootProps['modelValue']
   : TimeFieldRootProps['modelValue']) | undefined
 
-type _TimeFieldRootProps = Omit<TimeFieldRootProps, 'as' | 'asChild' | 'modelValue' | 'defaultValue' | 'dir' | 'locale'>
-type _TimeRangeFieldRootProps = Omit<TimeRangeFieldRootProps, 'as' | 'asChild' | 'modelValue' | 'defaultValue' | 'dir' | 'locale'>
+type _TimeFieldRootProps = Omit<TimeFieldRootProps, 'as' | 'asChild' | 'modelValue' | 'defaultValue' | 'dir'>
+type _TimeRangeFieldRootProps = Omit<TimeRangeFieldRootProps, 'as' | 'asChild' | 'modelValue' | 'defaultValue' | 'dir'>
 
 /**
  * @memo: we not use variant


### PR DESCRIPTION
Port of upstream nuxt/ui [`ed2f955f`](https://github.com/nuxt/ui/commit/ed2f955f092b6213ba2c3a4750260433f0edc2c6) — `fix(InputNumber/InputDate/InputTime/Calendar): restore `locale` prop (#6546)`.

## Problem
A prior refactor accidentally dropped the `locale` prop from these date/number components. This restores it.

## Changes
- **Calendar.vue**: `getWeekNumber(weekDates[0], props.locale ?? locale.code)`.
- **InputDate.vue**: drop `'locale'` from both root-prop `Omit` lists.
- **InputTime.vue**: drop `'locale'` from both root-prop `Omit` lists.
- **InputNumber.vue**: add `'locale'` to the `Pick<NumberFieldRootProps, …>` and to the `reactivePick(props, …)` forwarded as `rootProps`.

**Divergence note:** b24ui's `Calendar.vue` Omit lists **already lacked `'locale'`** (so it was already a prop there) — only the `getWeekNumber` edit was needed for Calendar; the other three matched upstream's pre-fix state and got the full edit.

## Verification (pnpm 11.5.0, gate ON)
frozen install · dev:prepare · lint · **typecheck** · test (**4988 passed**, 6 skipped) · module build — all green. Type-only/prop-forwarding change → no snapshot churn.

Ledger: records the merge sha for the previous port (#156, `9afaeb2d`) and advances the sync cursor to `ed2f955f`.

https://claude.ai/code/session_01Qz7EXMncvEGiCj4WbmYgJo

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qz7EXMncvEGiCj4WbmYgJo)_