### PR TITLE
fix(Link): set default for locale prop

### DIFF
--- a/.sync/log/e9ab75888a3143f77ebcc18b8fe40ba370d065d5.md
+++ b/.sync/log/e9ab75888a3143f77ebcc18b8fe40ba370d065d5.md
@@ -1,0 +1,20 @@
+# Port: fix(Link): set default for locale prop (#6563)
+
+**Upstream:** `e9ab75888a3143f77ebcc18b8fe40ba370d065d5` (nuxt/ui)
+**Decision:** port
+
+## Upstream change
+`Link.vue`: add `locale: undefined` to the `withDefaults` block so the `locale`
+prop has an explicit default.
+
+## b24ui adaptation
+Direct 1:1 — added `locale: undefined` after `active: undefined` in b24ui's
+`withDefaults` (b24ui also carries an extra `isAction: false` default; left as
+is).
+
+## Verification (pnpm 11.5.0, gate ON)
+dev:prepare · lint · typecheck · test (5036 passed, 6 skipped) · module build —
+all green. `undefined` is already the implicit default → no rendered/snapshot
+change.
+
+Platform note: b24ui CI is `ubuntu-latest` only.

--- a/.sync/nuxt-ui.json
+++ b/.sync/nuxt-ui.json
@@ -2,7 +2,7 @@
   "upstream": "nuxt/ui",
   "branch": "v4",
   "sync_enabled": false,
-  "cursor": "dc0515128ee6783b6cebd410c85a3e405fb7872a",
+  "cursor": "e9ab75888a3143f77ebcc18b8fe40ba370d065d5",
   "_cursor_note": "cursor = last upstream commit ported into b24ui (oldest-first, manual cadence). sync_enabled stays false until Phase 2 (porter workflow #67 + CLAUDE_CODE_OAUTH_TOKEN) is wired and trusted. `processed` is maintained per port from now on (backfilled #68-#72 on 2026-06-09).",
   "stats": {
     "queue_depth": 0,
@@ -461,10 +461,16 @@
       "summary": "feat(ContentSearch/DashboardSearch): forward input config to command palette (#6312) — CommandPalette.vue: move v-bind(props.input) after explicit input binds so forwarded config wins; DashboardSearch.vue + ContentSearch.vue: add input?:boolean|Omit<InputProps,'modelValue'|'defaultValue'> prop, inputProps computed (false->false else defu(input,{fixed:true})), bind :input=\"inputProps\". No snapshot churn (default still {fixed:true})"
     },
     "dc0515128ee6783b6cebd410c85a3e405fb7872a": {
+      "pr": 176,
+      "b24ui_sha": "4fc446be",
+      "decision": "port",
+      "summary": "feat(useTour): new composable (#6557) — new useTour.ts (verbatim, framework-agnostic; jsdoc UPopover->B24Popover), registered in composables/index.ts + imports.ts publicComposables. Popover.vue: move reference from Trigger to Content (:reference=props.reference??props.content?.reference) + jsdoc; Trigger v-if drops ||props.reference. Tests: useTour.spec verbatim + Popover reference case/2 it-tests (+2 snapshots). Docs use-tour.md + UseTourExample.vue (B24*, MagicWandIcon, air-tertiary, text-base; badge New not Soon)"
+    },
+    "e9ab75888a3143f77ebcc18b8fe40ba370d065d5": {
       "pr": null,
       "b24ui_sha": "pending-merge",
       "decision": "port",
-      "summary": "feat(useTour): new composable (#6557) — new useTour.ts (verbatim, framework-agnostic; jsdoc UPopover->B24Popover), registered in composables/index.ts + imports.ts publicComposables. Popover.vue: move reference from Trigger to Content (:reference=props.reference??props.content?.reference) + jsdoc; Trigger v-if drops ||props.reference. Tests: useTour.spec verbatim + Popover reference case/2 it-tests (+2 snapshots). Docs use-tour.md + UseTourExample.vue (B24*, MagicWandIcon, air-tertiary, text-base; badge New not Soon)"
+      "summary": "fix(Link): set default for locale prop (#6563) — add locale: undefined to Link.vue withDefaults (explicit default). Direct 1:1; no render change (undefined already implicit)"
     }
   }
 }

--- a/src/runtime/components/Link.vue
+++ b/src/runtime/components/Link.vue
@@ -136,7 +136,8 @@ const props = withDefaults(defineProps<LinkProps>(), {
   type: 'button',
   ariaCurrentValue: 'page',
   isAction: false,
-  active: undefined
+  active: undefined,
+  locale: undefined
 })
 defineSlots<LinkSlots>()
 


### PR DESCRIPTION
Port of upstream nuxt/ui [`e9ab7588`](https://github.com/nuxt/ui/commit/e9ab75888a3143f77ebcc18b8fe40ba370d065d5) — `fix(Link): set default for locale prop (#6563)`.

## Changes
- **`Link.vue`**: add `locale: undefined` to the `withDefaults` block so the `locale` prop has an explicit default. Direct 1:1 (b24ui also carries an extra `isAction: false` default, left as is).

## Verification (pnpm 11.5.0, gate ON)
dev:prepare · lint · typecheck · test (**5036 passed**, 6 skipped) · module build — all green. `undefined` is already the implicit default → no rendered/snapshot change.

Ledger: records the merge sha for the previous port (#176, `dc051512`) and advances the sync cursor to `e9ab7588`.

https://claude.ai/code/session_01Qz7EXMncvEGiCj4WbmYgJo

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qz7EXMncvEGiCj4WbmYgJo)_