### PR TITLE
feat(ScrollArea): add `shadow` prop

### DIFF
--- a/.sync/log/d850ae60531787984ba2416d6fca99626637b41b.md
+++ b/.sync/log/d850ae60531787984ba2416d6fca99626637b41b.md
@@ -1,0 +1,34 @@
+# Port: feat(ScrollArea): add `shadow` prop (#6561)
+
+**Upstream:** `d850ae60531787984ba2416d6fca99626637b41b` (nuxt/ui)
+**Decision:** port
+
+## Upstream change
+- `ScrollArea.vue`: add `shadow?: boolean | { size?: number }` prop
+  (`@defaultValue false`); import `useScrollShadow`; compute
+  `scrollShadowStyle` (only when `shadow` is set) and bind it as `:style` on the
+  root.
+- spec: add a `['with shadow', …]` `renderEach` case + regenerated snapshots.
+- docs: new `ScrollAreaShadowExample.vue` + a "Shadow" section in
+  `scroll-area.md`.
+
+## b24ui adaptation
+Same edits, b24ui-namespaced (`b24ui` prop/slots; b24ui already ships the
+`useScrollShadow` composable, ported earlier):
+- prop + jsDoc, `shadow: false` default, `useScrollShadow` import, the
+  `scrollShadowStyle` block (identical), and `:style="scrollShadowStyle"` on the
+  root `<Primitive>`.
+- spec: `['with shadow', { props: { ...props, shadow: true } }]`; regenerated
+  both snapshot projects (**+2** snapshots).
+- example `ScrollAreaShadowExample.vue`: `UScrollArea`→`B24ScrollArea`,
+  `:ui`→`:b24ui`.
+- `scroll-area.md`: "Shadow" section with the `collapse: true` component-example
+  + the `:shadow="{ size: 48 }"` tip. Dropped upstream's `:badge{label="Soon"}`
+  on the heading — the feature is fully implemented in b24ui, so a "Soon" badge
+  would be inaccurate.
+
+## Verification (pnpm 11.5.0, gate ON)
+dev:prepare · lint · typecheck · test (4996 passed, 6 skipped — +2 ScrollArea)
+· module build — all green.
+
+Platform note: b24ui CI is `ubuntu-latest` only.

--- a/.sync/nuxt-ui.json
+++ b/.sync/nuxt-ui.json
@@ -2,7 +2,7 @@
   "upstream": "nuxt/ui",
   "branch": "v4",
   "sync_enabled": false,
-  "cursor": "b8ee80b663d9a0076a2db0a2f3ef54ae9db7e893",
+  "cursor": "d850ae60531787984ba2416d6fca99626637b41b",
   "_cursor_note": "cursor = last upstream commit ported into b24ui (oldest-first, manual cadence). sync_enabled stays false until Phase 2 (porter workflow #67 + CLAUDE_CODE_OAUTH_TOKEN) is wired and trusted. `processed` is maintained per port from now on (backfilled #68-#72 on 2026-06-09).",
   "stats": {
     "queue_depth": 0,
@@ -437,10 +437,16 @@
       "summary": "feat(FileUpload): expose removeFile in slots (#6492) — FileUpload.vue: add removeFile:(index?)=>void to the files/file/file-trailing slot type defs and bind :remove-file=\"removeFile\" on those 3 slots (files-top/files-bottom/actions already had it). b24ui file-trailing carries b24ui:FileUpload['b24ui']. Slot-prop only, no snapshot churn"
     },
     "b8ee80b663d9a0076a2db0a2f3ef54ae9db7e893": {
+      "pr": 172,
+      "b24ui_sha": "6d1fb0c1",
+      "decision": "port",
+      "summary": "docs(composables): improve examples — replace inline vue code in use-overlay/use-scroll-shadow/use-toast docs with ::component-example; add 4 example components adapted to b24ui (B24Button/B24Modal, b24ui prop, air colors, ReplyIcon from b24icons). All 3 composables+pages already existed in b24ui"
+    },
+    "d850ae60531787984ba2416d6fca99626637b41b": {
       "pr": null,
       "b24ui_sha": "pending-merge",
       "decision": "port",
-      "summary": "docs(composables): improve examples — replace inline vue code in use-overlay/use-scroll-shadow/use-toast docs with ::component-example; add 4 example components adapted to b24ui (B24Button/B24Modal, b24ui prop, air colors, ReplyIcon from b24icons). All 3 composables+pages already existed in b24ui"
+      "summary": "feat(ScrollArea): add shadow prop (#6561) — ScrollArea.vue: add shadow?:boolean|{size?:number} prop (default false), import useScrollShadow, compute scrollShadowStyle, bind :style on root Primitive; spec +['with shadow'] case (+2 snapshots nuxt/vue); example ScrollAreaShadowExample.vue (B24ScrollArea, :b24ui) + scroll-area.md Shadow section. Dropped upstream :badge Soon (feature works in b24ui)"
     }
   }
 }

