### PR TITLE
docs(composables): improve examples

### DIFF
--- a/.sync/log/b8ee80b663d9a0076a2db0a2f3ef54ae9db7e893.md
+++ b/.sync/log/b8ee80b663d9a0076a2db0a2f3ef54ae9db7e893.md
@@ -1,0 +1,32 @@
+# Port: docs(composables): improve examples
+
+**Upstream:** `b8ee80b663d9a0076a2db0a2f3ef54ae9db7e893` (nuxt/ui)
+**Decision:** port
+
+## Upstream change
+Replace the inline `vue` code blocks in three composable docs pages with live
+`::component-example` blocks, adding four example components:
+- `use-overlay/UseOverlayExample.vue` + `use-overlay/UseOverlayModalExample.vue`
+- `use-scroll-shadow/UseScrollShadowExample.vue`
+- `use-toast/UseToastExample.vue`
+
+## b24ui adaptation
+All three composables + docs pages already exist in b24ui. Ported the same
+restructure, adapted to b24ui conventions:
+- example components use `B24Button`/`B24Modal`, the `b24ui` prop, air colors,
+  and a real b24icons import.
+- `UseOverlayModalExample`: `:b24ui="{ footer: 'justify-end' }"`, plain `B24Button`
+  for the close action (matches b24ui's own Modal examples).
+- `UseToastExample`: `icon: 'i-lucide-reply'` → `import ReplyIcon from
+  '@bitrix24/b24icons-vue/actions/ReplyIcon'`; `color: 'neutral'/'success'` →
+  `air-secondary-accent-2` / `air-primary-success`.
+- `UseScrollShadowExample`: identical (no UI components; `bg-elevated/50` is
+  used elsewhere in b24ui examples).
+- 3 md pages: inline code block → `::component-example` (`use-overlay-example`,
+  `use-scroll-shadow-example`, `use-toast-example`).
+
+## Verification (pnpm 11.5.0, gate ON)
+dev:prepare · lint · typecheck (incl. `nuxt typecheck docs`) · module build —
+all green. Docs-only; no component/test impact.
+
+Platform note: b24ui CI is `ubuntu-latest` only.

--- a/.sync/nuxt-ui.json
+++ b/.sync/nuxt-ui.json
@@ -2,7 +2,7 @@
   "upstream": "nuxt/ui",
   "branch": "v4",
   "sync_enabled": false,
-  "cursor": "4da3a5d34373b8c99a7304d5cd143da8273a9238",
+  "cursor": "b8ee80b663d9a0076a2db0a2f3ef54ae9db7e893",
   "_cursor_note": "cursor = last upstream commit ported into b24ui (oldest-first, manual cadence). sync_enabled stays false until Phase 2 (porter workflow #67 + CLAUDE_CODE_OAUTH_TOKEN) is wired and trusted. `processed` is maintained per port from now on (backfilled #68-#72 on 2026-06-09).",
   "stats": {
     "queue_depth": 0,
@@ -431,10 +431,16 @@
       "summary": "docs(navigation): query description field for content toc — docs/server/api/navigation.json.get.ts: add 'description' to queryCollectionNavigation fields (['framework','category']->['framework','category','description']). Direct 1:1; b24ui matched upstream pre-change"
     },
     "4da3a5d34373b8c99a7304d5cd143da8273a9238": {
+      "pr": 171,
+      "b24ui_sha": "1be274b8",
+      "decision": "port",
+      "summary": "feat(FileUpload): expose removeFile in slots (#6492) — FileUpload.vue: add removeFile:(index?)=>void to the files/file/file-trailing slot type defs and bind :remove-file=\"removeFile\" on those 3 slots (files-top/files-bottom/actions already had it). b24ui file-trailing carries b24ui:FileUpload['b24ui']. Slot-prop only, no snapshot churn"
+    },
+    "b8ee80b663d9a0076a2db0a2f3ef54ae9db7e893": {
       "pr": null,
       "b24ui_sha": "pending-merge",
       "decision": "port",
-      "summary": "feat(FileUpload): expose removeFile in slots (#6492) — FileUpload.vue: add removeFile:(index?)=>void to the files/file/file-trailing slot type defs and bind :remove-file=\"removeFile\" on those 3 slots (files-top/files-bottom/actions already had it). b24ui file-trailing carries b24ui:FileUpload['b24ui']. Slot-prop only, no snapshot churn"
+      "summary": "docs(composables): improve examples — replace inline vue code in use-overlay/use-scroll-shadow/use-toast docs with ::component-example; add 4 example components adapted to b24ui (B24Button/B24Modal, b24ui prop, air colors, ReplyIcon from b24icons). All 3 composables+pages already existed in b24ui"
     }
   }
 }

