### PR TITLE
feat(ContentSearch/DashboardSearch): forward input config to command palette

### DIFF
--- a/.sync/log/5199b7e1d262d693af4114884f06bd9126cd3202.md
+++ b/.sync/log/5199b7e1d262d693af4114884f06bd9126cd3202.md
@@ -1,0 +1,30 @@
+# Port: feat(ContentSearch/DashboardSearch): forward input config to command palette (#6312)
+
+**Upstream:** `5199b7e1d262d693af4114884f06bd9126cd3202` (nuxt/ui)
+**Decision:** port
+
+## Upstream change
+Let ContentSearch/DashboardSearch configure (or hide) the CommandPalette's
+search input:
+- `CommandPalette.vue`: move the `v-bind="typeof props.input === 'object' ?
+  props.input : {}"` **after** the explicit input bindings so a forwarded input
+  config takes precedence.
+- `DashboardSearch.vue` + `ContentSearch.vue`: add an `input?: boolean |
+  Omit<InputProps, 'modelValue' | 'defaultValue'>` prop (import `InputProps`),
+  a `inputProps` computed (`false` → `false`; else `defu(input, { fixed: true })`),
+  and bind `:input="inputProps"` instead of the hard-coded `:input="{ fixed: true }"`.
+
+## b24ui adaptation
+Same edits, b24ui-namespaced (`B24Input`; `defu`/`computed` already imported in
+both wrappers):
+- `CommandPalette.vue`: reorder the `v-bind` below `:icon`/the explicit binds
+  (b24ui's input has `no-border`/`no-padding` and no `loading-icon`, otherwise
+  identical placement).
+- `DashboardSearch.vue` / `ContentSearch.vue`: `InputProps` import, the `input`
+  prop + jsDoc, the `inputProps` computed, and `:input="inputProps"`.
+
+## Verification (pnpm 11.5.0, gate ON)
+dev:prepare · lint · typecheck · test (4996 passed, 6 skipped) · module build —
+all green. Default resolves to `{ fixed: true }` (unchanged) → no snapshot churn.
+
+Platform note: b24ui CI is `ubuntu-latest` only.

--- a/.sync/nuxt-ui.json
+++ b/.sync/nuxt-ui.json
@@ -2,7 +2,7 @@
   "upstream": "nuxt/ui",
   "branch": "v4",
   "sync_enabled": false,
-  "cursor": "4d0232566be9bd14f17e3311b3e9e20610724fb9",
+  "cursor": "5199b7e1d262d693af4114884f06bd9126cd3202",
   "_cursor_note": "cursor = last upstream commit ported into b24ui (oldest-first, manual cadence). sync_enabled stays false until Phase 2 (porter workflow #67 + CLAUDE_CODE_OAUTH_TOKEN) is wired and trusted. `processed` is maintained per port from now on (backfilled #68-#72 on 2026-06-09).",
   "stats": {
     "queue_depth": 0,
@@ -449,10 +449,16 @@
       "summary": "feat(ScrollArea): add shadow prop (#6561) — ScrollArea.vue: add shadow?:boolean|{size?:number} prop (default false), import useScrollShadow, compute scrollShadowStyle, bind :style on root Primitive; spec +['with shadow'] case (+2 snapshots nuxt/vue); example ScrollAreaShadowExample.vue (B24ScrollArea, :b24ui) + scroll-area.md Shadow section. Dropped upstream :badge Soon (feature works in b24ui)"
     },
     "4d0232566be9bd14f17e3311b3e9e20610724fb9": {
+      "pr": 174,
+      "b24ui_sha": "c63b8d32",
+      "decision": "port",
+      "summary": "docs(form-field): add a warning to help field (#6560) — append one sentence to the Help section of form-field.md noting error takes precedence over help when both are set. Direct 1:1 markdown prose"
+    },
+    "5199b7e1d262d693af4114884f06bd9126cd3202": {
       "pr": null,
       "b24ui_sha": "pending-merge",
       "decision": "port",
-      "summary": "docs(form-field): add a warning to help field (#6560) — append one sentence to the Help section of form-field.md noting error takes precedence over help when both are set. Direct 1:1 markdown prose"
+      "summary": "feat(ContentSearch/DashboardSearch): forward input config to command palette (#6312) — CommandPalette.vue: move v-bind(props.input) after explicit input binds so forwarded config wins; DashboardSearch.vue + ContentSearch.vue: add input?:boolean|Omit<InputProps,'modelValue'|'defaultValue'> prop, inputProps computed (false->false else defu(input,{fixed:true})), bind :input=\"inputProps\". No snapshot churn (default still {fixed:true})"
     }
   }
 }