--- a/docs/app/components/content/examples/scroll-area/ScrollAreaShadowExample.vue
+++ b/docs/app/components/content/examples/scroll-area/ScrollAreaShadowExample.vue
@@ -1,0 +1,13 @@
+<template>
+  <div class="max-w-sm bg-elevated/50 rounded-lg">
+    <B24ScrollArea
+      shadow
+      class="p-4 h-72"
+      :b24ui="{ viewport: 'gap-4' }"
+    >
+      <p v-for="i in 6" :key="i">
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam pulvinar risus non risus hendrerit venenatis. Pellentesque sit amet hendrerit risus, sed porttitor quam. Morbi accumsan cursus enim, sed ultricies sapien.
+      </p>
+    </B24ScrollArea>
+  </div>
+</template>

--- a/docs/content/docs/2.components/scroll-area.md
+++ b/docs/content/docs/2.components/scroll-area.md
@@ -97,6 +97,21 @@ options:
 ---
 ::
 
+### Shadow
+
+Use the `shadow` prop to display fade shadows on the scrollable edges, indicating that more content is available in the scroll direction. The fade automatically follows the `orientation` and only appears when the content overflows.
+
+::component-example
+---
+collapse: true
+name: 'scroll-area-shadow-example'
+---
+::
+
+::tip
+Pass an object to the `shadow` prop to configure the fade size, e.g. `:shadow="{ size: 48 }"`.
+::
+
 ## Examples
 
 ### As masonry layout

--- a/src/runtime/components/ScrollArea.vue
+++ b/src/runtime/components/ScrollArea.vue
@@ -59,6 +59,12 @@ export interface ScrollAreaProps<T extends ScrollAreaItem = ScrollAreaItem> {
    * @defaultValue false
    */
   virtualize?: boolean | ScrollAreaVirtualizeOptions
+  /**
+   * Display fade shadows on the scrollable edges to indicate more content.
+   * Pass an object to configure the shadow size (in px).
+   * @defaultValue false
+   */
+  shadow?: boolean | { size?: number }
   class?: any
   b24ui?: ScrollArea['slots']
 }
@@ -89,10 +95,12 @@ import { useAppConfig } from '#imports'
 import { useComponentProps } from '../composables/useComponentProps'
 import { tv } from '../utils/tv'
 import { useLocale } from '../composables/useLocale'
+import { useScrollShadow } from '../composables/useScrollShadow'
 
 const _props = withDefaults(defineProps<ScrollAreaProps<T>>(), {
   orientation: 'vertical',
-  virtualize: false
+  virtualize: false,
+  shadow: false
 })
 defineSlots<ScrollAreaSlots<T>>()
 const emits = defineEmits<ScrollAreaEmits>()