--- a/docs/app/components/content/examples/use-overlay/UseOverlayExample.vue
+++ b/docs/app/components/content/examples/use-overlay/UseOverlayExample.vue
@@ -1,0 +1,11 @@
+<script setup lang="ts">
+import { LazyUseOverlayModalExample } from '#components'
+
+const overlay = useOverlay()
+
+const modal = overlay.create(LazyUseOverlayModalExample)
+</script>
+
+<template>
+  <B24Button label="Open modal" @click="modal.open()" />
+</template>

--- a/docs/app/components/content/examples/use-overlay/UseOverlayModalExample.vue
+++ b/docs/app/components/content/examples/use-overlay/UseOverlayModalExample.vue
@@ -1,0 +1,16 @@
+<script setup lang="ts">
+const emit = defineEmits<{ close: [] }>()
+</script>
+
+<template>
+  <B24Modal
+    title="Welcome 👋"
+    description="This modal was opened programmatically with useOverlay."
+    :close="{ onClick: () => emit('close') }"
+    :b24ui="{ footer: 'justify-end' }"
+  >
+    <template #footer>
+      <B24Button label="Close" @click="emit('close')" />
+    </template>
+  </B24Modal>
+</template>

--- a/docs/app/components/content/examples/use-scroll-shadow/UseScrollShadowExample.vue
+++ b/docs/app/components/content/examples/use-scroll-shadow/UseScrollShadowExample.vue
@@ -1,0 +1,19 @@
+<script setup lang="ts">
+const el = useTemplateRef('el')
+
+const { style } = useScrollShadow(el)
+</script>
+
+<template>
+  <div class="max-w-sm bg-elevated/50 rounded-lg">
+    <div
+      ref="el"
+      :style="style"
+      class="h-72 p-4 space-y-4 overflow-y-auto"
+    >
+      <p v-for="i in 6" :key="i">
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam pulvinar risus non risus hendrerit venenatis. Pellentesque sit amet hendrerit risus, sed porttitor quam. Morbi accumsan cursus enim, sed ultricies sapien.
+      </p>
+    </div>
+  </div>
+</template>

--- a/docs/app/components/content/examples/use-toast/UseToastExample.vue
+++ b/docs/app/components/content/examples/use-toast/UseToastExample.vue
@@ -1,0 +1,24 @@
+<script setup lang="ts">
+import ReplyIcon from '@bitrix24/b24icons-vue/actions/ReplyIcon'
+
+const toast = useToast()
+
+function showToast() {
+  toast.add({
+    title: 'New message',
+    description: 'You have a new message from Benjamin.',
+    actions: [{
+      icon: ReplyIcon,
+      label: 'Reply',
+      color: 'air-secondary-accent-2',
+      onClick: () => {
+        toast.add({ title: 'Reply sent', color: 'air-primary-success' })
+      }
+    }]
+  })
+}
+</script>
+
+<template>
+  <B24Button label="Show toast" @click="showToast" />
+</template>

