### PR TITLE
feat(locale): add Latvian language

### DIFF
--- a/.sync/log/fa5253825258dfb7e543dd84452602979b329703.md
+++ b/.sync/log/fa5253825258dfb7e543dd84452602979b329703.md
@@ -1,0 +1,32 @@
+# Port: feat(locale): add Latvian language (#6552)
+
+**Upstream:** `fa5253825258dfb7e543dd84452602979b329703` (nuxt/ui)
+**Decision:** port
+
+## Upstream change
+New locale `lv` (Latviešu): adds `src/runtime/locale/lv.ts` and exports it
+from `src/runtime/locale/index.ts`.
+
+## b24ui adaptation
+Ported the Latvian translations, reconciled to b24ui's `Messages` shape and
+`defineLocale` contract (which diverge from upstream):
+- **`+ locale: 'lv'`** — b24ui's `DefineLocaleOptions` requires a `locale`
+  (BCP-47) field in addition to `name`/`code` (upstream has only name/code).
+  Typecheck flagged this; added `locale: 'lv'`.
+- **Dropped `listbox`** block — b24ui's `Messages` has no `listbox` key
+  (b24ui has no Listbox component).
+- **Added `sidebarLayout`** block (b24ui-specific top-level key, last in the
+  message object to mirror en.ts), translated to Latvian:
+  open `Atvērt navigāciju`, close `Aizvērt navigāciju`,
+  slideoverTitle `Navigācija`, slideoverDescription `Satura navigācija`.
+- `index.ts`: `export { default as lv } from './lv'` (placed next to `la`,
+  b24ui's own grouping — its index doesn't carry upstream's lt/lb/lo).
+
+All other sections matched b24ui's `Messages` 1:1 (verified by a nested-key
+diff against en.ts; only `sidebarLayout`/`listbox` differed).
+
+## Verification (pnpm 11.5.0, gate ON)
+frozen install · dev:prepare · lint · **typecheck** · test (4994 passed, 6
+skipped) · module build — all green.
+
+Platform note: b24ui CI is `ubuntu-latest` only.

--- a/.sync/nuxt-ui.json
+++ b/.sync/nuxt-ui.json
@@ -2,7 +2,7 @@
   "upstream": "nuxt/ui",
   "branch": "v4",
   "sync_enabled": false,
-  "cursor": "f66eb65f5cb80e245491a6de75d9bb3b175be011",
+  "cursor": "fa5253825258dfb7e543dd84452602979b329703",
   "_cursor_note": "cursor = last upstream commit ported into b24ui (oldest-first, manual cadence). sync_enabled stays false until Phase 2 (porter workflow #67 + CLAUDE_CODE_OAUTH_TOKEN) is wired and trusted. `processed` is maintained per port from now on (backfilled #68-#72 on 2026-06-09).",
   "stats": {
     "queue_depth": 0,
@@ -407,10 +407,16 @@
       "summary": "chore(release): v4.8.2 — n/a: upstream @nuxt/ui version bump 4.8.1->4.8.2 + CHANGELOG (aggregates #6539/#6538/#6546/#6531, already ported as b24ui #153/#155/#157/#149). b24ui versions independently (@bitrix24/b24ui-nuxt, own changelog). Same as #124 (v4.8.0) / #142 (v4.8.1)"
     },
     "f66eb65f5cb80e245491a6de75d9bb3b175be011": {
+      "pr": 166,
+      "b24ui_sha": "ffb0859f",
+      "decision": "port",
+      "summary": "feat(Select/SelectMenu): use multiple in theme (#6554) — pass multiple:props.multiple into the b24ui computed in Select.vue + SelectMenu.vue; add empty multiple:{true:''} variant to theme/select.ts (styling hook). select-menu.ts merges select() via defuFn so it inherits the variant (only select.ts edited, mirroring upstream). Empty variant -> no snapshot churn"
+    },
+    "fa5253825258dfb7e543dd84452602979b329703": {
       "pr": null,
       "b24ui_sha": "pending-merge",
       "decision": "port",
-      "summary": "feat(Select/SelectMenu): use multiple in theme (#6554) — pass multiple:props.multiple into the b24ui computed in Select.vue + SelectMenu.vue; add empty multiple:{true:''} variant to theme/select.ts (styling hook). select-menu.ts merges select() via defuFn so it inherits the variant (only select.ts edited, mirroring upstream). Empty variant -> no snapshot churn"
+      "summary": "feat(locale): add Latvian language (#6552) — add src/runtime/locale/lv.ts + index export. Adapted to b24ui Messages/defineLocale: added required locale:'lv' field, dropped listbox block (no Listbox in b24ui), added b24ui-specific sidebarLayout block in Latvian (Atvērt/Aizvērt navigāciju, Navigācija, Satura navigācija). typecheck-verified"
     }
   }
 }

