### PR TITLE
feat(useTour): new composable

### DIFF
--- a/.sync/log/dc0515128ee6783b6cebd410c85a3e405fb7872a.md
+++ b/.sync/log/dc0515128ee6783b6cebd410c85a3e405fb7872a.md
@@ -1,0 +1,39 @@
+# Port: feat(useTour): new composable (#6557)
+
+**Upstream:** `dc0515128ee6783b6cebd410c85a3e405fb7872a` (nuxt/ui)
+**Decision:** port
+
+## Upstream change
+New `useTour` composable that drives a guided tour with a single Popover whose
+anchor (`reference`) moves between steps. Includes a Popover change to support
+re-anchoring, registration in the auto-import maps, docs, an example, and tests.
+
+## b24ui adaptation
+- **`src/runtime/composables/useTour.ts`** — copied essentially verbatim
+  (framework-agnostic; only `reka-ui` `ReferenceElement` + Vue). Only change:
+  the jsDoc `@example` references `<UPopover>` → `<B24Popover>`.
+- **`src/runtime/composables/index.ts`** — `export * from './useTour'`.
+- **`src/imports.ts`** — add `useTour: ['useTour']` to `publicComposables`.
+- **`Popover.vue`** — port the reference move so the content can anchor to a
+  (virtual) reference for a tour:
+  - `reference` prop jsDoc: note virtual-element / reactive re-anchor support.
+  - Trigger: `v-if="!!slots.default || !!props.reference"` → `v-if="!!slots.default"`
+    and drop `:reference` from the Trigger.
+  - Content: add `:reference="props.reference ?? props.content?.reference"`.
+- **tests** — `test/composables/useTour.spec.ts` copied verbatim (34 cases
+  across nuxt+vue); `Popover.spec.ts` gains the `reference` const, a
+  `['with reference', …]` renderEach case, and the two new anchor `it` tests;
+  regenerated Popover snapshots (**+2**).
+- **docs** — `use-tour.md` (B24-namespaced code, trailing-slash Popover link,
+  `navigation.badge: New` since the composable ships in b24ui, vs upstream's
+  `Soon`) + `UseTourExample.vue` adapted: `B24Button`/`B24Popover`,
+  `i-lucide-wand-sparkles` → `@bitrix24/b24icons-vue/outline/MagicWandIcon`,
+  `color="neutral" variant="outline"` → `color="air-tertiary"`,
+  `text-highlighted` → `text-base`.
+
+## Verification (pnpm 11.5.0, gate ON)
+dev:prepare · lint · typecheck (incl. docs) · test (5036 passed, 6 skipped —
++40: useTour spec ×2 projects + Popover reference cases) · module build — all
+green.
+
+Platform note: b24ui CI is `ubuntu-latest` only.

--- a/.sync/nuxt-ui.json
+++ b/.sync/nuxt-ui.json
@@ -2,7 +2,7 @@
   "upstream": "nuxt/ui",
   "branch": "v4",
   "sync_enabled": false,
-  "cursor": "5199b7e1d262d693af4114884f06bd9126cd3202",
+  "cursor": "dc0515128ee6783b6cebd410c85a3e405fb7872a",
   "_cursor_note": "cursor = last upstream commit ported into b24ui (oldest-first, manual cadence). sync_enabled stays false until Phase 2 (porter workflow #67 + CLAUDE_CODE_OAUTH_TOKEN) is wired and trusted. `processed` is maintained per port from now on (backfilled #68-#72 on 2026-06-09).",
   "stats": {
     "queue_depth": 0,
@@ -455,10 +455,16 @@
       "summary": "docs(form-field): add a warning to help field (#6560) — append one sentence to the Help section of form-field.md noting error takes precedence over help when both are set. Direct 1:1 markdown prose"
     },
     "5199b7e1d262d693af4114884f06bd9126cd3202": {
+      "pr": 175,
+      "b24ui_sha": "3a3c4148",
+      "decision": "port",
+      "summary": "feat(ContentSearch/DashboardSearch): forward input config to command palette (#6312) — CommandPalette.vue: move v-bind(props.input) after explicit input binds so forwarded config wins; DashboardSearch.vue + ContentSearch.vue: add input?:boolean|Omit<InputProps,'modelValue'|'defaultValue'> prop, inputProps computed (false->false else defu(input,{fixed:true})), bind :input=\"inputProps\". No snapshot churn (default still {fixed:true})"
+    },
+    "dc0515128ee6783b6cebd410c85a3e405fb7872a": {
       "pr": null,
       "b24ui_sha": "pending-merge",
       "decision": "port",
-      "summary": "feat(ContentSearch/DashboardSearch): forward input config to command palette (#6312) — CommandPalette.vue: move v-bind(props.input) after explicit input binds so forwarded config wins; DashboardSearch.vue + ContentSearch.vue: add input?:boolean|Omit<InputProps,'modelValue'|'defaultValue'> prop, inputProps computed (false->false else defu(input,{fixed:true})), bind :input=\"inputProps\". No snapshot churn (default still {fixed:true})"
+      "summary": "feat(useTour): new composable (#6557) — new useTour.ts (verbatim, framework-agnostic; jsdoc UPopover->B24Popover), registered in composables/index.ts + imports.ts publicComposables. Popover.vue: move reference from Trigger to Content (:reference=props.reference??props.content?.reference) + jsdoc; Trigger v-if drops ||props.reference. Tests: useTour.spec verbatim + Popover reference case/2 it-tests (+2 snapshots). Docs use-tour.md + UseTourExample.vue (B24*, MagicWandIcon, air-tertiary, text-base; badge New not Soon)"
     }
   }
 }

