### PR TITLE
docs(navigation): query `description` field for content toc

### DIFF
--- a/.sync/log/71b900105281de05df07dff4fe4426ac49043e63.md
+++ b/.sync/log/71b900105281de05df07dff4fe4426ac49043e63.md
@@ -1,0 +1,21 @@
+# Port: docs(navigation): query `description` field for content toc (#…)
+
+**Upstream:** `71b900105281de05df07dff4fe4426ac49043e63` (nuxt/ui)
+**Decision:** port
+
+## Upstream change
+`docs/server/api/navigation.json.get.ts`: add `'description'` to the fields
+queried by `queryCollectionNavigation(event, 'docs', [...])` so the content
+TOC can surface page descriptions.
+
+## b24ui adaptation
+Direct 1:1 — b24ui's `docs/server/api/navigation.json.get.ts` matched the
+upstream pre-change array (`['framework', 'category']`). Added `'description'`:
+`['framework', 'category', 'description']`. (b24ui already had a commented-out
+reference line listing `'description', 'badge'`; left untouched.)
+
+## Verification (pnpm 11.5.0, gate ON)
+dev:prepare · lint · typecheck (incl. `nuxt typecheck docs`) · module build —
+all green. Docs-only server endpoint change; no component/test impact.
+
+Platform note: b24ui CI is `ubuntu-latest` only.

--- a/.sync/nuxt-ui.json
+++ b/.sync/nuxt-ui.json
@@ -2,7 +2,7 @@
   "upstream": "nuxt/ui",
   "branch": "v4",
   "sync_enabled": false,
-  "cursor": "af80a674a5061dea3272ea113fa497d698fc184b",
+  "cursor": "71b900105281de05df07dff4fe4426ac49043e63",
   "_cursor_note": "cursor = last upstream commit ported into b24ui (oldest-first, manual cadence). sync_enabled stays false until Phase 2 (porter workflow #67 + CLAUDE_CODE_OAUTH_TOKEN) is wired and trusted. `processed` is maintained per port from now on (backfilled #68-#72 on 2026-06-09).",
   "stats": {
     "queue_depth": 0,
@@ -419,10 +419,16 @@
       "summary": "feat(locale): add Latvian language (#6552) — SKIPPED per maintainer decision: b24ui does not introduce new locales from upstream. Initial lv.ts port (PR #167) closed without merge; skip recorded via PR #168. Added PORTING.md §2 'Locales' rule — future upstream locale-addition commits are skipped the same way."
     },
     "af80a674a5061dea3272ea113fa497d698fc184b": {
+      "pr": 169,
+      "b24ui_sha": "71092336",
+      "decision": "port",
+      "summary": "feat(Sidebar): add transition prop (#6484) — Sidebar.vue: add transition?:boolean prop (default true) + pass to b24ui computed; theme/sidebar.ts: move transition utils from base gap/container/rail slots into a transition:{true:{...}} variant, easing ease-linear->ease-out (per upstream). Snapshots regenerated with no change (b24ui specs don't render those slots)."
+    },
+    "71b900105281de05df07dff4fe4426ac49043e63": {
       "pr": null,
       "b24ui_sha": "pending-merge",
       "decision": "port",
-      "summary": "feat(Sidebar): add transition prop (#6484) — Sidebar.vue: add transition?:boolean prop (default true) + pass to b24ui computed; theme/sidebar.ts: move transition utils from base gap/container/rail slots into a transition:{true:{...}} variant, easing ease-linear->ease-out (per upstream). Snapshots regenerated with no change (b24ui specs don't render those slots)."
+      "summary": "docs(navigation): query description field for content toc — docs/server/api/navigation.json.get.ts: add 'description' to queryCollectionNavigation fields (['framework','category']->['framework','category','description']). Direct 1:1; b24ui matched upstream pre-change"
     }
   }
 }

--- a/docs/server/api/navigation.json.get.ts
+++ b/docs/server/api/navigation.json.get.ts
@@ -3,5 +3,5 @@ import { queryCollectionNavigation } from '@nuxt/content/server'
 
 // const { data: navigation } = await useAsyncData('navigation', () => queryCollectionNavigation('docs', ['framework', 'category', 'description', 'badge']))
 export default defineEventHandler((event) => {
-  return queryCollectionNavigation(event, 'docs', ['framework', 'category'])
+  return queryCollectionNavigation(event, 'docs', ['framework', 'category', 'description'])
 })


### PR DESCRIPTION
Port of upstream nuxt/ui [`71b90010`](https://github.com/nuxt/ui/commit/71b900105281de05df07dff4fe4426ac49043e63) — `docs(navigation): query `description` field for content toc`.

## Changes
- **`docs/server/api/navigation.json.get.ts`**: add `'description'` to the fields queried by `queryCollectionNavigation` so the content TOC can surface page descriptions: `['framework', 'category']` → `['framework', 'category', 'description']`.

Direct 1:1 — b24ui's file matched the upstream pre-change array.

## Verification (pnpm 11.5.0, gate ON)
dev:prepare · lint · typecheck (incl. `nuxt typecheck docs`) · module build — all green. Docs-only server endpoint change.

Ledger: records the merge sha for the previous port (#169, `af80a674`) and advances the sync cursor to `71b90010`.

https://claude.ai/code/session_01Qz7EXMncvEGiCj4WbmYgJo

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qz7EXMncvEGiCj4WbmYgJo)_