--- a/src/runtime/locale/index.ts
+++ b/src/runtime/locale/index.ts
@@ -34,6 +34,7 @@ export { default as ms } from './ms'
 export { default as de } from './de'
 export { default as en } from './en'
 export { default as la } from './la'
+export { default as lv } from './lv'
 
 export { default as fr } from './fr'
 export { default as in } from './in'

--- a/src/runtime/locale/lv.ts
+++ b/src/runtime/locale/lv.ts
@@ -1,0 +1,156 @@
+import type { Messages } from '../types'
+import { defineLocale } from '../composables/defineLocale'
+
+export default defineLocale<Messages>({
+  name: 'Latviešu',
+  code: 'lv',
+  locale: 'lv',
+  messages: {
+    alert: {
+      close: 'Aizvērt'
+    },
+    authForm: {
+      hidePassword: 'Paslēpt paroli',
+      showPassword: 'Rādīt paroli',
+      submit: 'Turpināt'
+    },
+    banner: {
+      close: 'Aizvērt'
+    },
+    calendar: {
+      nextMonth: 'Nākamais mēnesis',
+      nextYear: 'Nākamais gads',
+      prevMonth: 'Iepriekšējais mēnesis',
+      prevYear: 'Iepriekšējais gads'
+    },
+    carousel: {
+      dots: 'Izvēlies slaidu, ko rādīt',
+      goto: 'Pāriet uz slaidu {slide}',
+      next: 'Nākamais',
+      prev: 'Iepriekšējais'
+    },
+    chatPrompt: {
+      placeholder: 'Raksti savu ziņu šeit…'
+    },
+    chatPromptSubmit: {
+      label: 'Sūtīt ziņu'
+    },
+    colorMode: {
+      dark: 'Tumšs',
+      light: 'Gaišs',
+      switchToDark: 'Pārslēgt uz tumšo režīmu',
+      switchToLight: 'Pārslēgt uz gaišo režīmu',
+      system: 'Sistēmas'
+    },
+    commandPalette: {
+      back: 'Atpakaļ',
+      close: 'Aizvērt',
+      noData: 'Nav datu',
+      noMatch: 'Nav atbilstošu datu',
+      placeholder: 'Ievadi komandu vai meklē…'
+    },
+    contentSearch: {
+      links: 'Saites',
+      search: 'Rezultāti',
+      theme: 'Tēma'
+    },
+    contentSearchButton: {
+      label: 'Meklēt…'
+    },
+    contentToc: {
+      title: 'Šajā lapā'
+    },
+    dropdownMenu: {
+      noMatch: 'Nav atbilstošu datu',
+      search: 'Meklēt…'
+    },
+    dashboardSearch: {
+      theme: 'Tēma'
+    },
+    dashboardSearchButton: {
+      label: 'Meklēt…'
+    },
+    dashboardSidebarCollapse: {
+      collapse: 'Sakļaut sānjoslu',
+      expand: 'Izvērst sānjoslu'
+    },
+    dashboardSidebarToggle: {
+      close: 'Aizvērt sānjoslu',
+      open: 'Atvērt sānjoslu'
+    },
+    error: {
+      clear: 'Atpakaļ uz sākumlapu'
+    },
+    fileUpload: {
+      removeFile: 'Noņemt {filename}'
+    },
+    header: {
+      close: 'Aizvērt izvēlni',
+      open: 'Atvērt izvēlni'
+    },
+    inputMenu: {
+      create: 'Izveidot "{label}"',
+      noData: 'Nav datu',
+      noMatch: 'Nav atbilstošu datu'
+    },
+    inputNumber: {
+      decrement: 'Samazināt',
+      increment: 'Palielināt'
+    },
+    modal: {
+      close: 'Aizvērt'
+    },
+    pricingTable: {
+      caption: 'Cenu salīdzinājums'
+    },
+    prose: {
+      codeCollapse: {
+        closeText: 'Sakļaut',
+        name: 'kods',
+        openText: 'Izvērst'
+      },
+      collapsible: {
+        closeText: 'Paslēpt',
+        name: 'īpašības',
+        openText: 'Rādīt'
+      },
+      pre: {
+        copy: 'Kopēt kodu'
+      },
+      prompt: {
+        copy: 'Kopēt vaicājumu',
+        openIn: 'Atvērt iekš {name}'
+      }
+    },
+    chatReasoning: {
+      thinking: 'Domā…',
+      thought: 'Domāja',
+      thoughtFor: 'Domāja {duration}'
+    },
+    sidebar: {
+      close: 'Aizvērt',
+      toggle: 'Pārslēgt'
+    },
+    selectMenu: {
+      create: 'Izveidot "{label}"',
+      noData: 'Nav datu',
+      noMatch: 'Nav atbilstošu datu',
+      search: 'Meklēt…'
+    },
+    slideover: {
+      close: 'Aizvērt'
+    },
+    table: {
+      noData: 'Nav datu'
+    },
+    toast: {
+      close: 'Aizvērt'
+    },
+    sidebarLayout: {
+      open: 'Atvērt navigāciju',
+      close: 'Aizvērt navigāciju',
+      slideoverTitle: 'Navigācija',
+      slideoverDescription: 'Satura navigācija'
+    }
+  }
+})