--- a/docs/app/components/content/examples/use-tour/UseTourExample.vue
+++ b/docs/app/components/content/examples/use-tour/UseTourExample.vue
@@ -1,0 +1,100 @@
+<script setup lang="ts">
+import MagicWandIcon from '@bitrix24/b24icons-vue/outline/MagicWandIcon'
+
+const dashboard = useTemplateRef('dashboard')
+const profile = useTemplateRef('profile')
+const settings = useTemplateRef('settings')
+
+const tour = useTour([
+  {
+    target: () => dashboard.value,
+    title: 'Welcome aboard',
+    body: 'The popover re-anchors to each target as you step through the tour.'
+  },
+  {
+    target: () => profile.value,
+    title: 'Make it yours',
+    body: 'You own the content and the buttons — no extra theme or locale to maintain.',
+    side: 'right' as const
+  },
+  {
+    target: () => settings.value,
+    title: 'You\'re all set',
+    body: 'Press Finish to close the tour.'
+  }
+])
+</script>
+
+<template>
+  <div class="w-full space-y-4">
+    <div class="flex justify-end">
+      <B24Button :icon="MagicWandIcon" @click="tour.start()">
+        Start tour
+      </B24Button>
+    </div>
+
+    <div class="grid grid-cols-1 sm:grid-cols-3 gap-4">
+      <div ref="dashboard" class="p-4 rounded-lg border border-default bg-elevated/50">
+        <p class="font-medium text-base">
+          Dashboard
+        </p>
+        <p class="text-sm text-muted">
+          Overview of your workspace.
+        </p>
+      </div>
+      <div ref="profile" class="p-4 rounded-lg border border-default bg-elevated/50">
+        <p class="font-medium text-base">
+          Profile
+        </p>
+        <p class="text-sm text-muted">
+          Manage your account.
+        </p>
+      </div>
+      <div ref="settings" class="p-4 rounded-lg border border-default bg-elevated/50">
+        <p class="font-medium text-base">
+          Settings
+        </p>
+        <p class="text-sm text-muted">
+          Configure your preferences.
+        </p>
+      </div>
+    </div>
+
+    <B24Popover
+      :open="tour.open.value"
+      :reference="tour.reference.value"
+      :content="{ side: tour.current.value?.side, sideOffset: 8 }"
+      :dismissible="false"
+      arrow
+    >
+      <template #content>
+        <div class="p-4 max-w-xs space-y-2">
+          <div class="flex items-center justify-between gap-4">
+            <p class="font-semibold text-base">
+              {{ tour.current.value?.title }}
+            </p>
+            <span class="text-xs text-muted tabular-nums">
+              {{ tour.index.value + 1 }} / {{ tour.total.value }}
+            </span>
+          </div>
+          <p class="text-sm text-muted">
+            {{ tour.current.value?.body }}
+          </p>
+          <div class="flex items-center justify-between pt-2">
+            <B24Button
+              color="air-tertiary"
+              size="sm"
+              :disabled="!tour.hasPrev.value"
+              @click="tour.prev()"
+            >
+              Back
+            </B24Button>
+            <B24Button size="sm" @click="tour.next()">
+              {{ tour.hasNext.value ? 'Next' : 'Finish' }}
+            </B24Button>
+          </div>
+        </div>
+      </template>
+    </B24Popover>
+  </div>
+</template>

