### PR TITLE
feat(Sidebar): add `transition` prop

### DIFF
--- a/.sync/log/af80a674a5061dea3272ea113fa497d698fc184b.md
+++ b/.sync/log/af80a674a5061dea3272ea113fa497d698fc184b.md
@@ -1,0 +1,36 @@
+# Port: feat(Sidebar): add `transition` prop (#6484)
+
+**Upstream:** `af80a674a5061dea3272ea113fa497d698fc184b` (nuxt/ui)
+**Decision:** port
+
+## Upstream change
+Make the sidebar collapse/expand animation toggleable:
+- `Sidebar.vue`: add `transition?: boolean` prop (`@defaultValue true`),
+  default it in `withDefaults`, and pass `transition: props.transition` to the
+  `ui` computed.
+- `theme/sidebar.ts`: move the transition utilities out of the base
+  `gap`/`container`/`rail` slots into a new `transition: { true: {...} }`
+  variant; also switch the easing from `ease-linear` to `ease-out`.
+- regenerated Sidebar snapshots.
+
+## b24ui adaptation
+Same three edits, b24ui-namespaced (`b24ui` computed; theme is a plain object,
+not an `(options) =>` factory):
+- `Sidebar.vue`: add the `transition` prop + jsDoc, `transition: true` default,
+  and `transition: props.transition` in the `b24ui` computed.
+- `theme/sidebar.ts`:
+  - `gap`: drop `transition-[width] duration-200 ease-linear`.
+  - `container`: drop `transition-[left,right,width] duration-200 ease-linear`.
+  - `rail`: drop `transition-all ease-linear` (kept the b24ui
+    `after:transition-colors` + air token `--ui-color-divider-accent`).
+  - add `transition: { true: { gap, container, rail } }` with `ease-out`
+    (following upstream's easing change).
+- Snapshots: regeneration produced **no change** — b24ui's Sidebar specs don't
+  render the gap/container/rail slots, so relocating the classes (default
+  `transition: true`) is transparent to them.
+
+## Verification (pnpm 11.5.0, gate ON)
+dev:prepare · lint · typecheck · test (4994 passed, 6 skipped) · module build
+— all green.
+
+Platform note: b24ui CI is `ubuntu-latest` only.

--- a/.sync/nuxt-ui.json
+++ b/.sync/nuxt-ui.json
@@ -2,7 +2,7 @@
   "upstream": "nuxt/ui",
   "branch": "v4",
   "sync_enabled": false,
-  "cursor": "fa5253825258dfb7e543dd84452602979b329703",
+  "cursor": "af80a674a5061dea3272ea113fa497d698fc184b",
   "_cursor_note": "cursor = last upstream commit ported into b24ui (oldest-first, manual cadence). sync_enabled stays false until Phase 2 (porter workflow #67 + CLAUDE_CODE_OAUTH_TOKEN) is wired and trusted. `processed` is maintained per port from now on (backfilled #68-#72 on 2026-06-09).",
   "stats": {
     "queue_depth": 0,
@@ -413,10 +413,16 @@
       "summary": "feat(Select/SelectMenu): use multiple in theme (#6554) — pass multiple:props.multiple into the b24ui computed in Select.vue + SelectMenu.vue; add empty multiple:{true:''} variant to theme/select.ts (styling hook). select-menu.ts merges select() via defuFn so it inherits the variant (only select.ts edited, mirroring upstream). Empty variant -> no snapshot churn"
     },
     "fa5253825258dfb7e543dd84452602979b329703": {
-      "pr": 167,
-      "b24ui_sha": "skipped",
+      "pr": 168,
+      "b24ui_sha": "dc448660",
       "decision": "skip",
-      "summary": "feat(locale): add Latvian language (#6552) — SKIPPED per maintainer decision: b24ui does not introduce new locales from upstream. PR #167 (initial lv.ts port) closed without merge. See PORTING.md §2 'Locales' rule. Future upstream locale-addition commits are skipped the same way."
+      "summary": "feat(locale): add Latvian language (#6552) — SKIPPED per maintainer decision: b24ui does not introduce new locales from upstream. Initial lv.ts port (PR #167) closed without merge; skip recorded via PR #168. Added PORTING.md §2 'Locales' rule — future upstream locale-addition commits are skipped the same way."
+    },
+    "af80a674a5061dea3272ea113fa497d698fc184b": {
+      "pr": null,
+      "b24ui_sha": "pending-merge",
+      "decision": "port",
+      "summary": "feat(Sidebar): add transition prop (#6484) — Sidebar.vue: add transition?:boolean prop (default true) + pass to b24ui computed; theme/sidebar.ts: move transition utils from base gap/container/rail slots into a transition:{true:{...}} variant, easing ease-linear->ease-out (per upstream). Snapshots regenerated with no change (b24ui specs don't render those slots)."
     }
   }
 }

