### PR TITLE
chore(deps): update reka-ui to v2.9.9

### DIFF
--- a/.sync/log/c354247d5550ba32c69fcb5b24203dee4a851b0c.md
+++ b/.sync/log/c354247d5550ba32c69fcb5b24203dee4a851b0c.md
@@ -1,0 +1,20 @@
+# Port: chore(deps): update reka-ui to v2.9.9 (#6556)
+
+**Upstream:** `c354247d5550ba32c69fcb5b24203dee4a851b0c` (nuxt/ui)
+**Decision:** port
+
+## Upstream change
+root `package.json`: `reka-ui` `2.9.8` → `2.9.9` (exact pin) + lockfile regen.
+
+## b24ui adaptation
+Direct 1:1 bump — b24ui pins `reka-ui` at the same exact version in root
+`package.json`.
+- `reka-ui` `2.9.8` → `2.9.9`.
+- lockfile regen under the active minimumReleaseAge gate (resolves to `2.9.9`;
+  2.9.10 exists but we hold the same exact pin as upstream).
+
+## Verification (pnpm 11.5.0, gate ON)
+frozen install · dev:prepare · lint · typecheck · test (4994 passed, 6
+skipped) · module build — all green.
+
+Platform note: b24ui CI is `ubuntu-latest` only; dep bump.

--- a/.sync/nuxt-ui.json
+++ b/.sync/nuxt-ui.json
@@ -2,7 +2,7 @@
   "upstream": "nuxt/ui",
   "branch": "v4",
   "sync_enabled": false,
