### PR TITLE
chore(deps): update vite

### DIFF
--- a/.sync/log/ee996542e51d2b2b7e8fc3373d3eadd07b8f3877.md
+++ b/.sync/log/ee996542e51d2b2b7e8fc3373d3eadd07b8f3877.md
@@ -1,0 +1,32 @@
+# Port: chore(deps): update vite (#6530)
+
+**Upstream:** `ee996542e51d2b2b7e8fc3373d3eadd07b8f3877` (nuxt/ui)
+**Decision:** port
+
+## Upstream change
+- root `package.json`: `vue` ^3.5.34 → ^3.5.35.
+- `playgrounds/repl`: `vue` ^3.5.34 → ^3.5.35, `vite` ^7.3.3 → ^7.3.5.
+- `playgrounds/vue`: `vue` ^3.5.34 → ^3.5.35, `vue-router` ^5.0.7 → ^5.1.0,
+  `vite` ^7.3.3 → ^7.3.5.
+- lockfile regen.
+
+## b24ui adaptation
+Direct 1:1 bump — b24ui pins the same versions in the same manifests:
+- root `package.json`: `vue` → ^3.5.35.
+- `playgrounds/repl`: `vue` → ^3.5.35, `vite` → ^7.3.5.
+- `playgrounds/vue`: `vue` → ^3.5.35, `vue-router` → ^5.1.0, `vite` → ^7.3.5.
+- lockfile regen under the active minimumReleaseAge gate.
+
+Notes:
+- `playgrounds/nuxt` and `playgrounds/demo` don't pin `vue`/`vite`/`vue-router`
+  directly (they go through `nuxt`), so the playground-mirroring invariant
+  doesn't add anything here.
+- root `vue-router` is only a peerDependency range (`^4.5.0 || ^5.0.0`),
+  untouched by upstream — left as is.
+
+## Verification (pnpm 11.5.0, gate ON)
+frozen install · dev:prepare · lint · typecheck · test (4994 passed, 6
+skipped) · module build — all green.
+
+Platform note: b24ui CI is `ubuntu-latest` only; dep bump.
+First port to run on the faster PR CI (playground builds moved to deploy/release in #160).

--- a/.sync/nuxt-ui.json
+++ b/.sync/nuxt-ui.json
@@ -2,7 +2,7 @@
   "upstream": "nuxt/ui",
   "branch": "v4",
   "sync_enabled": false,
-  "cursor": "5c8343041c8ed92f7f10c4bc3eb0ed111e8e7aaf",
+  "cursor": "ee996542e51d2b2b7e8fc3373d3eadd07b8f3877",
   "_cursor_note": "cursor = last upstream commit ported into b24ui (oldest-first, manual cadence). sync_enabled stays false until Phase 2 (porter workflow #67 + CLAUDE_CODE_OAUTH_TOKEN) is wired and trusted. `processed` is maintained per port from now on (backfilled #68-#72 on 2026-06-09).",
   "stats": {
     "queue_depth": 0,
@@ -377,10 +377,16 @@
       "summary": "fix(InputNumber/InputDate/InputTime/Calendar): restore locale prop (#6546) — drop 'locale' from Omit lists in InputDate/InputTime (both root-prop types) and Calendar getWeekNumber uses props.locale??locale.code; InputNumber adds 'locale' to Pick<NumberFieldRootProps> + reactivePick rootProps. b24ui Calendar Omit lists already lacked 'locale' (only getWeekNumber edit needed there)"
     },
     "5c8343041c8ed92f7f10c4bc3eb0ed111e8e7aaf": {
+      "pr": 161,
+      "b24ui_sha": "8545b9d8",
+      "decision": "port",
+      "summary": "chore(deps): update nuxt framework to ^4.4.7 (#6549) — nuxt/@nuxt/kit/@nuxt/schema ^4.4.6->^4.4.7 (root/docs/playgrounds nuxt+demo mirrored; repl/vue don't pin); @nuxt/kit override ^4.4.7; lockfile regen (resolved already 4.4.8). No-ops already in b24ui: h3:1.15.11 override present, docs a11y block absent (@nuxt/a11y dropped #120), LinkBase href string|null applied #117"
+    },
+    "ee996542e51d2b2b7e8fc3373d3eadd07b8f3877": {
       "pr": null,
       "b24ui_sha": "pending-merge",
       "decision": "port",
-      "summary": "chore(deps): update nuxt framework to ^4.4.7 (#6549) — nuxt/@nuxt/kit/@nuxt/schema ^4.4.6->^4.4.7 (root/docs/playgrounds nuxt+demo mirrored; repl/vue don't pin); @nuxt/kit override ^4.4.7; lockfile regen (resolved already 4.4.8). No-ops already in b24ui: h3:1.15.11 override present, docs a11y block absent (@nuxt/a11y dropped #120), LinkBase href string|null applied #117"
+      "summary": "chore(deps): update vite (#6530) — vue ^3.5.34->^3.5.35 (root + repl + vue playgrounds); vite ^7.3.3->^7.3.5 (repl + vue); vue-router ^5.0.7->^5.1.0 (vue playground). nuxt/demo don't pin these (via nuxt); root vue-router is peer range, untouched. lockfile regen under gate"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -218,7 +218,7 @@
     "vitest": "^4.1.7",
     "vitest-axe": "^0.1.0",
     "vitest-environment-nuxt": "^2.0.0",
-    "vue": "^3.5.34",
+    "vue": "^3.5.35",
     "vue-tsc": "^3.3.3",
     "@types/canvas-confetti": "^1.9.0",
     "@types/node": "^25.3.0"

--- a/playgrounds/repl/package.json
+++ b/playgrounds/repl/package.json
@@ -12,10 +12,10 @@
     "@bitrix24/b24ui-nuxt": "workspace:*",
     "@vue/repl": "^4.7.2",
     "tailwindcss": "^4.3.0",
-    "vue": "^3.5.34"
+    "vue": "^3.5.35"
   },
   "devDependencies": {
     "@vitejs/plugin-vue": "^6.0.7",
-    "vite": "^7.3.3"
+    "vite": "^7.3.5"
   }
 }