### PR DESCRIPTION
Port of upstream nuxt/ui [`fa525382`](https://github.com/nuxt/ui/commit/fa5253825258dfb7e543dd84452602979b329703) — `feat(locale): add Latvian language (#6552)`.

## Changes
Adds the `lv` (Latviešu) locale: `src/runtime/locale/lv.ts` + export in `src/runtime/locale/index.ts`.

Reconciled to b24ui's `Messages` shape and `defineLocale` contract (which diverge from upstream):
- **`+ locale: 'lv'`** — b24ui's `DefineLocaleOptions` requires a BCP-47 `locale` field beyond `name`/`code` (typecheck flagged this).
- **Dropped the `listbox` block** — b24ui's `Messages` has no `listbox` key (no Listbox component).
- **Added the `sidebarLayout` block** (b24ui-specific top-level key), translated to Latvian: open `Atvērt navigāciju`, close `Aizvērt navigāciju`, slideoverTitle `Navigācija`, slideoverDescription `Satura navigācija`.

All other sections matched b24ui's `Messages` 1:1 (verified via a nested-key diff against `en.ts`).

## Verification (pnpm 11.5.0, gate ON)
frozen install · dev:prepare · lint · **typecheck** · test (**4994 passed**, 6 skipped) · module build — all green.

Ledger: records the merge sha for the previous port (#166, `f66eb65f`) and advances the sync cursor to `fa525382`.

https://claude.ai/code/session_01Qz7EXMncvEGiCj4WbmYgJo

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qz7EXMncvEGiCj4WbmYgJo)_