### PR TITLE
feat(module): add `theme.unstyled` option

### DIFF
--- a/.sync/log/a2a8bc907a5e490fd056e112f86e52c6416b8636.md
+++ b/.sync/log/a2a8bc907a5e490fd056e112f86e52c6416b8636.md
@@ -1,0 +1,37 @@
+# Port: feat(module): add `theme.unstyled` option (#6551)
+
+**Upstream:** `a2a8bc907a5e490fd056e112f86e52c6416b8636` (nuxt/ui)
+**Decision:** port
+
+## Upstream change
+New `theme.unstyled` module option that blanks all default theme class strings
+(keeping slot/variant keys) so components render structure-only.
+- `module.ts`: add `unstyled?: boolean` to `ModuleOptions.theme`.
+- `utils/theme.ts`: new `applyUnstyled(result, unstyled)`.
+- `templates.ts`: import + call `applyUnstyled` between `applyDefaultVariants`
+  and `applyPrefixToObject` (prod + dev template paths).
+- `utils/defaults.ts`: `unstyled: false` default.
+- `Avatar.vue`: guard `(rootClass.value || '')` (root can be empty when unstyled).
+- tests `test/utils/theme.spec.ts`; docs sections in nuxt.md + vue.md.
+
+## b24ui adaptation
+- `module.ts`: `unstyled?: boolean` added to the theme interface (b24ui has no
+  `transitions`/`colors`/`defaultVariants`-with-jsdoc-`@see` to ui.nuxt.com;
+  used the b24ui docs URL and `b24ui`/`app.config.b24ui` wording).
+- `utils/theme.ts`: `applyUnstyled` copied verbatim, jsdoc `ui`→`b24ui`.
+- `templates.ts`: same insertion (prod + dev). b24ui's dev path keeps its own
+  `prefixJson = 'undefined'`; `unstyledJson` uses `JSON.stringify(...)` so
+  unstyled applies in `--uiDev` too.
+- `Avatar.vue`: same `(rootClass.value || '')` guard.
+- **`utils/defaults.ts`: skipped** — b24ui's `defaultOptions` has no `theme`
+  block, and `applyUnstyled` treats `undefined` as off, so no default needed.
+- tests: `theme.spec.ts` copied verbatim (framework-agnostic fixture).
+- docs: `### theme.unstyled` sections added to `1.nuxt.md` (`b24ui:` module
+  key) and `2.vue.md` (`bitrix24UIPluginVite`), `ui`→`b24ui`, dropped the
+  upstream `:badge{label="Soon"}` since the option ships in b24ui.
+
+## Verification (pnpm 11.5.2, gate ON)
+dev:prepare · lint · typecheck (incl. docs) · test (5046 passed, 6 skipped —
++10 applyUnstyled ×2 projects) · module build — all green.
+
+Platform note: b24ui CI is `ubuntu-latest` only.

--- a/.sync/nuxt-ui.json
+++ b/.sync/nuxt-ui.json
@@ -2,7 +2,7 @@
   "upstream": "nuxt/ui",
   "branch": "v4",
   "sync_enabled": false,
