### PR TITLE
feat(FileUpload): expose `removeFile` in slots

### DIFF
--- a/.sync/log/4da3a5d34373b8c99a7304d5cd143da8273a9238.md
+++ b/.sync/log/4da3a5d34373b8c99a7304d5cd143da8273a9238.md
@@ -1,0 +1,25 @@
+# Port: feat(FileUpload): expose `removeFile` in slots (#6492)
+
+**Upstream:** `4da3a5d34373b8c99a7304d5cd143da8273a9238` (nuxt/ui)
+**Decision:** port
+
+## Upstream change
+`FileUpload.vue`: expose the `removeFile(index?)` callback to three more slots
+that previously lacked it (the `files-top`/`files-bottom`/`actions` slots
+already had it):
+- slot type defs: add `removeFile: (index?: number) => void` to `files`,
+  `file`, `file-trailing`.
+- template: bind `:remove-file="removeFile"` on the `files`, `file`, and
+  `file-trailing` `<slot>`s.
+
+## b24ui adaptation
+Same edits, b24ui-namespaced (the `file-trailing` slot carries `b24ui:
+FileUpload['b24ui']` rather than upstream's `ui`; template binds `:b24ui`):
+- types (3 slots) + template bindings (3 slots), identical otherwise.
+
+## Verification (pnpm 11.5.0, gate ON)
+dev:prepare · lint · typecheck · test (4994 passed, 6 skipped) · module build
+— all green. Slot-prop additions only; default render unchanged → no snapshot
+churn.
+
+Platform note: b24ui CI is `ubuntu-latest` only.

--- a/.sync/nuxt-ui.json
+++ b/.sync/nuxt-ui.json
@@ -2,7 +2,7 @@
   "upstream": "nuxt/ui",
   "branch": "v4",
   "sync_enabled": false,
-  "cursor": "71b900105281de05df07dff4fe4426ac49043e63",
+  "cursor": "4da3a5d34373b8c99a7304d5cd143da8273a9238",
   "_cursor_note": "cursor = last upstream commit ported into b24ui (oldest-first, manual cadence). sync_enabled stays false until Phase 2 (porter workflow #67 + CLAUDE_CODE_OAUTH_TOKEN) is wired and trusted. `processed` is maintained per port from now on (backfilled #68-#72 on 2026-06-09).",
   "stats": {
     "queue_depth": 0,
@@ -425,10 +425,16 @@
       "summary": "feat(Sidebar): add transition prop (#6484) — Sidebar.vue: add transition?:boolean prop (default true) + pass to b24ui computed; theme/sidebar.ts: move transition utils from base gap/container/rail slots into a transition:{true:{...}} variant, easing ease-linear->ease-out (per upstream). Snapshots regenerated with no change (b24ui specs don't render those slots)."
     },
     "71b900105281de05df07dff4fe4426ac49043e63": {
+      "pr": 170,
+      "b24ui_sha": "4159373b",
+      "decision": "port",
+      "summary": "docs(navigation): query description field for content toc — docs/server/api/navigation.json.get.ts: add 'description' to queryCollectionNavigation fields (['framework','category']->['framework','category','description']). Direct 1:1; b24ui matched upstream pre-change"
+    },
+    "4da3a5d34373b8c99a7304d5cd143da8273a9238": {
       "pr": null,
       "b24ui_sha": "pending-merge",
       "decision": "port",
-      "summary": "docs(navigation): query description field for content toc — docs/server/api/navigation.json.get.ts: add 'description' to queryCollectionNavigation fields (['framework','category']->['framework','category','description']). Direct 1:1; b24ui matched upstream pre-change"
+      "summary": "feat(FileUpload): expose removeFile in slots (#6492) — FileUpload.vue: add removeFile:(index?)=>void to the files/file/file-trailing slot type defs and bind :remove-file=\"removeFile\" on those 3 slots (files-top/files-bottom/actions already had it). b24ui file-trailing carries b24ui:FileUpload['b24ui']. Slot-prop only, no snapshot churn"
     }
   }
 }