--- a/docs/content/docs/3.composables/use-tour.md
+++ b/docs/content/docs/3.composables/use-tour.md
@@ -1,0 +1,146 @@
+---
+title: useTour
+description: 'A composable to build guided tours by re-anchoring a single Popover across steps.'
+navigation.badge: New
+---
+
+## Usage
+
+Use the auto-imported `useTour` composable to drive a guided tour with a single [Popover](/docs/components/popover/) whose anchor moves between steps. The composable owns the step state and resolves each step's `target` into a `reference` you bind to `<B24Popover>`, while you keep full control over the content and navigation.
+
+::component-example
+---
+collapse: true
+name: 'use-tour-example'
+---
+::
+
+Each step requires a `target` that the popover anchors to. It accepts a CSS selector, an element, a virtual element (anything with `getBoundingClientRect`), or a ref/getter returning one of those. Pass `null` to anchor the step to the center of the viewport. Any other field on a step (`title`, `body`, `side`, …) is passed through untouched and available via `current`.
+
+```vue
+<script setup lang="ts">
+const card = useTemplateRef('card')
+
+const tour = useTour([
+  { target: '#cta', title: 'Get started' },
+  { target: () => card.value, title: 'Profile', side: 'right' },
+  { target: null, title: 'All set' }
+])
+</script>
+
+<template>
+  <B24Button @click="tour.start()">Start tour</B24Button>
+
+  <B24Popover :open="tour.open.value" :reference="tour.reference.value" :dismissible="false">
+    <template #content>
+      <!-- your content + buttons -->
+      <B24Button :disabled="!tour.hasPrev.value" @click="tour.prev()">Back</B24Button>
+      <B24Button @click="tour.next()">{{ tour.hasNext.value ? 'Next' : 'Finish' }}</B24Button>
+    </template>
+  </B24Popover>
+</template>
+```
+
+- Built on the Popover's reactive `reference` prop, so the popover smoothly repositions when the active step changes.
+- The active target is scrolled into view automatically when a step becomes active.
+- Since you render the content yourself, there is no extra theme or locale to maintain.
+
+## API
+
+`useTour(steps, options?)`{lang="ts-type"}
+
+### Parameters
+
+::field-group
+
+  ::field{name="steps" type="MaybeRefOrGetter<TourStep[]>" required}
+  The list of tour steps. Can be a static array, a `ref`, or a getter for reactive steps.
+
+    ::collapsible
+
+      ::field-group
+        ::field{name="target" type="MaybeRefOrGetter<string | ReferenceElement | null | undefined>"}
+        The element the step anchors to. Accepts a CSS selector (`'#id'`, `'.class'`, or a bare id resolved as `#id`), an element, a virtual element, or a ref/getter returning one. Use `null` to center the step in the viewport.
+        ::
+
+        ::field{name="[key: string]" type="any"}
+        Any additional fields (`title`, `body`, `side`, …) are passed through and available via `current`.
+        ::
+      ::
+    ::
+  ::
+
+  ::field{name="options" type="UseTourOptions"}
+  Configuration options for the tour.
+
+    ::collapsible
+
+      ::field-group
+        ::field{name="initialStep" type="number" default="0"}
+        The step index the tour starts on.
+        ::
+
+        ::field{name="loop" type="boolean" default="false"}
+        Loop back to the first step after the last one.
+        ::
+
+        ::field{name="scrollIntoView" type="boolean | ScrollIntoViewOptions" default="true"}
+        Scroll the target into view when a step becomes active.
+        ::
+      ::
+    ::
+  ::
+::
+
+### Return
+
+::field-group
+
+  ::field{name="open" type="Ref<boolean>"}
+  Whether the tour is currently open.
+  ::
+
+  ::field{name="index" type="Ref<number>"}
+  The current step index, clamped to the steps range.
+  ::
+
+  ::field{name="current" type="ComputedRef<TourStep | undefined>"}
+  The current step object, or `undefined` when there are no steps.
+  ::
+
+  ::field{name="reference" type="ComputedRef<ReferenceElement | undefined>"}
+  The resolved anchor for the current step, to pass to `<B24Popover :reference>`.
+  ::
+
+  ::field{name="total" type="ComputedRef<number>"}
+  The total number of steps.
+  ::
+
+  ::field{name="hasNext" type="ComputedRef<boolean>"}
+  Whether a next step exists.
+  ::
+
+  ::field{name="hasPrev" type="ComputedRef<boolean>"}
+  Whether a previous step exists.
+  ::
+
+  ::field{name="start" type="(index?: number) => void"}
+  Open the tour, optionally at a given index.
+  ::
+
+  ::field{name="next" type="() => void"}
+  Go to the next step. Loops or finishes at the end depending on the `loop` option.
+  ::
+
+  ::field{name="prev" type="() => void"}
+  Go to the previous step.
+  ::
+
+  ::field{name="goTo" type="(index: number) => void"}
+  Jump to a specific step and open the tour.
+  ::
+
+  ::field{name="finish" type="() => void"}
+  Close the tour.
+  ::
+::

