### PR TITLE
chore(sync): record upstream v4.8.2 release as no-op

### DIFF
--- a/.sync/log/d6341d559c191558bf7fc5e613023b0589047c07.md
+++ b/.sync/log/d6341d559c191558bf7fc5e613023b0589047c07.md
@@ -1,0 +1,20 @@
+# Port: chore(release): v4.8.2
+
+**Upstream:** `d6341d559c191558bf7fc5e613023b0589047c07` (nuxt/ui)
+**Decision:** no-op
+
+## Upstream change
+Upstream release commit: bumps `@nuxt/ui` `version` 4.8.1 → 4.8.2 in
+`package.json` and prepends the v4.8.2 section to `CHANGELOG.md` (aggregating
+#6539/#6538/#6546/#6531 — all already ported as b24ui #153/#155/#157/#149).
+
+## b24ui adaptation — n/a
+b24ui ships under its own package name `@bitrix24/b24ui-nuxt` and versions
+independently (currently `2.8.0`) with its own `CHANGELOG.md`. Upstream's
+version/changelog maintenance for the `@nuxt/ui` package doesn't map. Same
+rationale as the prior upstream release bumps #124 (v4.8.0) and #142 (v4.8.1).
+
+(The b24ui release itself — version bump + changelog + tag — is cut separately
+on its own cadence, independent of this sync stream.)
+
+No file change — bookkeeping only.

--- a/.sync/nuxt-ui.json
+++ b/.sync/nuxt-ui.json
@@ -2,7 +2,7 @@
   "upstream": "nuxt/ui",
   "branch": "v4",
   "sync_enabled": false,
-  "cursor": "c550912da7fac862a1c51e2e356493ca5b4863b5",
+  "cursor": "d6341d559c191558bf7fc5e613023b0589047c07",
   "_cursor_note": "cursor = last upstream commit ported into b24ui (oldest-first, manual cadence). sync_enabled stays false until Phase 2 (porter workflow #67 + CLAUDE_CODE_OAUTH_TOKEN) is wired and trusted. `processed` is maintained per port from now on (backfilled #68-#72 on 2026-06-09).",
   "stats": {
     "queue_depth": 0,
@@ -395,10 +395,16 @@
       "summary": "chore(deps): update reka-ui to v2.9.9 (#6556) — direct 1:1 exact-version bump in root package.json (2.9.8->2.9.9); lockfile regen under gate (resolves 2.9.9; held same exact pin as upstream though 2.9.10 exists)"
     },
     "c550912da7fac862a1c51e2e356493ca5b4863b5": {
+      "pr": 164,
+      "b24ui_sha": "504ffb78",
+      "decision": "noop",
+      "summary": "chore: ignore .claude dir (#6555) — n/a: upstream adds a blanket `.claude` to .gitignore. b24ui deliberately manages .claude granularly (ignores .claude/settings.local.json, channels/, debug/, /.claude/skills/b24-ui-nuxt/) to keep the rest trackable; a blanket ignore would over-ignore. .cursor sibling already ported in #135"
+    },
+    "d6341d559c191558bf7fc5e613023b0589047c07": {
       "pr": null,
       "b24ui_sha": "pending-merge",
       "decision": "noop",
-      "summary": "chore: ignore .claude dir (#6555) — n/a: upstream adds a blanket `.claude` to .gitignore. b24ui deliberately manages .claude granularly (ignores .claude/settings.local.json, channels/, debug/, /.claude/skills/b24-ui-nuxt/) to keep the rest trackable; a blanket ignore would over-ignore. .cursor sibling already ported in #135"
+      "summary": "chore(release): v4.8.2 — n/a: upstream @nuxt/ui version bump 4.8.1->4.8.2 + CHANGELOG (aggregates #6539/#6538/#6546/#6531, already ported as b24ui #153/#155/#157/#149). b24ui versions independently (@bitrix24/b24ui-nuxt, own changelog). Same as #124 (v4.8.0) / #142 (v4.8.1)"
     }
   }
 }


### PR DESCRIPTION
Port of upstream nuxt/ui [`d6341d55`](https://github.com/nuxt/ui/commit/d6341d559c191558bf7fc5e613023b0589047c07) — `chore(release): v4.8.2`.

## Decision: no-op

Upstream release commit bumps `@nuxt/ui` `version` 4.8.1 → 4.8.2 and prepends the v4.8.2 section to `CHANGELOG.md` (aggregating #6539 / #6538 / #6546 / #6531 — all already ported as b24ui #153 / #155 / #157 / #149).

b24ui ships under its own package name `@bitrix24/b24ui-nuxt` and versions independently (currently `2.8.0`) with its own `CHANGELOG.md`, so upstream's package version/changelog maintenance doesn't map. Same rationale as #124 (v4.8.0) and #142 (v4.8.1). The b24ui release itself is cut separately on its own cadence.

## Changes
Bookkeeping only — `.sync/` ledger + log entry. Records the merge sha for the previous port (#164, `c550912d`) and advances the sync cursor to `d6341d55`.

https://claude.ai/code/session_01Qz7EXMncvEGiCj4WbmYgJo

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qz7EXMncvEGiCj4WbmYgJo)_