--- a/playgrounds/vue/package.json
+++ b/playgrounds/vue/package.json
@@ -16,15 +16,15 @@
     "@tiptap/extension-text-align": "^3.24.0",
     "@internationalized/date": "^3.9.0",
     "tailwindcss": "^4.3.0",
-    "vue": "^3.5.34",
-    "vue-router": "^5.0.7",
+    "vue": "^3.5.35",
+    "vue-router": "^5.1.0",
     "zod": "^4.4.3",
     "maska": "^3.2.0"
   },
   "devDependencies": {
     "@vitejs/plugin-vue": "^6.0.7",
     "typescript": "^6.0.3",
-    "vite": "^7.3.3",
+    "vite": "^7.3.5",
     "vue-tsc": "^3.3.3"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -291,7 +291,7 @@ importers:
         specifier: ^2.0.0
         version: 2.0.0(@vue/test-utils@2.4.10(@vue/compiler-dom@3.5.38)(@vue/server-renderer@3.5.38(vue@3.5.38(typescript@6.0.3)))(vue@3.5.38(typescript@6.0.3)))(crossws@0.4.5(srvx@0.11.15))(happy-dom@20.9.0)(magicast@0.5.3)(typescript@6.0.3)(vite@7.3.5(@types/node@25.6.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.1)(yaml@2.9.0))(vitest@4.1.8(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(happy-dom@20.9.0)(vite@7.3.5(@types/node@25.6.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.1)(yaml@2.9.0)))
       vue:
-        specifier: ^3.5.34
+        specifier: ^3.5.35
         version: 3.5.38(typescript@6.0.3)
       vue-tsc:
         specifier: ^3.3.3
@@ -582,14 +582,14 @@ importers:
         specifier: ^4.3.0
         version: 4.3.0
       vue:
-        specifier: ^3.5.34
+        specifier: ^3.5.35
         version: 3.5.38(typescript@6.0.3)
     devDependencies:
       '@vitejs/plugin-vue':
         specifier: ^6.0.7
         version: 6.0.7(vite@7.3.5(@types/node@25.6.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.1)(yaml@2.9.0))(vue@3.5.38(typescript@6.0.3))
       vite:
-        specifier: ^7.3.3
+        specifier: ^7.3.5
         version: 7.3.5(@types/node@25.6.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.1)(yaml@2.9.0)
 
   playgrounds/vue:
@@ -616,10 +616,10 @@ importers:
         specifier: ^4.3.0
         version: 4.3.0
       vue:
-        specifier: ^3.5.34
+        specifier: ^3.5.35
         version: 3.5.38(typescript@6.0.3)
       vue-router:
-        specifier: ^5.0.7
+        specifier: ^5.1.0
         version: 5.1.0(@vue/compiler-sfc@3.5.38)(vite@7.3.5(@types/node@25.6.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.1)(yaml@2.9.0))(vue@3.5.38(typescript@6.0.3))
       zod:
         specifier: ^4.4.3
@@ -632,7 +632,7 @@ importers:
         specifier: ^6.0.3
         version: 6.0.3
       vite:
-        specifier: ^7.3.3
+        specifier: ^7.3.5
         version: 7.3.5(@types/node@25.6.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.1)(yaml@2.9.0)
       vue-tsc:
         specifier: ^3.3.3


### PR DESCRIPTION
Port of upstream nuxt/ui [`ee996542`](https://github.com/nuxt/ui/commit/ee996542e51d2b2b7e8fc3373d3eadd07b8f3877) — `chore(deps): update vite (#6530)`.

## Changes
- `vue` `^3.5.34` → `^3.5.35` — root `package.json`, `playgrounds/repl`, `playgrounds/vue`
- `vite` `^7.3.3` → `^7.3.5` — `playgrounds/repl`, `playgrounds/vue`
- `vue-router` `^5.0.7` → `^5.1.0` — `playgrounds/vue`
- lockfile regen under the active `minimumReleaseAge` gate

`playgrounds/nuxt` and `playgrounds/demo` don't pin these directly (they go through `nuxt`); root `vue-router` is only a peerDependency range (`^4.5.0 || ^5.0.0`) and is left untouched.

## Verification (pnpm 11.5.0, gate ON)
frozen install · dev:prepare · lint · typecheck · test (**4994 passed**, 6 skipped) · module build — all green.

Ledger: records the merge sha for the previous port (#161, `5c834304`) and advances the sync cursor to `ee996542`.

https://claude.ai/code/session_01Qz7EXMncvEGiCj4WbmYgJo

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qz7EXMncvEGiCj4WbmYgJo)_