--- a/src/imports.ts
+++ b/src/imports.ts
@@ -13,6 +13,7 @@ export const publicComposables: Record<string, string[]> = {
   useScrollShadow: ['useScrollShadow'],
   useScrollspy: ['useScrollspy'],
   useToast: ['useToast'],
+  useTour: ['useTour'],
   // special composables
   useLocale: ['useLocale'],
   useDevice: ['useDevice'],

--- a/src/runtime/components/Popover.vue
+++ b/src/runtime/components/Popover.vue
@@ -33,6 +33,8 @@ export interface PopoverProps<M extends PopoverMode = PopoverMode> extends Popov
   /**
    * The reference (or anchor) element that is being referred to for positioning.
    *
+   * Accepts an element or a virtual element (anything with `getBoundingClientRect`),
+   * and can be changed reactively to re-anchor the popover (e.g. for a guided tour).
    * If not provided will use the current component as anchor.
    */
   reference?: HoverCardTriggerProps['reference']
@@ -120,9 +122,8 @@ const Component = computed(() => props.mode === 'hover' ? HoverCard : Popover)
 <template>
   <Component.Root v-slot="{ open, close }: { open: boolean, close?: () => void }" v-bind="rootProps">
     <Component.Trigger
-      v-if="!!slots.default || !!props.reference"
+      v-if="!!slots.default"
       as-child
-      :reference="props.reference"
       :class="props.class"
     >
       <slot :open="open" />
@@ -134,7 +135,7 @@ const Component = computed(() => props.mode === 'hover' ? HoverCard : Popover)
 
     <Component.Portal v-bind="portalProps">
       <FieldGroupReset>
-        <Component.Content v-bind="contentProps" data-slot="content" :class="b24ui.content({ class: [!slots.default && props.class, props.b24ui?.content] })" v-on="contentEvents">
+        <Component.Content v-bind="contentProps" :reference="props.reference ?? props.content?.reference" data-slot="content" :class="b24ui.content({ class: [!slots.default && props.class, props.b24ui?.content] })" v-on="contentEvents">
           <slot name="content" v-bind="((close ? { close } : {}) as SlotProps<M>)" />
 
           <Component.Arrow v-if="!!props.arrow" v-bind="arrowProps" data-slot="arrow" :class="b24ui.arrow({ class: props.b24ui?.arrow })" />

--- a/src/runtime/composables/index.ts
+++ b/src/runtime/composables/index.ts
@@ -18,6 +18,7 @@ export * from './useResizable'
 export * from './useScrollShadow'
 export * from './useScrollspy'
 export * from './useToast'
+export * from './useTour'
 // special composables
 export * from './useDevice'
 export * from './useConfetti'

--- a/src/runtime/composables/useTour.ts
+++ b/src/runtime/composables/useTour.ts
@@ -1,0 +1,210 @@
+import { ref, computed, toValue, nextTick, watch } from 'vue'
+import type { MaybeRefOrGetter, Ref, ComputedRef } from 'vue'
+import type { ReferenceElement } from 'reka-ui'
+
+export interface TourStep {
+  /**
+   * The element this step points to. Accepts:
+   * - a CSS selector (`'#id'`, `'.class'`, or a bare id resolved as `#id`)
+   * - an element or a virtual element (anything with `getBoundingClientRect`)
+   * - a ref or a getter returning any of the above
+   *
+   * Omit or pass `null` to anchor the step to the center of the viewport
+   * (useful for intro / summary steps with no target).
+   */
+  target?: MaybeRefOrGetter<string | ReferenceElement | null | undefined>
+  /**
+   * Any other fields (title, body, side, …) are passed through untouched
+   * and available via `current` — you own the rendering and copy.
+   */
+  [key: string]: any
+}
+
+export interface UseTourOptions {
+  /**
+   * The step index the tour starts on.
+   * @defaultValue 0
+   */
+  initialStep?: number
+  /**
+   * Loop back to the first step after the last one.
+   * @defaultValue false
+   */
+  loop?: boolean
+  /**
+   * Scroll the target into view when a step becomes active.
+   * @defaultValue true
+   */
+  scrollIntoView?: boolean | ScrollIntoViewOptions
+}
+
+export interface UseTourReturn {
+  /** Whether the tour is currently open. */
+  open: Ref<boolean>
+  /** The current step index (clamped to the steps range). */
+  index: Ref<number>
+  /** The current step object, or `undefined` when there are no steps. */
+  current: ComputedRef<TourStep | undefined>
+  /** The resolved anchor for the current step, to pass to `<B24Popover :reference>`. */
+  reference: ComputedRef<ReferenceElement | undefined>
+  /** Total number of steps. */
+  total: ComputedRef<number>
+  /** Whether a next step exists. */
+  hasNext: ComputedRef<boolean>
+  /** Whether a previous step exists. */
+  hasPrev: ComputedRef<boolean>
+  /** Open the tour, optionally at a given index. */
+  start: (index?: number) => void
+  /** Go to the next step (loops or finishes at the end depending on `loop`). */
+  next: () => void
+  /** Go to the previous step. */
+  prev: () => void
+  /** Jump to a specific step and open the tour. */
+  goTo: (index: number) => void
+  /** Close the tour. */
+  finish: () => void
+}
+
+/**
+ * Drive a guided tour with a single `<B24Popover>` whose anchor moves between steps.
+ *
+ * @example
+ * ```ts
+ * const tour = useTour([
+ *   { target: '#cta', title: 'Get started' },
+ *   { target: () => card.value, title: 'Profile', side: 'right' },
+ *   { target: null, title: 'All set' } // centered, no target
+ * ])
+ * ```
+ * ```vue
+ * <B24Popover :open="tour.open.value" :reference="tour.reference.value">
+ *   <template #content>…your content + buttons…</template>
+ * </B24Popover>
+ * ```
+ */
+export function useTour(steps: MaybeRefOrGetter<TourStep[]>, options: UseTourOptions = {}): UseTourReturn {
+  const { loop = false, scrollIntoView = true } = options
+
+  const stepList = computed<TourStep[]>(() => toValue(steps) ?? [])
+  const total = computed(() => stepList.value.length)
+
+  const open = ref(false)
+  const rawIndex = ref(options.initialStep ?? 0)
+
+  function clamp(value: number): number {
+    return Math.min(Math.max(value, 0), Math.max(total.value - 1, 0))
+  }
+
+  const index = computed<number>({
+    get: () => clamp(rawIndex.value),
+    set: value => (rawIndex.value = clamp(value))
+  })
+
+  const current = computed(() => stepList.value[index.value])
+  const hasNext = computed(() => index.value < total.value - 1)
+  const hasPrev = computed(() => index.value > 0)
+
+  // A virtual element centered in the viewport, for steps without a target.
+  const centerAnchor: ReferenceElement = {
+    getBoundingClientRect() {
+      const x = typeof window === 'undefined' ? 0 : window.innerWidth / 2
+      const y = typeof window === 'undefined' ? 0 : window.innerHeight / 2
+      return { x, y, top: y, left: x, right: x, bottom: y, width: 0, height: 0, toJSON: () => ({}) } as DOMRect
+    }
+  }
+
+  const reference = computed<ReferenceElement | undefined>(() => {
+    if (!open.value || typeof window === 'undefined') {
+      return undefined
+    }
+
+    const target = toValue(current.value?.target)
+    if (target == null) {
+      return centerAnchor
+    }
+
+    if (typeof target === 'string') {
+      const selector = target.startsWith('#') || target.startsWith('.') ? target : `#${target}`
+      try {
+        return (document.querySelector(selector) as ReferenceElement | null) ?? undefined
+      } catch {
+        // Ignore malformed selectors and leave the step unanchored.
+        return undefined
+      }
+    }
+
+    return target
+  })
+
+  function scrollTargetIntoView() {
+    if (!scrollIntoView) {
+      return
+    }
+    const el = reference.value
+    if (el instanceof Element) {
+      el.scrollIntoView(typeof scrollIntoView === 'object' ? scrollIntoView : { behavior: 'smooth', block: 'center' })
+    }
+  }
+
+  function goTo(value: number) {
+    index.value = value
+    // Don't open with nothing to show — the `total` watcher only reacts to changes,
+    // so it can't catch a tour that is started while already empty.
+    if (total.value > 0) {
+      open.value = true
+    }
+  }
+
+  function start(value: number = options.initialStep ?? 0) {
+    goTo(value)
+  }
+
+  function next() {
+    if (hasNext.value) {
+      index.value++
+    } else if (loop) {
+      index.value = 0
+    } else {
+      finish()
+    }
+  }
+
+  function prev() {
+    if (hasPrev.value) {
+      index.value--
+    }
+  }
+
+  function finish() {
+    open.value = false
+  }
+
+  // Close automatically if the steps disappear while open.
+  watch(total, (value) => {
+    if (!value) {
+      open.value = false
+    }
+  })
+
+  // Scroll the active target into view on open / step change.
+  watch([open, index], () => {
+    if (open.value) {
+      nextTick(scrollTargetIntoView)
+    }
+  })
+
+  return {
+    open,
+    index,
+    current,
+    reference,
+    total,
+    hasNext,
+    hasPrev,
+    start,
+    next,
+    prev,
+    goTo,
+    finish
+  }
+}

--- a/test/components/Popover.spec.ts
+++ b/test/components/Popover.spec.ts
@@ -4,6 +4,8 @@ import { mountSuspended } from '@nuxt/test-utils/runtime'
 import { renderEach } from '../component-render'
 import Popover from '../../src/runtime/components/Popover.vue'
 
+const reference = { getBoundingClientRect: () => ({ x: 0, y: 0, top: 0, left: 0, right: 0, bottom: 0, width: 0, height: 0, toJSON: () => ({}) }) as DOMRect }
+
 describe('Popover', () => {
   const props = { open: true, portal: false }
 
@@ -13,11 +15,38 @@ describe('Popover', () => {
     ['with arrow', { props: { ...props, arrow: true } }],
     ['with class', { props: { ...props, class: 'shadow-xl' } }],
     ['with b24ui', { props: { ...props, b24ui: { content: 'shadow-xl' } } }],
+    ['with reference', { props: { ...props, reference }, slots: { content: () => 'Content slot' } }],
     // Slots
     ['with default slot', { props, slots: { default: () => 'Default slot' } }],
     ['with content slot', { props, slots: { content: () => 'Content slot' } }],
     ['with anchor slot', { props, slots: { anchor: () => 'Anchor slot' } }]
   ])
+
+  it('anchors the content to a custom reference without rendering a trigger', async () => {
+    const wrapper = await mountSuspended(Popover, {
+      props: { ...props, reference },
+      slots: { content: () => 'Tour step' }
+    })
+
+    // Content renders, positioned against the reference
+    expect(wrapper.find('[data-slot="content"]').exists()).toBe(true)
+    expect(wrapper.text()).toContain('Tour step')
+
+    // No trigger and no leftover anchor placeholder element
+    expect(wrapper.find('button').exists()).toBe(false)
+    expect(wrapper.find('span[aria-hidden="true"]').exists()).toBe(false)
+  })
+
+  it('renders the trigger and anchors to the reference when both are provided', async () => {
+    const wrapper = await mountSuspended(Popover, {
+      props: { ...props, reference },
+      slots: { default: () => 'Trigger', content: () => 'Anchored content' }
+    })
+
+    expect(wrapper.text()).toContain('Trigger')
+    expect(wrapper.find('[data-slot="content"]').exists()).toBe(true)
+    expect(wrapper.text()).toContain('Anchored content')
+  })
 
   it('passes accessibility tests', async () => {
     const wrapper = await mountSuspended(Popover, {

--- a/test/components/__snapshots__/Popover-vue.spec.ts.snap
+++ b/test/components/__snapshots__/Popover-vue.spec.ts.snap
@@ -113,3 +113,21 @@ exports[`Popover > renders with open correctly 1`] = `
 
 <!--teleport end-->"
 `;
+
+exports[`Popover > renders with reference correctly 1`] = `
+"<!--v-if-->
+<!--v-if-->
+<!--teleport start-->
+
+
+
+<div data-reka-popper-content-wrapper="" style="position: fixed; left: 0px; top: 0px; transform: translate(0, -200%); min-width: max-content;">
+  <div data-dismissable-layer="" style="--reka-popover-content-transform-origin: var(--reka-popper-transform-origin); --reka-popover-content-available-width: var(--reka-popper-available-width); --reka-popover-content-available-height: var(--reka-popper-available-height); --reka-popover-trigger-width: var(--reka-popper-anchor-width); --reka-popover-trigger-height: var(--reka-popper-anchor-height); animation: none;" tabindex="-1" data-slot="content" class="base-mode bg-(--ui-color-bg-content-primary) shadow-(--popup-window-box-shadow) rounded-(--ui-border-radius-xl) will-change-[opacity] motion-safe:data-[state=open]:animate-[scale-in_100ms_ease-out] motion-safe:data-[state=closed]:animate-[scale-out_100ms_ease-in] origin-(--reka-popover-content-transform-origin) focus:outline-none pointer-events-auto" id="reka-popover-content-v-0" data-state="open" aria-labelledby="" role="dialog" data-side="bottom" data-align="center">Content slot
+    <!--v-if-->
+  </div>
+</div>
+
+
+
+<!--teleport end-->"
+`;

--- a/test/components/__snapshots__/Popover.spec.ts.snap
+++ b/test/components/__snapshots__/Popover.spec.ts.snap
@@ -113,3 +113,21 @@ exports[`Popover > renders with open correctly 1`] = `
 
 <!--teleport end-->"
 `;
+
+exports[`Popover > renders with reference correctly 1`] = `
+"<!--v-if-->
+<!--v-if-->
+<!--teleport start-->
+
+
+
+<div data-reka-popper-content-wrapper="" style="position: fixed; left: 0px; top: 0px; transform: translate(0, -200%); min-width: max-content;">
+  <div data-dismissable-layer="" style="--reka-popover-content-transform-origin: var(--reka-popper-transform-origin); --reka-popover-content-available-width: var(--reka-popper-available-width); --reka-popover-content-available-height: var(--reka-popper-available-height); --reka-popover-trigger-width: var(--reka-popper-anchor-width); --reka-popover-trigger-height: var(--reka-popper-anchor-height); animation: none;" tabindex="-1" data-slot="content" class="base-mode bg-(--ui-color-bg-content-primary) shadow-(--popup-window-box-shadow) rounded-(--ui-border-radius-xl) will-change-[opacity] motion-safe:data-[state=open]:animate-[scale-in_100ms_ease-out] motion-safe:data-[state=closed]:animate-[scale-out_100ms_ease-in] origin-(--reka-popover-content-transform-origin) focus:outline-none pointer-events-auto" id="reka-popover-content-v-0-0-0" data-state="open" aria-labelledby="" role="dialog" data-side="bottom" data-align="center">Content slot
+    <!--v-if-->
+  </div>
+</div>
+
+
+
+<!--teleport end-->"
+`;

--- a/test/composables/useTour.spec.ts
+++ b/test/composables/useTour.spec.ts
@@ -1,0 +1,183 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import { ref, nextTick } from 'vue'
+import { useTour } from '../../src/runtime/composables/useTour'
+
+describe('useTour', () => {
+  afterEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  describe('state & navigation', () => {
+    it('starts closed with sensible defaults', () => {
+      const tour = useTour([{ title: 'a' }, { title: 'b' }, { title: 'c' }])
+
+      expect(tour.open.value).toBe(false)
+      expect(tour.index.value).toBe(0)
+      expect(tour.total.value).toBe(3)
+      expect(tour.hasPrev.value).toBe(false)
+      expect(tour.hasNext.value).toBe(true)
+      expect(tour.current.value).toEqual({ title: 'a' })
+    })
+
+    it('opens with start() and walks forward/back', () => {
+      const tour = useTour([{ title: 'a' }, { title: 'b' }, { title: 'c' }])
+
+      tour.start()
+      expect(tour.open.value).toBe(true)
+      expect(tour.index.value).toBe(0)
+
+      tour.next()
+      expect(tour.index.value).toBe(1)
+      expect(tour.hasPrev.value).toBe(true)
+      expect(tour.hasNext.value).toBe(true)
+
+      tour.next()
+      expect(tour.index.value).toBe(2)
+      expect(tour.hasNext.value).toBe(false)
+
+      tour.prev()
+      expect(tour.index.value).toBe(1)
+    })
+
+    it('finishes (closes) when calling next() on the last step without loop', () => {
+      const tour = useTour([{ title: 'a' }, { title: 'b' }])
+
+      tour.start(1)
+      expect(tour.open.value).toBe(true)
+
+      tour.next()
+      expect(tour.open.value).toBe(false)
+    })
+
+    it('loops back to the first step when loop is enabled', () => {
+      const tour = useTour([{ title: 'a' }, { title: 'b' }], { loop: true })
+
+      tour.start(1)
+      tour.next()
+      expect(tour.index.value).toBe(0)
+      expect(tour.open.value).toBe(true)
+    })
+
+    it('clamps goTo() to the steps range and opens', () => {
+      const tour = useTour([{ title: 'a' }, { title: 'b' }, { title: 'c' }])
+
+      tour.goTo(99)
+      expect(tour.index.value).toBe(2)
+      expect(tour.open.value).toBe(true)
+
+      tour.goTo(-5)
+      expect(tour.index.value).toBe(0)
+    })
+
+    it('respects initialStep', () => {
+      const tour = useTour([{ title: 'a' }, { title: 'b' }], { initialStep: 1 })
+
+      expect(tour.index.value).toBe(1)
+      tour.start()
+      expect(tour.index.value).toBe(1)
+    })
+
+    it('closes automatically when the steps become empty', async () => {
+      const steps = ref([{ title: 'a' }])
+      const tour = useTour(steps)
+
+      tour.start()
+      expect(tour.open.value).toBe(true)
+
+      steps.value = []
+      await nextTick()
+
+      expect(tour.open.value).toBe(false)
+      expect(tour.total.value).toBe(0)
+    })
+
+    it('does not open when there are no steps', () => {
+      const tour = useTour([])
+
+      tour.start()
+      expect(tour.open.value).toBe(false)
+      expect(tour.total.value).toBe(0)
+
+      tour.goTo(2)
+      expect(tour.open.value).toBe(false)
+    })
+
+    it('passes arbitrary step fields through via current', () => {
+      const tour = useTour([{ target: null, title: 'x', side: 'right', body: 'hello' }])
+      tour.start()
+
+      expect(tour.current.value?.side).toBe('right')
+      expect(tour.current.value?.body).toBe('hello')
+    })
+  })
+
+  describe('reference resolution', () => {
+    it('is undefined while the tour is closed', () => {
+      const el = document.createElement('div')
+      const tour = useTour([{ target: el }])
+
+      expect(tour.reference.value).toBeUndefined()
+    })
+
+    it('resolves a direct element target', () => {
+      const el = document.createElement('div')
+      const tour = useTour([{ target: el }])
+      tour.start()
+
+      expect(tour.reference.value).toBe(el)
+    })
+
+    it('resolves a getter target', () => {
+      const el = document.createElement('div')
+      const tour = useTour([{ target: () => el }])
+      tour.start()
+
+      expect(tour.reference.value).toBe(el)
+    })
+
+    it('resolves a string selector target', () => {
+      const el = document.createElement('div')
+      el.id = 'tour-step'
+      document.body.appendChild(el)
+
+      const tour = useTour([{ target: '#tour-step' }])
+      tour.start()
+
+      expect(tour.reference.value).toBe(el)
+    })
+
+    it('resolves a bare id as #id', () => {
+      const el = document.createElement('div')
+      el.id = 'bare-id'
+      document.body.appendChild(el)
+
+      const tour = useTour([{ target: 'bare-id' }])
+      tour.start()
+
+      expect(tour.reference.value).toBe(el)
+    })
+
+    it('is undefined for a non-matching selector', () => {
+      const tour = useTour([{ target: '#no-such-id' }])
+      tour.start()
+
+      expect(tour.reference.value).toBeUndefined()
+    })
+
+    it('does not throw on a malformed selector and resolves to undefined', () => {
+      const tour = useTour([{ target: '#a b]' }])
+      tour.start()
+
+      expect(() => tour.reference.value).not.toThrow()
+      expect(tour.reference.value).toBeUndefined()
+    })
+
+    it('falls back to a centered virtual element when target is null', () => {
+      const tour = useTour([{ target: null }])
+      tour.start()
+
+      expect(typeof tour.reference.value?.getBoundingClientRect).toBe('function')
+      expect(tour.reference.value).not.toBeInstanceOf(Element)
+    })
+  })
+})


### PR DESCRIPTION
Port of upstream nuxt/ui [`dc051512`](https://github.com/nuxt/ui/commit/dc0515128ee6783b6cebd410c85a3e405fb7872a) — `feat(useTour): new composable (#6557)`.

## Changes
New `useTour` composable that drives a guided tour with a single Popover whose anchor moves between steps.

- **`useTour.ts`** — new composable, copied essentially verbatim (framework-agnostic: only `reka-ui` `ReferenceElement` + Vue). Only adaptation: jsDoc `@example` `<UPopover>` → `<B24Popover>`.
- **`composables/index.ts`** + **`imports.ts`** — register `useTour` for auto-import.
- **`Popover.vue`** — move the `reference` off the Trigger onto the Content (`:reference="props.reference ?? props.content?.reference"`), so the popover can (reactively) re-anchor to a virtual element for a tour. Trigger now renders on `v-if="!!slots.default"`.
- **tests** — `useTour.spec.ts` verbatim; `Popover.spec.ts` gains a `with reference` case + two anchor tests; regenerated Popover snapshots (+2).
- **docs** — `use-tour.md` + `UseTourExample.vue`, adapted: `B24Button`/`B24Popover`, `i-lucide-wand-sparkles` → `@bitrix24/b24icons-vue/outline/MagicWandIcon`, `color="neutral" variant="outline"` → `color="air-tertiary"`, `text-highlighted` → `text-base`, badge `Soon` → `New` (the composable ships in b24ui).

## Verification (pnpm 11.5.0, gate ON)
dev:prepare · lint · typecheck (incl. docs) · test (**5036 passed**, 6 skipped — +40) · module build — all green.

Ledger: records the merge sha for the previous port (#175, `5199b7e1`) and advances the sync cursor to `dc051512`.

https://claude.ai/code/session_01Qz7EXMncvEGiCj4WbmYgJo

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qz7EXMncvEGiCj4WbmYgJo)_