-  "cursor": "9ad24cfdb49c6c203fa7a59e542fd19d7828113a",
+  "cursor": "a2a8bc907a5e490fd056e112f86e52c6416b8636",
   "_cursor_note": "cursor = last upstream commit ported into b24ui (oldest-first, manual cadence). sync_enabled stays false until Phase 2 (porter workflow #67 + CLAUDE_CODE_OAUTH_TOKEN) is wired and trusted. `processed` is maintained per port from now on (backfilled #68-#72 on 2026-06-09).",
   "stats": {
     "queue_depth": 0,
@@ -479,10 +479,16 @@
       "summary": "chore(deps): update tiptap to ^3.26.0 (#6568) — all @tiptap/* ^3.24.0->^3.26.0 across 5 manifests (root 17, docs/nuxt/vue/demo 2 each; demo mirrored per invariant; repl pins none); lockfile regen under gate (resolves 3.26.1)"
     },
     "9ad24cfdb49c6c203fa7a59e542fd19d7828113a": {
+      "pr": 179,
+      "b24ui_sha": "233b6bd0",
+      "decision": "port",
+      "summary": "chore(deps): update all non-major dependencies (#6567) — selective shared deps: root packageManager 11.5.0->11.5.2, @tanstack/vue-virtual ^3.13.28, fuse.js ^7.4.2, @vue/test-utils ^2.4.11, ai ^6.0.197, happy-dom ^20.10.2, vitest ^4.1.8; docs @ai-sdk/mcp ^1.0.46/@ai-sdk/vue ^3.0.197/@comark/vue ^0.4.0/@takumi-rs/core ^1.7.0/ai ^6.0.197/nuxt-og-image ^6.5.2/nuxt-schema-org ^6.1.0/shiki ^4.2.0; playgrounds nuxt+demo @ai-sdk/vue ^3.0.197/@comark/vue ^0.4.0/ai ^6.0.197 (demo mirrored). Skipped reproduire.yml, @nuxt/icon, @ai-sdk/gateway, @iconify-json/*, release-it (n/a). lockfile regen under gate"
+    },
+    "a2a8bc907a5e490fd056e112f86e52c6416b8636": {
       "pr": null,
       "b24ui_sha": "pending-merge",
       "decision": "port",
-      "summary": "chore(deps): update all non-major dependencies (#6567) — selective shared deps: root packageManager 11.5.0->11.5.2, @tanstack/vue-virtual ^3.13.28, fuse.js ^7.4.2, @vue/test-utils ^2.4.11, ai ^6.0.197, happy-dom ^20.10.2, vitest ^4.1.8; docs @ai-sdk/mcp ^1.0.46/@ai-sdk/vue ^3.0.197/@comark/vue ^0.4.0/@takumi-rs/core ^1.7.0/ai ^6.0.197/nuxt-og-image ^6.5.2/nuxt-schema-org ^6.1.0/shiki ^4.2.0; playgrounds nuxt+demo @ai-sdk/vue ^3.0.197/@comark/vue ^0.4.0/ai ^6.0.197 (demo mirrored). Skipped reproduire.yml, @nuxt/icon, @ai-sdk/gateway, @iconify-json/*, release-it (n/a). lockfile regen under gate"
+      "summary": "feat(module): add theme.unstyled option (#6551) — module.ts unstyled?:boolean in theme interface; utils/theme.ts applyUnstyled (blanks slots/variants/compoundVariants classes, keeps keys); templates.ts call in prod+dev paths; Avatar.vue (rootClass.value||'') guard; test/utils/theme.spec.ts verbatim (+10 tests); docs nuxt.md+vue.md sections (b24ui key, dropped Soon badge). Skipped defaults.ts (b24ui has no theme defaults block)"
     }
   }
 }

--- a/docs/content/docs/1.getting-started/2.installation/1.nuxt.md
+++ b/docs/content/docs/1.getting-started/2.installation/1.nuxt.md
@@ -171,6 +171,28 @@ export default defineNuxtConfig({
 })
 ```
 
+### `theme.unstyled`
+
+Use the `theme.unstyled` option to remove all default theme classes from components, keeping only their structure and the classes you provide through `class`, `b24ui` or `app.config.b24ui`.
+
+- Default: `false`{lang="ts-type"}
+
+```ts [nuxt.config.ts] {4-8}
+export default defineNuxtConfig({
+  modules: ['@bitrix24/b24ui-nuxt'],
+  css: ['~/assets/css/main.css'],
+  b24ui: {
+    theme: {
+      unstyled: true
+    }
+  }
+})
+```
+
+::warning
+This strips **structural** classes too (positioning, transitions, flex/grid), not just cosmetic ones. Layout-heavy components like `Modal`, `Drawer` or `Calendar` will need you to re-supply their layout, similar to PrimeVue's unstyled mode.
+::
+
 ### `theme.prefix`
 
 Use the `theme.prefix` option to configure the same prefix you set on your Tailwind CSS import. This ensures Bitrix24 UI components use the correct prefixed utility classes and CSS variables.

--- a/docs/content/docs/1.getting-started/2.installation/2.vue.md
+++ b/docs/content/docs/1.getting-started/2.installation/2.vue.md
@@ -514,6 +514,33 @@ export default defineConfig({
 })
 ```
 