-  "cursor": "ee996542e51d2b2b7e8fc3373d3eadd07b8f3877",
+  "cursor": "c354247d5550ba32c69fcb5b24203dee4a851b0c",
   "_cursor_note": "cursor = last upstream commit ported into b24ui (oldest-first, manual cadence). sync_enabled stays false until Phase 2 (porter workflow #67 + CLAUDE_CODE_OAUTH_TOKEN) is wired and trusted. `processed` is maintained per port from now on (backfilled #68-#72 on 2026-06-09).",
   "stats": {
     "queue_depth": 0,
@@ -383,10 +383,16 @@
       "summary": "chore(deps): update nuxt framework to ^4.4.7 (#6549) — nuxt/@nuxt/kit/@nuxt/schema ^4.4.6->^4.4.7 (root/docs/playgrounds nuxt+demo mirrored; repl/vue don't pin); @nuxt/kit override ^4.4.7; lockfile regen (resolved already 4.4.8). No-ops already in b24ui: h3:1.15.11 override present, docs a11y block absent (@nuxt/a11y dropped #120), LinkBase href string|null applied #117"
     },
     "ee996542e51d2b2b7e8fc3373d3eadd07b8f3877": {
+      "pr": 162,
+      "b24ui_sha": "5e5a1100",
+      "decision": "port",
+      "summary": "chore(deps): update vite (#6530) — vue ^3.5.34->^3.5.35 (root + repl + vue playgrounds); vite ^7.3.3->^7.3.5 (repl + vue); vue-router ^5.0.7->^5.1.0 (vue playground). nuxt/demo don't pin these (via nuxt); root vue-router is peer range, untouched. lockfile regen under gate"
+    },
+    "c354247d5550ba32c69fcb5b24203dee4a851b0c": {
       "pr": null,
       "b24ui_sha": "pending-merge",
       "decision": "port",
-      "summary": "chore(deps): update vite (#6530) — vue ^3.5.34->^3.5.35 (root + repl + vue playgrounds); vite ^7.3.3->^7.3.5 (repl + vue); vue-router ^5.0.7->^5.1.0 (vue playground). nuxt/demo don't pin these (via nuxt); root vue-router is peer range, untouched. lockfile regen under gate"
+      "summary": "chore(deps): update reka-ui to v2.9.9 (#6556) — direct 1:1 exact-version bump in root package.json (2.9.8->2.9.9); lockfile regen under gate (resolves 2.9.9; held same exact pin as upstream though 2.9.10 exists)"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -189,7 +189,7 @@
     "motion-v": "^2.2.1",
     "ohash": "^2.0.11",
     "pathe": "^2.0.3",
-    "reka-ui": "2.9.8",
+    "reka-ui": "2.9.9",
     "scule": "^1.3.0",
     "tailwind-merge": "^3.6.0",
     "tailwind-variants": "^3.2.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -185,8 +185,8 @@ importers:
         specifier: ^2.0.3
         version: 2.0.3
       reka-ui:
-        specifier: 2.9.8
-        version: 2.9.8(vue@3.5.38(typescript@6.0.3))
+        specifier: 2.9.9
+        version: 2.9.9(vue@3.5.38(typescript@6.0.3))
       scule:
         specifier: ^1.3.0
         version: 1.3.0
@@ -225,7 +225,7 @@ importers:
         version: 1.4.1(typescript@6.0.3)
       vaul-vue:
         specifier: 0.4.1
-        version: 0.4.1(reka-ui@2.9.8(vue@3.5.38(typescript@6.0.3)))(vue@3.5.38(typescript@6.0.3))
+        version: 0.4.1(reka-ui@2.9.9(vue@3.5.38(typescript@6.0.3)))(vue@3.5.38(typescript@6.0.3))
       vue-component-type-helpers:
         specifier: ^3.3.3
         version: 3.3.4
@@ -7167,8 +7167,8 @@ packages:
     peerDependencies:
       vue: '>= 3.4.0'
 
-  reka-ui@2.9.8:
-    resolution: {integrity: sha512-7dxaBJ6nQ0zOQZXPV45219tTEgZPstmihBLS9ABPhSiPiJ8SiF0sacfZHFaBptS0v9N4tzsevq+8MNBpE4p5JQ==}
+  reka-ui@2.9.9:
+    resolution: {integrity: sha512-/e+hdF9vP8E2kPrKR4RdgMQQsfpCr8l436Zn8GRWM3jKT9EG1lOO/UFMGBVEnrMLOVoJSjjmIFrej4tMOb+6qQ==}
     peerDependencies:
       vue: '>= 3.4.0'
 
@@ -15940,7 +15940,7 @@ snapshots:
     transitivePeerDependencies:
       - '@vue/composition-api'
 
-  reka-ui@2.9.8(vue@3.5.38(typescript@6.0.3)):
+  reka-ui@2.9.9(vue@3.5.38(typescript@6.0.3)):
     dependencies:
       '@floating-ui/dom': 1.7.6
       '@floating-ui/vue': 1.1.11(vue@3.5.38(typescript@6.0.3))
@@ -16967,10 +16967,10 @@ snapshots:
     transitivePeerDependencies:
       - '@vue/composition-api'
 
-  vaul-vue@0.4.1(reka-ui@2.9.8(vue@3.5.38(typescript@6.0.3)))(vue@3.5.38(typescript@6.0.3)):
+  vaul-vue@0.4.1(reka-ui@2.9.9(vue@3.5.38(typescript@6.0.3)))(vue@3.5.38(typescript@6.0.3)):
     dependencies:
       '@vueuse/core': 10.11.1(vue@3.5.38(typescript@6.0.3))
-      reka-ui: 2.9.8(vue@3.5.38(typescript@6.0.3))
+      reka-ui: 2.9.9(vue@3.5.38(typescript@6.0.3))
       vue: 3.5.38(typescript@6.0.3)
     transitivePeerDependencies:
       - '@vue/composition-api'


### PR DESCRIPTION
Port of upstream nuxt/ui [`c354247d`](https://github.com/nuxt/ui/commit/c354247d5550ba32c69fcb5b24203dee4a851b0c) — `chore(deps): update reka-ui to v2.9.9 (#6556)`.

## Changes
- `reka-ui` `2.9.8` → `2.9.9` (exact pin, root `package.json`) — b24ui pins the same exact version.
- lockfile regen under the active `minimumReleaseAge` gate (resolves to `2.9.9`; 2.9.10 exists but we hold the same exact pin as upstream).

## Verification (pnpm 11.5.0, gate ON)
frozen install · dev:prepare · lint · typecheck · test (**4994 passed**, 6 skipped) · module build — all green.

Ledger: records the merge sha for the previous port (#162, `ee996542`) and advances the sync cursor to `c354247d`.

https://claude.ai/code/session_01Qz7EXMncvEGiCj4WbmYgJo

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qz7EXMncvEGiCj4WbmYgJo)_