--- a/src/runtime/components/CommandPalette.vue
+++ b/src/runtime/components/CommandPalette.vue
@@ -675,12 +675,12 @@ function onSelect(e: Event, item: T) {
         no-border
         no-padding
         :size="props.size"
-        v-bind="typeof props.input === 'object' ? props.input : {}"
         :placeholder="placeholder"
         :autofocus="props.autofocus"
         :loading="props.loading"
         :trailing-icon="props.trailingIcon"
         :icon="props.icon || icons.search"
+        v-bind="typeof props.input === 'object' ? props.input : {}"
         data-slot="input"
         :class="b24ui.input({ class: props.b24ui?.input })"
         @keydown.backspace="onBackspace"

--- a/src/runtime/components/DashboardSearch.vue
+++ b/src/runtime/components/DashboardSearch.vue
@@ -4,7 +4,7 @@ import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/b24ui/dashboard-search'
 import type { UseFuseOptions } from '@vueuse/integrations/useFuse'
-import type { ButtonProps, ModalProps, CommandPaletteProps, CommandPaletteSlots, CommandPaletteGroup, CommandPaletteItem, LinkPropsKeys } from '../types'
+import type { ButtonProps, ModalProps, CommandPaletteProps, CommandPaletteSlots, CommandPaletteGroup, CommandPaletteItem, LinkPropsKeys, InputProps } from '../types'
 import type { ComponentConfig } from '../types/tv'
 
 type DashboardSearch = ComponentConfig<typeof theme, AppConfig, 'dashboardSearch'>
@@ -24,6 +24,12 @@ export interface DashboardSearchProps<T extends CommandPaletteItem = CommandPale
    * @defaultValue true
    */
   close?: boolean | Omit<ButtonProps, LinkPropsKeys>
+  /**
+   * Configure the input or hide it with `false`.
+   * `{ fixed: true }`{lang="ts-type"}
+   * @defaultValue true
+   */
+  input?: boolean | Omit<InputProps, 'modelValue' | 'defaultValue'>
   /**
    * Keyboard shortcut to open the search (used by [`defineShortcuts`](https://bitrix24.github.io/b24ui/docs/composables/define-shortcuts/))
    * @defaultValue 'meta_k'
@@ -105,6 +111,12 @@ const appConfig = useAppConfig() as DashboardSearch['AppConfig']
 /** @memo not use loadingIcon */
 const commandPaletteProps = useForwardProps(reactivePick(props, 'size', 'icon', 'trailingIcon', 'selectedIcon', 'childrenIcon', 'placeholder', 'autofocus', 'loading', 'close', 'closeIcon', 'back', 'backIcon', 'disabled', 'highlightOnHover', 'labelKey', 'descriptionKey', 'preserveGroupOrder', 'virtualize', 'searchDelay'))
 const modalProps = useForwardProps(reactivePick(props, 'overlay', 'transition', 'content', 'dismissible', 'fullscreen', 'modal', 'portal'))
+const inputProps = computed(() => {
+  if (props.input === false) {
+    return false
+  }
+  return defu(typeof props.input === 'object' ? props.input : {}, { fixed: true })
+})
 
 const getProxySlots = () => omit(slots, ['content'])
 
@@ -204,7 +216,7 @@ defineExpose({
           v-bind="commandPaletteProps"
           :groups="groups"
           :fuse="fuse"
-          :input="{ fixed: true }"
+          :input="inputProps"
           :b24ui="transformUI(omit(b24ui, ['modal']), props.b24ui)"
           @update:model-value="onSelect"
           @update:open="open = $event"

--- a/src/runtime/components/content/ContentSearch.vue
+++ b/src/runtime/components/content/ContentSearch.vue
@@ -5,7 +5,7 @@ import type { ContentNavigationItem } from '@nuxt/content'
 import type { AppConfig } from '@nuxt/schema'
 import type { UseFuseOptions } from '@vueuse/integrations/useFuse'
 import theme from '#build/b24ui/content/content-search'
-import type { ButtonProps, LinkProps, ModalProps, CommandPaletteProps, CommandPaletteSlots, CommandPaletteGroup, CommandPaletteItem, IconComponent, LinkPropsKeys } from '../../types'
+import type { ButtonProps, LinkProps, ModalProps, CommandPaletteProps, CommandPaletteSlots, CommandPaletteGroup, CommandPaletteItem, IconComponent, LinkPropsKeys, InputProps } from '../../types'
 import type { ComponentConfig } from '../../types/tv'
 
 type ContentSearch = ComponentConfig<typeof theme, AppConfig, 'contentSearch'>
@@ -70,6 +70,12 @@ export interface ContentSearchProps<T extends ContentSearchLink = ContentSearchL
    * @defaultValue true
    */
   close?: boolean | Omit<ButtonProps, LinkPropsKeys>
+  /**
+   * Configure the input or hide it with `false`.
+   * `{ fixed: true }`{lang="ts-type"}
+   * @defaultValue true
+   */
+  input?: boolean | Omit<InputProps, 'modelValue' | 'defaultValue'>
   /**
    * Keyboard shortcut to open the search (used by [`defineShortcuts`](https://bitrix24.github.io/b24ui/docs/composables/define-shortcuts/))
    * @defaultValue 'meta_k'
@@ -164,6 +170,12 @@ const appConfig = useAppConfig() as ContentSearch['AppConfig']
 /** @memo not use loadingIcon */
 const commandPaletteProps = useForwardProps(reactivePick(props, 'size', 'icon', 'trailingIcon', 'selectedIcon', 'childrenIcon', 'placeholder', 'autofocus', 'loading', 'close', 'closeIcon', 'back', 'backIcon', 'disabled', 'highlightOnHover', 'labelKey', 'descriptionKey', 'preserveGroupOrder', 'virtualize', 'searchDelay'))
 const modalProps = useForwardProps(reactivePick(props, 'overlay', 'transition', 'content', 'dismissible', 'fullscreen', 'modal', 'portal'))
+const inputProps = computed(() => {
+  if (props.input === false) {
+    return false
+  }
+  return defu(typeof props.input === 'object' ? props.input : {}, { fixed: true })
+})
 
 const getProxySlots = () => omit(slots, ['content'])
 
@@ -356,7 +368,7 @@ defineExpose({
           v-bind="commandPaletteProps"
           :groups="groups"
           :fuse="fuse"
-          :input="{ fixed: true }"
+          :input="inputProps"
           :b24ui="transformUI(omit(b24ui, ['modal']), props.b24ui)"
           @update:model-value="onSelect"
           @update:open="open = $event"


### PR DESCRIPTION
Port of upstream nuxt/ui [`5199b7e1`](https://github.com/nuxt/ui/commit/5199b7e1d262d693af4114884f06bd9126cd3202) — `feat(ContentSearch/DashboardSearch): forward input config to command palette (#6312)`.

## Changes
Let ContentSearch/DashboardSearch configure (or hide with `false`) the CommandPalette's search input:
- **`CommandPalette.vue`**: move the `v-bind="typeof props.input === 'object' ? props.input : {}"` **after** the explicit input bindings so a forwarded input config takes precedence.
- **`DashboardSearch.vue`** + **`ContentSearch.vue`**: add an `input?: boolean | Omit<InputProps, 'modelValue' | 'defaultValue'>` prop (import `InputProps`), an `inputProps` computed (`false` → `false`; else `defu(input, { fixed: true })`), and bind `:input="inputProps"` instead of the hard-coded `:input="{ fixed: true }"`.

(b24ui-namespaced: `B24Input`; `defu`/`computed` already imported in both wrappers.)

## Verification (pnpm 11.5.0, gate ON)
dev:prepare · lint · typecheck · test (**4996 passed**, 6 skipped) · module build — all green. Default resolves to `{ fixed: true }` (unchanged) → no snapshot churn.

Ledger: records the merge sha for the previous port (#174, `4d023256`) and advances the sync cursor to `5199b7e1`.

https://claude.ai/code/session_01Qz7EXMncvEGiCj4WbmYgJo

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qz7EXMncvEGiCj4WbmYgJo)_