### PR TITLE
docs(form-field): add a warning to help field

### DIFF
--- a/.sync/log/4d0232566be9bd14f17e3311b3e9e20610724fb9.md
+++ b/.sync/log/4d0232566be9bd14f17e3311b3e9e20610724fb9.md
@@ -1,0 +1,18 @@
+# Port: docs(form-field): add a warning to help field (#6560)
+
+**Upstream:** `4d0232566be9bd14f17e3311b3e9e20610724fb9` (nuxt/ui)
+**Decision:** port
+
+## Upstream change
+`docs/content/docs/2.components/form-field.md`, "Help" section: append one
+sentence noting that when `help` and `error` are used together, `error` takes
+precedence.
+
+## b24ui adaptation
+Direct 1:1 — same sentence appended to b24ui's identical "Help" line.
+
+## Verification (pnpm 11.5.0, gate ON)
+lint · module build — green. Single markdown prose change; no
+component/test/type impact.
+
+Platform note: b24ui CI is `ubuntu-latest` only.

--- a/.sync/nuxt-ui.json
+++ b/.sync/nuxt-ui.json
@@ -2,7 +2,7 @@
   "upstream": "nuxt/ui",
   "branch": "v4",
   "sync_enabled": false,
-  "cursor": "d850ae60531787984ba2416d6fca99626637b41b",
+  "cursor": "4d0232566be9bd14f17e3311b3e9e20610724fb9",
   "_cursor_note": "cursor = last upstream commit ported into b24ui (oldest-first, manual cadence). sync_enabled stays false until Phase 2 (porter workflow #67 + CLAUDE_CODE_OAUTH_TOKEN) is wired and trusted. `processed` is maintained per port from now on (backfilled #68-#72 on 2026-06-09).",
   "stats": {
     "queue_depth": 0,
@@ -443,10 +443,16 @@
       "summary": "docs(composables): improve examples — replace inline vue code in use-overlay/use-scroll-shadow/use-toast docs with ::component-example; add 4 example components adapted to b24ui (B24Button/B24Modal, b24ui prop, air colors, ReplyIcon from b24icons). All 3 composables+pages already existed in b24ui"
     },
     "d850ae60531787984ba2416d6fca99626637b41b": {
+      "pr": 173,
+      "b24ui_sha": "61753ad6",
+      "decision": "port",
+      "summary": "feat(ScrollArea): add shadow prop (#6561) — ScrollArea.vue: add shadow?:boolean|{size?:number} prop (default false), import useScrollShadow, compute scrollShadowStyle, bind :style on root Primitive; spec +['with shadow'] case (+2 snapshots nuxt/vue); example ScrollAreaShadowExample.vue (B24ScrollArea, :b24ui) + scroll-area.md Shadow section. Dropped upstream :badge Soon (feature works in b24ui)"
+    },
+    "4d0232566be9bd14f17e3311b3e9e20610724fb9": {
       "pr": null,
       "b24ui_sha": "pending-merge",
       "decision": "port",
-      "summary": "feat(ScrollArea): add shadow prop (#6561) — ScrollArea.vue: add shadow?:boolean|{size?:number} prop (default false), import useScrollShadow, compute scrollShadowStyle, bind :style on root Primitive; spec +['with shadow'] case (+2 snapshots nuxt/vue); example ScrollAreaShadowExample.vue (B24ScrollArea, :b24ui) + scroll-area.md Shadow section. Dropped upstream :badge Soon (feature works in b24ui)"
+      "summary": "docs(form-field): add a warning to help field (#6560) — append one sentence to the Help section of form-field.md noting error takes precedence over help when both are set. Direct 1:1 markdown prose"
     }
   }
 }

--- a/docs/content/docs/2.components/form-field.md
+++ b/docs/content/docs/2.components/form-field.md
@@ -103,7 +103,7 @@ slots:
 
 ### Help
 
-Use the `help` prop to display a help message below the form control.
+Use the `help` prop to display a help message below the form control. When used together with the `error` prop, the `error` prop takes precedence.
 
 ::component-code
 ---


### PR DESCRIPTION
Port of upstream nuxt/ui [`4d023256`](https://github.com/nuxt/ui/commit/4d0232566be9bd14f17e3311b3e9e20610724fb9) — `docs(form-field): add a warning to help field (#6560)`.

## Changes
- **`form-field.md`** "Help" section: append one sentence — when `help` and `error` are used together, the `error` prop takes precedence. Direct 1:1.

## Verification (pnpm 11.5.0, gate ON)
lint · module build — green. Single markdown prose change; no component/test/type impact.

Ledger: records the merge sha for the previous port (#173, `d850ae60`) and advances the sync cursor to `4d023256`.

https://claude.ai/code/session_01Qz7EXMncvEGiCj4WbmYgJo

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qz7EXMncvEGiCj4WbmYgJo)_