### PR TITLE
chore(sync): skip upstream Latvian locale; add no-new-locales rule

### DIFF
--- a/.sync/PORTING.md
+++ b/.sync/PORTING.md
@@ -44,6 +44,12 @@ material. Reproduce its *intent* in b24ui by editing files under `src/` only.
   with `node -e "..."` diffing nuxt vs demo (and check vue/repl), then
   regenerate the lockfile once. A dep that exists only in `nuxt` but not `demo`
   (or vice-versa) is fine; a dep present in **both** must not drift.
+- **Locales — do NOT add new ones.** b24ui maintains its own curated locale
+  set and does not adopt new languages from upstream. When an upstream commit
+  adds a locale (a new `src/runtime/locale/<code>.ts` + an `index.ts` export),
+  **skip** it: make no `src` change, record `.sync/log/<sha>.md` with the skip
+  rationale, set the ledger `decision` to `skip`, and close the PR as skipped.
+  (Edits to *existing* b24ui locales still port normally.)
 - **jsDoc on every prop** — keep the description and `@defaultValue`. Never drop
   a jsDoc block to make code compile. (A passing `vue-tsc` is necessary, not
   sufficient.)
@@ -117,3 +123,4 @@ History of the maps lives in git; no separate version field.
 - 2026-06-09 — port of `007b136a` (PR #72): added rule — match the reka **transform-origin / available-height CSS var namespace to the underlying primitive** (`--reka-combobox-*` for InputMenu/SelectMenu, `--reka-select-*` for Select, `--reka-dropdown-menu-*` / `--reka-context-menu-*` for menus); a `max-h` cap on `content` only takes effect when `content` is also `flex flex-col` (viewport scrolls via `flex-1`); do **not** add `overflow-hidden` to b24ui menu `content` — the arrow is rendered inside it and would be clipped. Last reviewed: 2026-06-09.
 - 2026-06-13 — port of `ca5accf3` (PR #126): added the **playground-manifest mirroring** invariant (§2). A `chore(deps)` port bumped `package.json`, `docs/package.json`, and `playgrounds/nuxt/package.json` but missed b24ui's extra `playgrounds/demo/package.json` (`ai`, `@ai-sdk/vue` drifted to old ranges); fixed in a follow-up. Always sweep `playgrounds/{nuxt,demo,vue,repl}` for shared deps before regenerating the lockfile. Last reviewed: 2026-06-13.
 - 2026-06-15 — port of `ffaf163f` (PR #140): added the §1 rewrite — **rename inferred type variables too**: when porting types that `infer UI` (or otherwise name a `UI` type-var), rename it to `B24UI`, consistent with `ui → b24ui`. Caught in review of the `ComponentAppConfig` rewrite (`A extends { b24ui: infer UI }` → `infer B24UI`). Last reviewed: 2026-06-15.
+- 2026-06-17 — skip of `fa525382` (PR #167): added the §2 **Locales** invariant — b24ui does not adopt new languages from upstream. The Latvian (`lv`) addition was ported then reverted on maintainer instruction; PR #167 closed without merge and recorded as `decision: skip`. Future upstream new-locale commits are skipped the same way (edits to existing locales still port). Last reviewed: 2026-06-17.

--- a/.sync/log/fa5253825258dfb7e543dd84452602979b329703.md
+++ b/.sync/log/fa5253825258dfb7e543dd84452602979b329703.md
@@ -1,0 +1,22 @@
+# Port: feat(locale): add Latvian language (#6552)
+
+**Upstream:** `fa5253825258dfb7e543dd84452602979b329703` (nuxt/ui)
+**Decision:** skip
+
+## Upstream change
+Adds a new locale `lv` (Latviešu): `src/runtime/locale/lv.ts` + an export in
+`src/runtime/locale/index.ts`.
+
+## b24ui decision — skip
+Per maintainer decision, **b24ui does not introduce new locales from upstream**
+— it maintains its own curated locale set. New-language additions are skipped.
+
+An initial adaptation was opened as PR #167 (porting `lv.ts` reconciled to
+b24ui's `Messages`/`defineLocale`), then withdrawn on instruction: PR #167 was
+closed without merge and no `src` change lands.
+
+This established the §2 **Locales** rule in `PORTING.md`: future upstream
+new-locale commits are skipped the same way (edits to *existing* b24ui locales
+still port normally).
+
+No file change — bookkeeping only (ledger marks this `skip`, advances cursor).

--- a/.sync/nuxt-ui.json
+++ b/.sync/nuxt-ui.json
@@ -2,7 +2,7 @@
   "upstream": "nuxt/ui",
   "branch": "v4",
   "sync_enabled": false,
-  "cursor": "f66eb65f5cb80e245491a6de75d9bb3b175be011",
+  "cursor": "fa5253825258dfb7e543dd84452602979b329703",
   "_cursor_note": "cursor = last upstream commit ported into b24ui (oldest-first, manual cadence). sync_enabled stays false until Phase 2 (porter workflow #67 + CLAUDE_CODE_OAUTH_TOKEN) is wired and trusted. `processed` is maintained per port from now on (backfilled #68-#72 on 2026-06-09).",
   "stats": {
     "queue_depth": 0,
@@ -407,10 +407,16 @@
       "summary": "chore(release): v4.8.2 — n/a: upstream @nuxt/ui version bump 4.8.1->4.8.2 + CHANGELOG (aggregates #6539/#6538/#6546/#6531, already ported as b24ui #153/#155/#157/#149). b24ui versions independently (@bitrix24/b24ui-nuxt, own changelog). Same as #124 (v4.8.0) / #142 (v4.8.1)"
     },
     "f66eb65f5cb80e245491a6de75d9bb3b175be011": {
-      "pr": null,
-      "b24ui_sha": "pending-merge",
+      "pr": 166,
+      "b24ui_sha": "ffb0859f",
       "decision": "port",
       "summary": "feat(Select/SelectMenu): use multiple in theme (#6554) — pass multiple:props.multiple into the b24ui computed in Select.vue + SelectMenu.vue; add empty multiple:{true:''} variant to theme/select.ts (styling hook). select-menu.ts merges select() via defuFn so it inherits the variant (only select.ts edited, mirroring upstream). Empty variant -> no snapshot churn"
+    },
+    "fa5253825258dfb7e543dd84452602979b329703": {
+      "pr": 167,
+      "b24ui_sha": "skipped",
+      "decision": "skip",
+      "summary": "feat(locale): add Latvian language (#6552) — SKIPPED per maintainer decision: b24ui does not introduce new locales from upstream. PR #167 (initial lv.ts port) closed without merge. See PORTING.md §2 'Locales' rule. Future upstream locale-addition commits are skipped the same way."
     }
   }
 }


### PR DESCRIPTION
Records upstream nuxt/ui [`fa525382`](https://github.com/nuxt/ui/commit/fa5253825258dfb7e543dd84452602979b329703) — `feat(locale): add Latvian language (#6552)` — as **skipped**.

## Decision: skip

Per maintainer decision, **b24ui does not introduce new locales from upstream** — it maintains its own curated locale set.

The initial adaptation (porting `lv.ts` reconciled to b24ui's `Messages`/`defineLocale`) was opened as #167, then withdrawn on instruction: **#167 is closed without merge** and no `src` change lands.

## Changes (bookkeeping only)
- `.sync/nuxt-ui.json`: record `fa525382` as `decision: skip`, finalize the previous port (#166 → `ffb0859f`), advance the cursor.
- `.sync/log/fa525382….md`: skip rationale.
- `.sync/PORTING.md`: add the §2 **Locales** invariant (skip new-locale commits; edits to existing locales still port) + a dated changelog entry.

https://claude.ai/code/session_01Qz7EXMncvEGiCj4WbmYgJo

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qz7EXMncvEGiCj4WbmYgJo)_