### PR TITLE
feat(Select/SelectMenu): use `multiple` in theme

### DIFF
--- a/.sync/log/f66eb65f5cb80e245491a6de75d9bb3b175be011.md
+++ b/.sync/log/f66eb65f5cb80e245491a6de75d9bb3b175be011.md
@@ -1,0 +1,29 @@
+# Port: feat(Select/SelectMenu): use `multiple` in theme (#6554)
+
+**Upstream:** `f66eb65f5cb80e245491a6de75d9bb3b175be011` (nuxt/ui)
+**Decision:** port
+
+## Upstream change
+Exposes the `multiple` state to the theme so it can be styled:
+- `Select.vue`: pass `multiple: props.multiple` into the `ui` computed.
+- `SelectMenu.vue`: pass `multiple: props.multiple` into the `ui` computed.
+- `src/theme/select.ts`: add an empty `multiple: { true: '' }` variant (a
+  styling hook for users / AppConfig).
+
+## b24ui adaptation
+Same three edits, b24ui-namespaced (`b24ui` computed instead of `ui`):
+- `Select.vue`: add `multiple: props.multiple` after `position: position.value`.
+- `SelectMenu.vue`: add `multiple: props.multiple` after `virtualize: !!props.virtualize`.
+- `src/theme/select.ts`: add `multiple: { true: '' }` as a sibling of the
+  `position` variant.
+
+As upstream, only `select.ts` gets the variant: b24ui's `select-menu.ts`
+merges the select theme (`defuFn({ … }, select())`), so SelectMenu inherits
+the new `multiple` variant — no separate edit to `select-menu.ts` needed.
+
+## Verification (pnpm 11.5.0, gate ON)
+frozen install · dev:prepare · lint · typecheck · test (4994 passed, 6
+skipped) · module build — all green. The variant value is empty (`true: ''`),
+so there is no rendered-output change → no snapshot churn.
+
+Platform note: b24ui CI is `ubuntu-latest` only.

--- a/.sync/nuxt-ui.json
+++ b/.sync/nuxt-ui.json
@@ -2,7 +2,7 @@
   "upstream": "nuxt/ui",
   "branch": "v4",
   "sync_enabled": false,
-  "cursor": "d6341d559c191558bf7fc5e613023b0589047c07",
+  "cursor": "f66eb65f5cb80e245491a6de75d9bb3b175be011",
   "_cursor_note": "cursor = last upstream commit ported into b24ui (oldest-first, manual cadence). sync_enabled stays false until Phase 2 (porter workflow #67 + CLAUDE_CODE_OAUTH_TOKEN) is wired and trusted. `processed` is maintained per port from now on (backfilled #68-#72 on 2026-06-09).",
   "stats": {
     "queue_depth": 0,
@@ -401,10 +401,16 @@
       "summary": "chore: ignore .claude dir (#6555) — n/a: upstream adds a blanket `.claude` to .gitignore. b24ui deliberately manages .claude granularly (ignores .claude/settings.local.json, channels/, debug/, /.claude/skills/b24-ui-nuxt/) to keep the rest trackable; a blanket ignore would over-ignore. .cursor sibling already ported in #135"
     },
     "d6341d559c191558bf7fc5e613023b0589047c07": {
-      "pr": null,
-      "b24ui_sha": "pending-merge",
+      "pr": 165,
+      "b24ui_sha": "5202a7ed",
       "decision": "noop",
       "summary": "chore(release): v4.8.2 — n/a: upstream @nuxt/ui version bump 4.8.1->4.8.2 + CHANGELOG (aggregates #6539/#6538/#6546/#6531, already ported as b24ui #153/#155/#157/#149). b24ui versions independently (@bitrix24/b24ui-nuxt, own changelog). Same as #124 (v4.8.0) / #142 (v4.8.1)"
+    },
+    "f66eb65f5cb80e245491a6de75d9bb3b175be011": {
+      "pr": null,
+      "b24ui_sha": "pending-merge",
+      "decision": "port",
+      "summary": "feat(Select/SelectMenu): use multiple in theme (#6554) — pass multiple:props.multiple into the b24ui computed in Select.vue + SelectMenu.vue; add empty multiple:{true:''} variant to theme/select.ts (styling hook). select-menu.ts merges select() via defuFn so it inherits the variant (only select.ts edited, mirroring upstream). Empty variant -> no snapshot churn"
     }
   }
 }

--- a/src/runtime/components/Select.vue
+++ b/src/runtime/components/Select.vue
@@ -237,7 +237,8 @@ const b24ui = computed(() => tv({ extend: tv(theme), ...(appConfig.b24ui?.select
   leading: Boolean(isLeading.value || !!props.avatar || !!slots.leading),
   trailing: Boolean(isTrailing.value || !!slots.trailing),
   fieldGroup: orientation.value,
-  position: position.value
+  position: position.value,
+  multiple: props.multiple
 }))
 
 const groups = computed<SelectItem[][]>(() =>

--- a/src/runtime/components/SelectMenu.vue
+++ b/src/runtime/components/SelectMenu.vue
@@ -349,7 +349,8 @@ const b24ui = computed(() => tv({ extend: tv(theme), ...(appConfig.b24ui?.select
   leading: Boolean(isLeading.value || !!props.avatar || !!slots.leading),
   trailing: Boolean(isTrailing.value || !!slots.trailing),
   fieldGroup: orientation.value,
-  virtualize: !!props.virtualize
+  virtualize: !!props.virtualize,
+  multiple: props.multiple
 }))
 
 function displayValue(value: GetItemValue<T, VK, ExcludeItem> | GetItemValue<T, VK, ExcludeItem>[]): string | undefined {

--- a/src/theme/select.ts
+++ b/src/theme/select.ts
@@ -190,6 +190,9 @@ export default () => {
             content: '',
             viewport: 'w-full'
           }
+        },
+        multiple: {
+          true: ''
         }
       },
       compoundVariants: (prev: Record<string, any>[]) => {


### PR DESCRIPTION
Port of upstream nuxt/ui [`f66eb65f`](https://github.com/nuxt/ui/commit/f66eb65f5cb80e245491a6de75d9bb3b175be011) — `feat(Select/SelectMenu): use `multiple` in theme (#6554)`.

## Changes
Exposes the `multiple` state to the theme so it can be styled:
- **`Select.vue`** / **`SelectMenu.vue`**: pass `multiple: props.multiple` into the `b24ui` computed.
- **`theme/select.ts`**: add an empty `multiple: { true: '' }` variant (a styling hook for users / AppConfig).

As upstream, only `select.ts` gets the variant: b24ui's `select-menu.ts` merges the select theme (`defuFn({ … }, select())`), so SelectMenu inherits the new `multiple` variant automatically.

## Verification (pnpm 11.5.0, gate ON)
frozen install · dev:prepare · lint · typecheck · test (**4994 passed**, 6 skipped) · module build — all green. The variant value is empty (`true: ''`), so there's no rendered-output change → no snapshot churn.

Ledger: records the merge sha for the previous port (#165, `d6341d55`) and advances the sync cursor to `f66eb65f`.

https://claude.ai/code/session_01Qz7EXMncvEGiCj4WbmYgJo

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qz7EXMncvEGiCj4WbmYgJo)_