+### `theme.unstyled`
+
+Use the `theme.unstyled` option to remove all default theme classes from components, keeping only their structure and the classes you provide through `class`, `b24ui` or `app.config.b24ui`.
+
+- Default: `false`{lang="ts-type"}
+
+```ts [vite.config.ts] {9-11}
+import { defineConfig } from 'vite'
+import vue from '@vitejs/plugin-vue'
+import bitrix24UIPluginVite from '@bitrix24/b24ui-nuxt/vite'
+
+export default defineConfig({
+  plugins: [
+    vue(),
+    bitrix24UIPluginVite({
+      theme: {
+        unstyled: true
+      }
+    })
+  ]
+})
+```
+
+::warning
+This strips **structural** classes too (positioning, transitions, flex/grid), not just cosmetic ones. Layout-heavy components like `Modal`, `Drawer` or `Calendar` will need you to re-supply their layout, similar to PrimeVue's unstyled mode.
+::
+
 ### `theme.prefix`
 
 Use the `theme.prefix` option to configure the same prefix you set on your Tailwind CSS import. This ensures Bitrix24 UI components use the correct prefixed utility classes and CSS variables.

--- a/src/module.ts
+++ b/src/module.ts
@@ -36,6 +36,14 @@ export interface ModuleOptions {
    */
   theme?: {
     /**
+     * Remove all default theme classes from components, keeping only their
+     * structure and the classes you supply via `class`, `b24ui` or `app.config.b24ui`.
+     * @defaultValue `false`
+     * @see https://bitrix24.github.io/b24ui/docs/getting-started/installation/nuxt/#themeunstyled
+     */
+    unstyled?: boolean
+
+    /**
      * The default variants to use for components
      * @see https://bitrix24.github.io/b24ui/docs/getting-started/installation/nuxt/#themedefaultvariants
      */

--- a/src/runtime/components/Avatar.vue
+++ b/src/runtime/components/Avatar.vue
@@ -88,7 +88,7 @@ const b24ui = computed(() => tv({ extend: tv(theme), ...(appConfig.b24ui?.avatar
 const rootClass = computed(() => b24ui.value.root({ class: [props.b24ui?.root, props.class] }))
 
 const sizePx = computed(() => {
-  const sizeClass = rootClass.value.split(' ').find(c => /^size-\d+$/.test(c))
+  const sizeClass = (rootClass.value || '').split(' ').find(c => /^size-\d+$/.test(c))
   if (sizeClass) {
     const num = Number.parseFloat(sizeClass.split('-')[1] ?? '')
     if (!Number.isNaN(num)) return num * 4

--- a/src/templates.ts
+++ b/src/templates.ts
@@ -6,7 +6,7 @@ import { addTemplate, addTypeTemplate, hasNuxtModule, logger, updateTemplates, g
 import type { Nuxt, NuxtTemplate, NuxtTypeTemplate } from '@nuxt/schema'
 import type { Resolver } from '@nuxt/kit'
 import type { ModuleOptions } from './module'
-import { applyDefaultVariants, applyPrefixToObject } from './utils/theme'
+import { applyDefaultVariants, applyPrefixToObject, applyUnstyled } from './utils/theme'
 import { detectUsedComponents } from './utils/components'
 import * as theme from './theme'
 import * as themeProse from './theme/prose'
@@ -32,6 +32,8 @@ export function getTemplates(options: ModuleOptions, uiConfig: Record<string, an
 
           // Override default variants from nuxt.config.ts
           result = applyDefaultVariants(result, options.theme?.defaultVariants)
+          // Strip default theme classes if `unstyled` is enabled
+          result = applyUnstyled(result, options.theme?.unstyled)
           // Apply Tailwind prefix if configured
           result = applyPrefixToObject(result, options.theme?.prefix)
 
@@ -65,14 +67,16 @@ export function getTemplates(options: ModuleOptions, uiConfig: Record<string, an
             const themeUtilsPath = fileURLToPath(new URL('./utils/theme', import.meta.url))
             const defaultVariantsJson = JSON.stringify(options.theme?.defaultVariants) ?? 'undefined'
             const prefixJson = 'undefined'
+            const unstyledJson = JSON.stringify(options.theme?.unstyled) ?? 'undefined'
 
             return [
               `import template from ${JSON.stringify(templatePath)}`,
-              `import { applyDefaultVariants, applyPrefixToObject } from ${JSON.stringify(themeUtilsPath)}`,
+              `import { applyDefaultVariants, applyPrefixToObject, applyUnstyled } from ${JSON.stringify(themeUtilsPath)}`,
               ...generateVariantDeclarations(variants),
               `const options = ${JSON.stringify(options, null, 2)}`,
               `let result = typeof template === 'function' ? (template as Function)(options) : template`,
               `result = applyDefaultVariants(result, ${defaultVariantsJson})`,
+              `result = applyUnstyled(result, ${unstyledJson})`,
               `result = applyPrefixToObject(result, ${prefixJson})`,
               `const theme = ${json}`,
               `export default result as typeof theme`

--- a/src/utils/theme.ts
+++ b/src/utils/theme.ts
@@ -77,6 +77,50 @@ export function applyPrefixToObject(obj: any, prefix?: string, context: string[]
 }
 
 /**
+ * Blank every class string in a theme so components render without their
+ * default styles, keeping only what the user supplies via `class`, `b24ui` or
+ * `app.config.b24ui`. All keys are preserved (slots stay callable, `variants` and
+ * `defaultVariants` keep their values) so variant props still type-check and
+ * validate. Mirrors `tailwind-variants` shapes: a slot value is either a class
+ * string/array or, inside `variants`/`compoundVariants`, an object mapping slot
+ * names to classes.
+ * @param result - The theme result object
+ * @param unstyled - Whether to strip the theme classes
+ * @returns The theme result with blanked class strings
+ */
+export function applyUnstyled(result: any, unstyled?: boolean): any {
+  if (!result || !unstyled) {
+    return result
+  }
+
+  const blank = (value: unknown): unknown => (value && typeof value === 'object' && !Array.isArray(value))
+    ? Object.fromEntries(Object.keys(value as Record<string, unknown>).map(slot => [slot, '']))
+    : ''
+
+  if (result.slots) {
+    result.slots = Object.fromEntries(Object.keys(result.slots).map(slot => [slot, '']))
+  }
+
+  if (result.variants) {
+    result.variants = Object.fromEntries(
+      Object.entries(result.variants).map(([name, group]) => [
+        name,
+        Object.fromEntries(Object.entries(group as Record<string, unknown>).map(([key, value]) => [key, blank(value)]))
+      ])
+    )
+  }
+
+  if (result.compoundVariants) {
+    result.compoundVariants = result.compoundVariants.map((entry: Record<string, unknown>) => {
+      const { class: cls, ...selectors } = entry
+      return { ...selectors, class: blank(cls) }
+    })
+  }
+
+  return result
+}
+
+/**
  * Override default variants from module options
  * @param result - The theme result object
  * @param defaultVariants - The default variants from module options

--- a/test/utils/theme.spec.ts
+++ b/test/utils/theme.spec.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest'
+import { applyUnstyled } from '../../src/utils/theme'
+
+describe('applyUnstyled', () => {
+  const theme = () => ({
+    slots: {
+      base: 'inline-flex rounded-md',
+      label: 'truncate'
+    },
+    variants: {
+      color: {
+        primary: 'bg-primary text-inverted',
+        neutral: { base: 'bg-inverted', label: 'text-default' }
+      },
+      size: {
+        md: { base: 'px-2.5 text-sm' }
+      }
+    },
+    compoundVariants: [
+      { color: 'primary', variant: 'solid', class: 'bg-primary' },
+      { size: 'md', class: { base: 'gap-1.5' } }
+    ],
+    defaultVariants: {
+      color: 'primary',
+      size: 'md'
+    }
+  })
+
+  it('returns the theme untouched when unstyled is falsy', () => {
+    const input = theme()
+    expect(applyUnstyled(input, false)).toBe(input)
+    expect(applyUnstyled(input, undefined)).toBe(input)
+    expect(input).toEqual(theme())
+  })
+
+  it('blanks every slot class but keeps the slot keys', () => {
+    const result = applyUnstyled(theme(), true)
+    expect(result.slots).toEqual({ base: '', label: '' })
+  })
+
+  it('blanks variant classes in both string and slot-object forms', () => {
+    const result = applyUnstyled(theme(), true)
+    expect(result.variants.color.primary).toBe('')
+    expect(result.variants.color.neutral).toEqual({ base: '', label: '' })
+    expect(result.variants.size.md).toEqual({ base: '' })
+  })
+
+  it('blanks compoundVariants classes but keeps the selectors', () => {
+    const result = applyUnstyled(theme(), true)
+    expect(result.compoundVariants).toEqual([
+      { color: 'primary', variant: 'solid', class: '' },
+      { size: 'md', class: { base: '' } }
+    ])
+  })
+
+  it('preserves defaultVariants and variant keys so props still validate', () => {
+    const result = applyUnstyled(theme(), true)
+    expect(result.defaultVariants).toEqual({ color: 'primary', size: 'md' })
+    expect(Object.keys(result.variants)).toEqual(['color', 'size'])
+    expect(Object.keys(result.variants.color)).toEqual(['primary', 'neutral'])
+  })
+})


### PR DESCRIPTION
Port of upstream nuxt/ui [`a2a8bc90`](https://github.com/nuxt/ui/commit/a2a8bc907a5e490fd056e112f86e52c6416b8636) — `feat(module): add `theme.unstyled` option (#6551)`.

## Changes
New `theme.unstyled` module option — blanks all default theme class strings (keeping slot/variant/compoundVariant **keys** so variant props still type-check) for structure-only rendering.
- **`module.ts`**: `unstyled?: boolean` on `ModuleOptions.theme`.
- **`utils/theme.ts`**: new `applyUnstyled(result, unstyled)`.
- **`templates.ts`**: call `applyUnstyled` between `applyDefaultVariants` and `applyPrefixToObject` (prod + dev template paths).
- **`Avatar.vue`**: guard `(rootClass.value || '')` — root can be empty when unstyled.
- **tests**: `test/utils/theme.spec.ts` (verbatim, +10 across nuxt/vue).
- **docs**: `### theme.unstyled` sections in `1.nuxt.md` + `2.vue.md`.

### b24ui notes / deviations
- `app.config.ui`→`app.config.b24ui`, `ui`→`b24ui`, b24ui module key / vite-plugin in docs; dropped the upstream `:badge{label="Soon"}` (the option ships here).
- **Skipped `utils/defaults.ts`** — b24ui's `defaultOptions` has no `theme` block; `applyUnstyled` treats `undefined` as off, so no default is needed.

## Verification (pnpm 11.5.2, gate ON)
dev:prepare · lint · typecheck (incl. docs) · test (**5046 passed**, 6 skipped) · module build — all green.

Ledger: records the merge sha for the previous port (#179, `9ad24cfd`) and advances the sync cursor to `a2a8bc90`.

https://claude.ai/code/session_01Qz7EXMncvEGiCj4WbmYgJo

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qz7EXMncvEGiCj4WbmYgJo)_