### PR TITLE
fix(ProseKbd): type default slot as `VNode[]`

### DIFF
--- a/.sync/log/52367b1ac375e86b4f996ed07958114e9d63a81a.md
+++ b/.sync/log/52367b1ac375e86b4f996ed07958114e9d63a81a.md
@@ -1,0 +1,18 @@
+# Port: fix(ProseKbd): type default slot as `VNode[]` (#…)
+
+**Upstream:** `52367b1ac375e86b4f996ed07958114e9d63a81a` (nuxt/ui)
+**Decision:** port
+
+## Upstream change
+`prose/Kbd.vue`: import `VNode` and type the `default` slot as `VNode[]`
+instead of `any`.
+
+## b24ui adaptation
+Direct 1:1 — `import type { VNode } from 'vue'` and `ProseKbdSlots.default`
+return `VNode[]`. (b24ui's Kbd uses `#build/b24ui/prose/kbd`; otherwise identical.)
+
+## Verification (pnpm 11.5.2, gate ON)
+dev:prepare · lint · typecheck · test (5052 passed, 6 skipped) · module build —
+all green. Type-only change; no snapshot churn.
+
+Platform note: b24ui CI is `ubuntu-latest` only.

--- a/.sync/nuxt-ui.json
+++ b/.sync/nuxt-ui.json
@@ -2,7 +2,7 @@
   "upstream": "nuxt/ui",
   "branch": "v4",
   "sync_enabled": false,
-  "cursor": "89b30e8ebe2b3b3e637ba823d1c35bc2c2d32a68",
+  "cursor": "52367b1ac375e86b4f996ed07958114e9d63a81a",
   "_cursor_note": "cursor = last upstream commit ported into b24ui (oldest-first, manual cadence). sync_enabled stays false until Phase 2 (porter workflow #67 + CLAUDE_CODE_OAUTH_TOKEN) is wired and trusted. `processed` is maintained per port from now on (backfilled #68-#72 on 2026-06-09).",
   "stats": {
     "queue_depth": 0,
@@ -491,10 +491,16 @@
       "summary": "feat(module): add theme.unstyled option (#6551) — module.ts unstyled?:boolean in theme interface; utils/theme.ts applyUnstyled (blanks slots/variants/compoundVariants classes, keeps keys); templates.ts call in prod+dev paths; Avatar.vue (rootClass.value||'') guard; test/utils/theme.spec.ts verbatim (+10 tests); docs nuxt.md+vue.md sections (b24ui key, dropped Soon badge). Skipped defaults.ts (b24ui has no theme defaults block)"
     },
     "89b30e8ebe2b3b3e637ba823d1c35bc2c2d32a68": {
+      "pr": 181,
+      "b24ui_sha": "092f33a1",
+      "decision": "port",
+      "summary": "feat(PinInput): add separator prop (#6392) — PinInput.vue: separator?:number|number[] prop, PinInputSlots(separator slot), defineSlots, shouldInsertSeparator helper, template rewrite (template v-for + span data-slot=separator with #separator slot fallback bullet); theme/pin-input.ts separator slot. Spec +separator/positions/slot cases (+6 snapshots). Example (Minus40Icon), playground nuxt+demo rows (demo mirrored), docs Separator+Slots sections (dropped Soon badge)"
+    },
+    "52367b1ac375e86b4f996ed07958114e9d63a81a": {
       "pr": null,
       "b24ui_sha": "pending-merge",
       "decision": "port",
-      "summary": "feat(PinInput): add separator prop (#6392) — PinInput.vue: separator?:number|number[] prop, PinInputSlots(separator slot), defineSlots, shouldInsertSeparator helper, template rewrite (template v-for + span data-slot=separator with #separator slot fallback bullet); theme/pin-input.ts separator slot. Spec +separator/positions/slot cases (+6 snapshots). Example (Minus40Icon), playground nuxt+demo rows (demo mirrored), docs Separator+Slots sections (dropped Soon badge)"
+      "summary": "fix(ProseKbd): type default slot as VNode[] — prose/Kbd.vue: import VNode, ProseKbdSlots.default return any -> VNode[]. Direct 1:1 type-only; no snapshot churn"
     }
   }
 }

--- a/src/runtime/components/prose/Kbd.vue
+++ b/src/runtime/components/prose/Kbd.vue
@@ -1,4 +1,5 @@
 <script lang="ts">
+import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/b24ui/prose/kbd'
 import type { ComponentConfig } from '../../types/tv'
@@ -12,7 +13,7 @@ export interface ProseKbdProps {
 }
 
 export interface ProseKbdSlots {
-  default?(props?: {}): any
+  default?(props?: {}): VNode[]
 }
 </script>
 


### PR DESCRIPTION
Port of upstream nuxt/ui [`52367b1a`](https://github.com/nuxt/ui/commit/52367b1ac375e86b4f996ed07958114e9d63a81a) — `fix(ProseKbd): type default slot as `VNode[]``.

## Changes
- **`prose/Kbd.vue`**: `import type { VNode } from 'vue'` and type `ProseKbdSlots.default` as `VNode[]` instead of `any`. Direct 1:1.

## Verification (pnpm 11.5.2, gate ON)
dev:prepare · lint · typecheck · test (**5052 passed**, 6 skipped) · module build — all green. Type-only change; no snapshot churn.

Ledger: records the merge sha for the previous port (#181, `89b30e8e`) and advances the sync cursor to `52367b1a`.

https://claude.ai/code/session_01Qz7EXMncvEGiCj4WbmYgJo

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qz7EXMncvEGiCj4WbmYgJo)_