--- a/src/runtime/components/FileUpload.vue
+++ b/src/runtime/components/FileUpload.vue
@@ -125,14 +125,14 @@ export interface FileUploadSlots<M extends boolean = false> {
   'label'?(props?: {}): VNode[]
   'description'?(props?: {}): VNode[]
   'actions'?(props: { files: FileUploadFiles<M> | undefined, open: UseFileDialogReturn['open'], removeFile: (index?: number) => void }): VNode[]
-  'files'?(props: { files: FileUploadFiles<M> }): VNode[]
+  'files'?(props: { files: FileUploadFiles<M>, removeFile: (index?: number) => void }): VNode[]
   'files-top'?(props: { files: FileUploadFiles<M>, open: UseFileDialogReturn['open'], removeFile: (index?: number) => void }): VNode[]
   'files-bottom'?(props: { files: FileUploadFiles<M>, open: UseFileDialogReturn['open'], removeFile: (index?: number) => void }): VNode[]
-  'file'?(props: { file: File, index: number }): VNode[]
+  'file'?(props: { file: File, index: number, removeFile: (index?: number) => void }): VNode[]
   'file-leading'?(props: { file: File, index: number, b24ui: FileUpload['b24ui'] }): VNode[]
   'file-name'?(props: { file: File, index: number }): VNode[]
   'file-size'?(props: { file: File, index: number }): VNode[]
-  'file-trailing'?(props: { file: File, index: number, b24ui: FileUpload['b24ui'] }): VNode[]
+  'file-trailing'?(props: { file: File, index: number, b24ui: FileUpload['b24ui'], removeFile: (index?: number) => void }): VNode[]
 }
 </script>
 
@@ -297,14 +297,14 @@ defineExpose({
       <slot name="files-top" :files="modelValue" :open="open" :remove-file="removeFile" />
 
       <div data-slot="files" :class="b24ui.files({ class: props.b24ui?.files })">
-        <slot name="files" :files="modelValue">
+        <slot name="files" :files="modelValue" :remove-file="removeFile">
           <div
             v-for="(file, index) in Array.isArray(modelValue) ? modelValue : [modelValue]"
             :key="(file as File).name"
             data-slot="file"
             :class="b24ui.file({ class: props.b24ui?.file })"
           >
-            <slot name="file" :file="file" :index="index">
+            <slot name="file" :file="file" :index="index" :remove-file="removeFile">
               <slot name="file-leading" :file="file" :index="index" :b24ui="b24ui">
                 <B24Avatar
                   :as="{ img: 'img' }"
@@ -330,7 +330,7 @@ defineExpose({
                 </span>
               </div>
 
-              <slot name="file-trailing" :file="file" :index="index" :b24ui="b24ui">
+              <slot name="file-trailing" :file="file" :index="index" :b24ui="b24ui" :remove-file="removeFile">
                 <B24Button
                   v-if="props.fileDelete"
                   v-bind="{


### PR DESCRIPTION
Port of upstream nuxt/ui [`4da3a5d3`](https://github.com/nuxt/ui/commit/4da3a5d34373b8c99a7304d5cd143da8273a9238) — `feat(FileUpload): expose `removeFile` in slots (#6492)`.

## Changes
`FileUpload.vue`: expose the `removeFile(index?)` callback to three more slots that previously lacked it (`files-top`/`files-bottom`/`actions` already had it):
- slot type defs: add `removeFile: (index?: number) => void` to `files`, `file`, `file-trailing`.
- template: bind `:remove-file="removeFile"` on the `files`, `file`, and `file-trailing` `<slot>`s.

(b24ui's `file-trailing` slot carries `b24ui: FileUpload['b24ui']` instead of upstream's `ui` — otherwise identical.)

## Verification (pnpm 11.5.0, gate ON)
dev:prepare · lint · typecheck · test (**4994 passed**, 6 skipped) · module build — all green. Slot-prop additions only → no snapshot churn.

Ledger: records the merge sha for the previous port (#170, `71b90010`) and advances the sync cursor to `4da3a5d3`.

https://claude.ai/code/session_01Qz7EXMncvEGiCj4WbmYgJo

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qz7EXMncvEGiCj4WbmYgJo)_