--- a/src/runtime/components/Sidebar.vue
+++ b/src/runtime/components/Sidebar.vue
@@ -63,6 +63,11 @@ export interface SidebarProps<T extends SidebarMode = SidebarMode> {
    */
   rail?: boolean
   /**
+   * Animate the sidebar when collapsing or expanding.
+   * @defaultValue true
+   */
+  transition?: boolean
+  /**
    * The mode of the sidebar menu on mobile.
    * @defaultValue 'slideover'
    */
@@ -111,6 +116,7 @@ const _props = withDefaults(defineProps<SidebarProps<T>>(), {
   collapsible: 'offcanvas',
   side: 'left',
   close: false,
+  transition: true,
   rail: false,
   mode: 'slideover' as never
 })
@@ -190,7 +196,8 @@ const hasHeader = computed(() => !!slots.header || props.title || !!slots.title 
 const b24ui = computed(() => tv({ extend: tv(theme), ...(appConfig.b24ui?.sidebar || {}) })({
   side: props.side,
   variant: props.variant,
-  collapsible: props.collapsible
+  collapsible: props.collapsible,
+  transition: props.transition
 }))
 
 const Menu = computed(() => ({

--- a/src/theme/sidebar.ts
+++ b/src/theme/sidebar.ts
@@ -6,8 +6,8 @@
 export default {
   slots: {
     root: 'peer [--sidebar-width:15rem] [--sidebar-width-icon:4.5rem]',
-    gap: 'relative w-(--sidebar-width) bg-transparent transition-[width] duration-200 ease-linear',
-    container: 'fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) transition-[left,right,width] duration-200 ease-linear lg:flex',
+    gap: 'relative w-(--sidebar-width) bg-transparent',
+    container: 'fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) lg:flex',
     inner: 'flex size-full flex-col overflow-hidden divide-y divide-default',
     header: 'flex items-center gap-1.5 overflow-hidden px-4 min-h-(--b24ui-header-height)',
     wrapper: 'min-w-0 flex-1',
@@ -18,7 +18,7 @@ export default {
     body: 'flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto p-4',
     footer: 'flex items-center gap-1.5 overflow-hidden p-4',
     rail: [
-      'absolute inset-y-0 z-20 hidden w-4 transition-all ease-linear after:absolute after:inset-y-0 after:left-1/2 after:w-px lg:flex hover:after:bg-(--ui-color-divider-accent)',
+      'absolute inset-y-0 z-20 hidden w-4 after:absolute after:inset-y-0 after:left-1/2 after:w-px lg:flex hover:after:bg-(--ui-color-divider-accent)',
       'after:transition-colors'
     ].join(' '),
     // @memo For compatibility with DashboardSidebar & Header
@@ -26,6 +26,13 @@ export default {
     overlay: ''
   },
   variants: {
+    transition: {
+      true: {
+        gap: 'transition-[width] duration-200 ease-out',
+        container: 'transition-[left,right,width] duration-200 ease-out',
+        rail: 'transition-all ease-out'
+      }
+    },
     side: {
       left: {
         container: 'left-0 border-e border-default',


### PR DESCRIPTION
Port of upstream nuxt/ui [`af80a674`](https://github.com/nuxt/ui/commit/af80a674a5061dea3272ea113fa497d698fc184b) — `feat(Sidebar): add `transition` prop (#6484)`.

## Changes
Make the sidebar collapse/expand animation toggleable:
- **`Sidebar.vue`**: add `transition?: boolean` prop (`@defaultValue true`), default it in `withDefaults`, and pass `transition: props.transition` to the `b24ui` computed.
- **`theme/sidebar.ts`**: move the transition utilities out of the base `gap`/`container`/`rail` slots into a new `transition: { true: {...} }` variant; switch the easing `ease-linear` → `ease-out` (per upstream). Kept b24ui's `after:transition-colors` and the air token `--ui-color-divider-accent` on `rail`.

## Notes
- Snapshot regeneration produced **no change** — b24ui's Sidebar specs don't render the gap/container/rail slots, so relocating the classes (default `transition: true`) is transparent.

## Verification (pnpm 11.5.0, gate ON)
dev:prepare · lint · typecheck · test (**4994 passed**, 6 skipped) · module build — all green.

Ledger: records the merge sha for the previous entry (#168, `fa525382` skip) and advances the sync cursor to `af80a674`.

https://claude.ai/code/session_01Qz7EXMncvEGiCj4WbmYgJo

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qz7EXMncvEGiCj4WbmYgJo)_