@@ -108,6 +116,16 @@ const b24ui = computed(() => tv({ extend: tv(theme), ...(appConfig.b24ui?.scroll
 }))
 
 const rootRef = useTemplateRef<ComponentPublicInstance>('rootRef')
+
+const scrollShadowStyle = props.shadow
+  ? useScrollShadow(
+    computed(() => rootRef.value?.$el as HTMLElement | undefined),
+    {
+      orientation: () => props.orientation ?? 'vertical',
+      size: typeof props.shadow === 'object' ? props.shadow.size : undefined
+    }
+  ).style
+  : undefined
 
 const isRtl = computed(() => dir.value === 'rtl')
 const isHorizontal = computed(() => props.orientation === 'horizontal')
@@ -273,6 +291,7 @@ defineExpose({
     data-slot="root"
     :data-orientation="props.orientation"
     :class="b24ui.root({ class: [props.b24ui?.root, props.class] })"
+    :style="scrollShadowStyle"
   >
     <template v-if="virtualizer">
       <div

--- a/test/components/ScrollArea.spec.ts
+++ b/test/components/ScrollArea.spec.ts
@@ -22,6 +22,7 @@ describe('ScrollArea', () => {
     ['with virtualize padding', { props: { ...props, virtualize: { paddingStart: 20, paddingEnd: 20 } } }],
     ['with virtualize lanes', { props: { ...props, virtualize: { lanes: 3 } } }],
     ['with virtualize scrollMargin', { props: { ...props, virtualize: { scrollMargin: 10 } } }],
+    ['with shadow', { props: { ...props, shadow: true } }],
     ['with as', { props: { ...props, as: 'section' } }],
     ['with class', { props: { ...props, class: 'absolute' } }],
     ['with b24ui', { props: { ...props, b24ui: { viewport: 'gap-4' } } }],

--- a/test/components/__snapshots__/ScrollArea-vue.spec.ts.snap
+++ b/test/components/__snapshots__/ScrollArea-vue.spec.ts.snap
@@ -66,6 +66,16 @@ exports[`ScrollArea > renders with orientation vertical correctly 1`] = `
 </div>"
 `;
 
+exports[`ScrollArea > renders with shadow correctly 1`] = `
+"<div data-slot="root" data-orientation="vertical" class="relative overflow-y-auto overflow-x-hidden">
+  <div data-slot="viewport" class="relative flex flex-col">
+    <div data-slot="item" class=""></div>
+    <div data-slot="item" class=""></div>
+    <div data-slot="item" class=""></div>
+  </div>
+</div>"
+`;
+
 exports[`ScrollArea > renders with virtualize boolean correctly 1`] = `
 "<div data-slot="root" data-orientation="vertical" class="relative overflow-y-auto overflow-x-hidden">
   <div data-slot="viewport" class="relative flex flex-col" style="position: relative; inline-size: 100%; block-size: 300px;"></div>

--- a/test/components/__snapshots__/ScrollArea.spec.ts.snap
+++ b/test/components/__snapshots__/ScrollArea.spec.ts.snap
@@ -66,6 +66,16 @@ exports[`ScrollArea > renders with orientation vertical correctly 1`] = `
 </div>"
 `;
 
+exports[`ScrollArea > renders with shadow correctly 1`] = `
+"<div data-slot="root" data-orientation="vertical" class="relative overflow-y-auto overflow-x-hidden">
+  <div data-slot="viewport" class="relative flex flex-col">
+    <div data-slot="item" class=""></div>
+    <div data-slot="item" class=""></div>
+    <div data-slot="item" class=""></div>
+  </div>
+</div>"
+`;
+
 exports[`ScrollArea > renders with virtualize boolean correctly 1`] = `
 "<div data-slot="root" data-orientation="vertical" class="relative overflow-y-auto overflow-x-hidden">
   <div data-slot="viewport" class="relative flex flex-col" style="position: relative; inline-size: 100%; block-size: 300px;"></div>


### PR DESCRIPTION
Port of upstream nuxt/ui [`d850ae60`](https://github.com/nuxt/ui/commit/d850ae60531787984ba2416d6fca99626637b41b) — `feat(ScrollArea): add `shadow` prop (#6561)`.

## Changes
- **`ScrollArea.vue`**: add `shadow?: boolean | { size?: number }` prop (`@defaultValue false`); import `useScrollShadow`; compute `scrollShadowStyle` (only when `shadow` is set) and bind it as `:style` on the root `<Primitive>`.
- **spec**: add a `['with shadow', …]` `renderEach` case → **+2 snapshots** (nuxt/vue).
- **docs**: `ScrollAreaShadowExample.vue` (`B24ScrollArea`, `:b24ui`) + a "Shadow" section in `scroll-area.md` with the `:shadow="{ size: 48 }"` tip.

**Deviation:** dropped upstream's `:badge{label="Soon"}` on the heading — the feature is fully implemented in b24ui, so a "Soon" badge would be inaccurate.

(b24ui already ships the `useScrollShadow` composable, ported earlier.)

## Verification (pnpm 11.5.0, gate ON)
dev:prepare · lint · typecheck · test (**4996 passed**, 6 skipped — +2 ScrollArea) · module build — all green.

Ledger: records the merge sha for the previous port (#172, `b8ee80b6`) and advances the sync cursor to `d850ae60`.

https://claude.ai/code/session_01Qz7EXMncvEGiCj4WbmYgJo

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qz7EXMncvEGiCj4WbmYgJo)_