--- a/docs/content/docs/3.composables/use-overlay.md
+++ b/docs/content/docs/3.composables/use-overlay.md
@@ -17,19 +17,11 @@ links:
 
 Use the auto-imported `useOverlay` composable to programmatically control [Modal](/docs/components/modal/) and [Slideover](/docs/components/slideover/) components.
 
-```vue
-<script setup lang="ts">
-import { LazyModalExample } from '#components'
-
-const overlay = useOverlay()
-
-const modal = overlay.create(LazyModalExample)
-
-async function openModal() {
-  modal.open()
-}
-</script>
-```
+::component-example
+---
+name: 'use-overlay-example'
+---
+::
 
 - The `useOverlay` composable is created using `createSharedComposable`, ensuring that the same overlay state is shared across your entire application.
 

--- a/docs/content/docs/3.composables/use-scroll-shadow.md
+++ b/docs/content/docs/3.composables/use-scroll-shadow.md
@@ -8,19 +8,11 @@ navigation.badge: New
 
 Use the auto-imported `useScrollShadow` composable to apply fade shadows on the edges of a scrollable element, indicating that more content is available in the scroll direction.
 
-```vue
-<script setup lang="ts">
-const el = useTemplateRef('el')
-
-const { style } = useScrollShadow(el)
-</script>
-
-<template>
-  <div ref="el" class="max-h-[200px] overflow-y-auto" :style="style">
-    <!-- Scrollable content -->
-  </div>
-</template>
-```
+::component-example
+---
+name: 'use-scroll-shadow-example'
+---
+::
 
 - Uses CSS `mask-image` to fade content at the edges rather than overlay elements, so it works on any background.
 - Automatically detects whether the element is overflowing and only applies shadows when needed.

--- a/docs/content/docs/3.composables/use-toast.md
+++ b/docs/content/docs/3.composables/use-toast.md
@@ -17,11 +17,11 @@ links:
 
 Use the auto-imported `useToast` composable to display [Toast](/docs/components/toast/) notifications.
 
-```vue
-<script setup lang="ts">
-const toast = useToast()
-</script>
-```
+::component-example
+---
+name: 'use-toast-example'
+---
+::
 
 - The `useToast` composable uses Nuxt's `useState` to manage the toast state, ensuring reactivity across your application.
 - A maximum of 5 toasts are displayed at a time. When adding a new toast that would exceed this limit, the oldest toast is automatically removed.


### PR DESCRIPTION
Port of upstream nuxt/ui [`b8ee80b6`](https://github.com/nuxt/ui/commit/b8ee80b663d9a0076a2db0a2f3ef54ae9db7e893) — `docs(composables): improve examples`.

## Changes
Replace the inline `vue` code blocks in three composable docs pages with live `::component-example` blocks, adding four example components:
- `use-overlay/UseOverlayExample.vue` + `use-overlay/UseOverlayModalExample.vue`
- `use-scroll-shadow/UseScrollShadowExample.vue`
- `use-toast/UseToastExample.vue`

All three composables + docs pages already exist in b24ui. Adapted to b24ui conventions:
- `B24Button` / `B24Modal`, the `b24ui` prop (`:b24ui="{ footer: 'justify-end' }"`), air colors.
- `UseToastExample`: `i-lucide-reply` → `import ReplyIcon from '@bitrix24/b24icons-vue/actions/ReplyIcon'`; `neutral`/`success` → `air-secondary-accent-2` / `air-primary-success`.
- `UseScrollShadowExample`: identical (no UI components; `bg-elevated/50` already used elsewhere in b24ui examples).

## Verification (pnpm 11.5.0, gate ON)
dev:prepare · lint · typecheck (incl. `nuxt typecheck docs`) · module build — all green. Docs-only.

Ledger: records the merge sha for the previous port (#171, `4da3a5d3`) and advances the sync cursor to `b8ee80b6`.

https://claude.ai/code/session_01Qz7EXMncvEGiCj4WbmYgJo

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qz7EXMncvEGiCj4WbmYgJo)_