### PR TITLE
feat(theme): allow replacing slot classes with a function

### DIFF
--- a/.sync/log/ea576e2f321665574c416af34e7ef04e68654a79.md
+++ b/.sync/log/ea576e2f321665574c416af34e7ef04e68654a79.md
@@ -1,0 +1,44 @@
+# Port: feat(theme): allow replacing slot classes with a function (#6562)
+
+**Upstream:** `ea576e2f321665574c416af34e7ef04e68654a79` (nuxt/ui)
+**Decision:** port
+
+## Upstream change
+Let a slot class be a function `(defaults) => classes` that **replaces** a
+slot's default classes (instead of merging) — usable in `:ui`, the `class`
+prop and `app.config.ui`.
+- `types/tv.ts`: add `SlotClassReplacer` + `SlotClass`; widen `base`/`slots` in
+  `TVConfig` and `ComponentSlots` from `ClassValue` to `SlotClass`.
+- `useComponentProps.ts`: `ClassValue` → `SlotClass`.
+- `utils/tv.ts`: rewrite `tv` as a Proxy that detects replacers
+  (findReplacer / plainClasses / applyReplacer / wrapSlots / extractDirectives),
+  plus a `WideTV`/`Widen` type so slot fns accept the replacer at call sites.
+- tests `test/utils/tv.spec.ts` + a Button `:ui` replacer case; docs + skills.
+
+## b24ui adaptation
+- `types/tv.ts` + `useComponentProps.ts`: same `SlotClass`/`SlotClassReplacer`
+  changes (b24ui naming).
+- `utils/tv.ts`: ported the full replacer machinery **preserving b24ui's own
+  `twMergeConfig`** (air `b24-context`/`b24-colors`/`b24-bg` class groups) and
+  the `appConfigTv.b24ui?.tv` config source — the shared `config` (incl.
+  `twMerge: true` + `twMergeConfig`) is reused for `createTV` and the
+  `cnMerge(...)(config)` calls so conflict resolution stays correct.
+- tests: `tv.spec.ts` copied verbatim (framework-agnostic); Button case uses
+  `b24ui: { label: () => … }` and asserts a real default (`text-clip`) is dropped.
+- **playground type fix**: widening `slots` to `SlotClass` made
+  `playgrounds/{nuxt,demo}` `Matrix.vue` / `PlaygroundPage.vue` fail typecheck —
+  they forward `props.b24ui?.root|body` (now possibly a replacer fn) inside a
+  plain `ClassValue` array passed to `B24Card`'s `:b24ui`. Cast those forwarded
+  values to `ClassValue` (dev helpers only ever merge strings).
+- docs: added the function-form note + `:b24ui` example + `theme.unstyled` tip
+  to the `### b24ui prop` section of `5.theme/3.components.md`. **Deviation:**
+  skipped upstream's larger global-config / "Theme component" doc restructure
+  and the `skills/nuxt-ui/...design-system.md` edit — b24ui's theme doc and
+  skills (`skills/b24-ui-nuxt/`) are structured differently; the substantive
+  feature + the per-component note are covered.
+
+## Verification (pnpm 11.5.2, gate ON)
+dev:prepare · lint · typecheck (incl. docs + both playgrounds) · test (5086
+passed, 6 skipped — +34 tv replacer/Button cases) · module build — all green.
+
+Platform note: b24ui CI is `ubuntu-latest` only.

--- a/.sync/nuxt-ui.json
+++ b/.sync/nuxt-ui.json
@@ -2,7 +2,7 @@
   "upstream": "nuxt/ui",
   "branch": "v4",
   "sync_enabled": false,
-  "cursor": "52367b1ac375e86b4f996ed07958114e9d63a81a",
+  "cursor": "ea576e2f321665574c416af34e7ef04e68654a79",
   "_cursor_note": "cursor = last upstream commit ported into b24ui (oldest-first, manual cadence). sync_enabled stays false until Phase 2 (porter workflow #67 + CLAUDE_CODE_OAUTH_TOKEN) is wired and trusted. `processed` is maintained per port from now on (backfilled #68-#72 on 2026-06-09).",
   "stats": {
     "queue_depth": 0,
@@ -497,10 +497,16 @@
       "summary": "feat(PinInput): add separator prop (#6392) — PinInput.vue: separator?:number|number[] prop, PinInputSlots(separator slot), defineSlots, shouldInsertSeparator helper, template rewrite (template v-for + span data-slot=separator with #separator slot fallback bullet); theme/pin-input.ts separator slot. Spec +separator/positions/slot cases (+6 snapshots). Example (Minus40Icon), playground nuxt+demo rows (demo mirrored), docs Separator+Slots sections (dropped Soon badge)"
     },
     "52367b1ac375e86b4f996ed07958114e9d63a81a": {
+      "pr": 182,
+      "b24ui_sha": "1648f650",
+      "decision": "port",
+      "summary": "fix(ProseKbd): type default slot as VNode[] — prose/Kbd.vue: import VNode, ProseKbdSlots.default return any -> VNode[]. Direct 1:1 type-only; no snapshot churn"
+    },
+    "ea576e2f321665574c416af34e7ef04e68654a79": {
       "pr": null,
       "b24ui_sha": "pending-merge",
       "decision": "port",
-      "summary": "fix(ProseKbd): type default slot as VNode[] — prose/Kbd.vue: import VNode, ProseKbdSlots.default return any -> VNode[]. Direct 1:1 type-only; no snapshot churn"
+      "summary": "feat(theme): allow replacing slot classes with a function (#6562) — types/tv.ts +SlotClassReplacer/SlotClass, widen base/slots/ComponentSlots ClassValue->SlotClass; useComponentProps ClassValue->SlotClass; utils/tv.ts rewritten as Proxy with findReplacer/plainClasses/applyReplacer/wrapSlots/extractDirectives + WideTV, preserving b24ui twMergeConfig + b24ui?.tv config; tv.spec.ts verbatim + Button :b24ui replacer case (+34). Playground fix: cast forwarded props.b24ui?.root|body to ClassValue in Matrix/PlaygroundPage (nuxt+demo). Docs: function-form note in 3.components.md b24ui-prop section; skipped global-config/Theme-component restructure + skills file (b24ui structure differs)"
     }
   }
 }

--- a/docs/content/docs/1.getting-started/5.theme/3.components.md
+++ b/docs/content/docs/1.getting-started/5.theme/3.components.md
@@ -240,6 +240,18 @@ slots:
 In this example, the `trailingIcon` slot is overwritten with `size-10` even though the `md` size variant would apply a `size-(--ui-btn-icon-size)` class to it.
 ::
 
+A slot value can also be a function to **replace** its classes instead of merging them. It receives the slot's fully resolved default class string as its argument, so you can reuse part of them if needed:
+
+```vue
+<template>
+  <B24Button :b24ui="{ label: () => 'text-base font-bold' }" label="Button" />
+</template>
+```
+
+::tip{to="/docs/getting-started/installation/nuxt/#themeunstyled"}
+To remove the default classes from all components at once, use the `theme.unstyled` option.
+::
+
 ### `class` prop
 
 The `class` prop allows you to override the classes of the `root` or `base` slot. This takes priority over both global config and resolved `variants`.

--- a/playgrounds/demo/app/components/Matrix.vue
+++ b/playgrounds/demo/app/components/Matrix.vue
@@ -1,4 +1,5 @@
 <script lang="ts">
+import type { ClassValue } from 'tailwind-variants'
 import type { CardProps } from '@bitrix24/b24ui-nuxt'
 
 export type MatrixValue<V> = V extends readonly (infer U)[] ? U : V
@@ -92,8 +93,8 @@ const headers = computed(() => {
         :variant="cardVariant"
         :b24ui="{
           ...props.b24ui,
-          root: ['grow', cardBorderClass, props.b24ui?.root],
-          body: ['flex flex-col items-start justify-start gap-5', props.b24ui?.body]
+          root: ['grow', cardBorderClass, props.b24ui?.root as ClassValue],
+          body: ['flex flex-col items-start justify-start gap-5', props.b24ui?.body as ClassValue]
         }"
       >
         <template #header>

--- a/playgrounds/demo/app/components/PlaygroundPage.vue
+++ b/playgrounds/demo/app/components/PlaygroundPage.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import type { ClassValue } from 'tailwind-variants'
 import type { CardProps } from '@bitrix24/b24ui-nuxt'
 import { createPlaygroundContext, providePlaygroundContext, usePlaygroundCardStyles } from '../composables/usePlaygroundContext'
 
@@ -39,8 +40,8 @@ const { cardVariant, cardBorderClass } = usePlaygroundCardStyles(playgroundConte
     :variant="cardVariant"
     :b24ui="{
       ...b24ui,
-      root: [playgroundContext.isUseBg.value ? 'backdrop-blur-xl' : '', 'overflow-clip border-0 border-t-2 lg:border-t-0 rounded-none lg:rounded-(--ui-border-radius-md)', b24ui?.root],
-      body: ['flex items-stretch flex-wrap justify-center md:justify-start gap-4 min-h-0 p-4', b24ui?.body]
+      root: [playgroundContext.isUseBg.value ? 'backdrop-blur-xl' : '', 'overflow-clip border-0 border-t-2 lg:border-t-0 rounded-none lg:rounded-(--ui-border-radius-md)', b24ui?.root as ClassValue],
+      body: ['flex items-stretch flex-wrap justify-center md:justify-start gap-4 min-h-0 p-4', b24ui?.body as ClassValue]
     }"
   >
     <slot v-bind="{ playgroundContext, cardVariant, cardBorderClass }" />

--- a/playgrounds/nuxt/app/components/Matrix.vue
+++ b/playgrounds/nuxt/app/components/Matrix.vue
@@ -1,4 +1,5 @@
 <script lang="ts">
+import type { ClassValue } from 'tailwind-variants'
 import type { CardProps } from '@bitrix24/b24ui-nuxt'
 
 export type MatrixValue<V> = V extends readonly (infer U)[] ? U : V
@@ -92,8 +93,8 @@ const headers = computed(() => {
         :variant="cardVariant"
         :b24ui="{
           ...props.b24ui,
-          root: ['grow', cardBorderClass, props.b24ui?.root],
-          body: ['flex flex-col items-start justify-start gap-5', props.b24ui?.body]
+          root: ['grow', cardBorderClass, props.b24ui?.root as ClassValue],
+          body: ['flex flex-col items-start justify-start gap-5', props.b24ui?.body as ClassValue]
         }"
       >
         <template #header>

--- a/playgrounds/nuxt/app/components/PlaygroundPage.vue
+++ b/playgrounds/nuxt/app/components/PlaygroundPage.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import type { ClassValue } from 'tailwind-variants'
 import type { CardProps } from '@bitrix24/b24ui-nuxt'
 import { createPlaygroundContext, providePlaygroundContext, usePlaygroundCardStyles } from '../composables/usePlaygroundContext'
 
@@ -39,8 +40,8 @@ const { cardVariant, cardBorderClass } = usePlaygroundCardStyles(playgroundConte
     :variant="cardVariant"
     :b24ui="{
       ...b24ui,
-      root: [playgroundContext.isUseBg.value ? 'backdrop-blur-xl' : '', 'overflow-clip border-0 border-t-2 lg:border-t-0 rounded-none lg:rounded-(--ui-border-radius-md)', b24ui?.root],
-      body: ['flex items-stretch flex-wrap justify-center md:justify-start gap-4 min-h-0 p-4', b24ui?.body]
+      root: [playgroundContext.isUseBg.value ? 'backdrop-blur-xl' : '', 'overflow-clip border-0 border-t-2 lg:border-t-0 rounded-none lg:rounded-(--ui-border-radius-md)', b24ui?.root as ClassValue],
+      body: ['flex items-stretch flex-wrap justify-center md:justify-start gap-4 min-h-0 p-4', b24ui?.body as ClassValue]
     }"
   >
     <slot v-bind="{ playgroundContext, cardVariant, cardBorderClass }" />

--- a/src/runtime/composables/useComponentProps.ts
+++ b/src/runtime/composables/useComponentProps.ts
@@ -1,16 +1,16 @@
 import type { ComputedRef, VNode } from 'vue'
-import type { ClassValue } from 'tailwind-variants'
 import { computed, getCurrentInstance } from 'vue'
 import defu from 'defu'
 import { createContext } from 'reka-ui'
 import { useAppConfig } from '#imports'
 import type * as ComponentTypes from '../types'
+import type { SlotClass } from '../types/tv'
 import type * as b24ui from '#build/b24ui'
 import { get } from '../utils'
 
 type ThemeSlotOverrides<T> = T extends { slots: infer S extends Record<string, any> }
-  ? { [K in keyof S]?: ClassValue }
-  : { [K in keyof T]?: T[K] extends any[] ? ClassValue : T[K] extends Record<string, any> ? ThemeSlotOverrides<T[K]> : ClassValue }
+  ? { [K in keyof S]?: SlotClass }
+  : { [K in keyof T]?: T[K] extends any[] ? SlotClass : T[K] extends Record<string, any> ? ThemeSlotOverrides<T[K]> : SlotClass }
 
 /**
  * Flat slot-class override shape: `{ button: { base: '...' }, modal: {...} }`.

--- a/src/runtime/types/tv.ts
+++ b/src/runtime/types/tv.ts
@@ -1,13 +1,27 @@
 import type { ClassValue, TVVariants, TVCompoundVariants, TVDefaultVariants } from 'tailwind-variants'
 
 /**
+ * A function form for a slot class that **replaces** the slot's default classes
+ * instead of merging onto them. It receives the slot's fully resolved default
+ * class string and returns the classes to use in its place.
+ * @example title: defaults => 'text-xl font-bold'
+ */
+export type SlotClassReplacer = (defaults: string) => ClassValue
+
+/**
+ * The value accepted for a slot in `:b24ui`, the `class` prop or `app.config.b24ui`:
+ * either classes to merge (the default) or a {@link SlotClassReplacer} to replace.
+ */
+export type SlotClass = ClassValue | SlotClassReplacer
+
+/**
  * Defines the AppConfig object based on the tailwind-variants configuration.
  */
 export type TVConfig<T extends Record<string, any>> = {
   [P in keyof T]?: {
-    [K in keyof T[P]as K extends 'base' | 'slots' | 'variants' | 'compoundVariants' | 'defaultVariants' ? K : never]?: K extends 'base' ? ClassValue
+    [K in keyof T[P]as K extends 'base' | 'slots' | 'variants' | 'compoundVariants' | 'defaultVariants' ? K : never]?: K extends 'base' ? SlotClass
       : K extends 'slots' ? {
-        [S in keyof T[P]['slots']]?: ClassValue
+        [S in keyof T[P]['slots']]?: SlotClass
       }
         : K extends 'variants' ? TVVariants<T[P]['slots'], ClassValue, T[P]['variants']>
           : K extends 'compoundVariants' ? TVCompoundVariants<T[P]['variants'], T[P]['slots'], ClassValue, object, undefined>
@@ -27,7 +41,7 @@ type ComponentVariants<T extends { variants?: Record<string, Record<string, any>
 }
 
 type ComponentSlots<T extends { slots?: Record<string, any> }> = Id<{
-  [K in keyof T['slots']]?: ClassValue
+  [K in keyof T['slots']]?: SlotClass
 }>
 
 type ComponentUI<T extends { slots?: Record<string, any> }> = Id<{

--- a/src/runtime/utils/tv.ts
+++ b/src/runtime/utils/tv.ts
@@ -1,6 +1,7 @@
-import { createTV } from 'tailwind-variants'
-import type { defaultConfig } from 'tailwind-variants'
+import { createTV, cnMerge } from 'tailwind-variants'
+import type { ClassValue, TVVariants, TVCompoundVariants, TVDefaultVariants, TVReturnType, defaultConfig } from 'tailwind-variants'
 import type { AppConfig } from '@nuxt/schema'
+import type { SlotClassReplacer } from '../types/tv'
 import appConfig from '#build/app.config'
 
 const appConfigTv = appConfig as AppConfig & { b24ui: { tv: typeof defaultConfig } }
@@ -51,8 +52,201 @@ const twMergeConfig = {
   }
 }
 
-export const tv = /* @__PURE__ */ createTV({
+// The resolved `tailwind-variants` config, reused for both `createTV` and the
+// `cnMerge` calls in the replacer path so twMerge resolves with b24ui's class groups.
+const config = {
   ...(appConfigTv.b24ui?.tv || {}),
   twMerge: true,
   twMergeConfig
-})
+}
+
+// Internal `tailwind-variants` helpers that are not re-exported.
+type TVSlots = Record<string, ClassValue> | undefined
+
+/**
+ * Widen the slot functions of a `tailwind-variants` return type so `class` /
+ * `className` also accept the `(defaults) => classes` replacer — `:b24ui` and the
+ * `class` prop flow straight into them. The concrete slot keys (and the
+ * extend-readable `slots` / `variants` / … properties) are preserved, so
+ * components keep type-checking under `noUncheckedIndexedAccess`.
+ */
+type WideSlotFn = (slotProps?: Record<string, any>) => string
+type Widen<R> = R extends (props?: infer P) => infer Slots
+  ? { (props?: P): Slots extends string ? string : { [K in keyof Slots]: WideSlotFn } } & Omit<R, never>
+  : R
+
+/**
+ * Mirrors `tailwind-variants`' `TV` call signature (so config inference is
+ * unchanged) but returns the {@link Widen}-ed result. Component prop types are
+ * derived from `typeof theme` via `ComponentConfig`, not from this type, so the
+ * widening only affects the internal `b24ui.slot(...)` calls.
+ */
+type WideTV = {
+  <
+    V extends TVVariants<S, B, EV>,
+    CV extends TVCompoundVariants<V, S, B, EV, ES>,
+    DV extends TVDefaultVariants<V, S, EV, ES>,
+    B extends ClassValue = undefined,
+    S extends TVSlots = undefined,
+    // @ts-expect-error mirror of tailwind-variants' own circular default
+    E extends TVReturnType = TVReturnType<V, S, B, EV extends undefined ? {} : EV, ES extends undefined ? {} : ES>,
+    EV extends TVVariants<ES, B, E['variants'], ES> = E['variants'],
+    ES extends TVSlots = E['slots'] extends TVSlots ? E['slots'] : undefined
+  >(
+    options: {
+      extend?: E
+      base?: B
+      slots?: S
+      variants?: V
+      compoundVariants?: CV
+      compoundSlots?: any
+      defaultVariants?: DV
+    },
+    config?: typeof defaultConfig
+  ): Widen<TVReturnType<V, S, B, EV, ES, E>>
+}
+
+const baseTv = /* @__PURE__ */ createTV(config)
+
+/**
+ * Find a class **replacer** — a function `(defaults) => classes` that replaces a
+ * slot's default classes instead of merging onto them. It may sit directly in a
+ * slot's `class` value (the `transformUI` scalar path) or inside the array a
+ * component forwards (e.g. `[props.b24ui?.base, props.class]`). Arrays are scanned
+ * deeply and the **last** replacer wins, mirroring `twMerge`'s last-in-wins
+ * semantics so e.g. `props.class` overrides `props.b24ui?.base`.
+ */
+function findReplacer(value: unknown): SlotClassReplacer | undefined {
+  if (typeof value === 'function') {
+    return value as SlotClassReplacer
+  }
+  if (Array.isArray(value)) {
+    for (let i = value.length - 1; i >= 0; i--) {
+      const replacer = findReplacer(value[i])
+      if (replacer) {
+        return replacer
+      }
+    }
+  }
+  return undefined
+}
+
+/**
+ * Keep the plain (non-function) classes passed alongside a replacer so they
+ * still apply on top of the replacement. Nested arrays are flattened so plain
+ * classes are never dropped.
+ */
+function plainClasses(value: unknown): ClassValue[] {
+  if (Array.isArray(value)) {
+    return value.flatMap(item => plainClasses(item))
+  }
+  if (typeof value === 'function') {
+    return []
+  }
+  return [value as ClassValue]
+}
+
+/**
+ * Apply a replacer: drop the baked-in default chain and return only the
+ * replacement, plus any plain classes passed alongside it. `resolveDefaults`
+ * computes the slot's default classes (without any user class) so the replacer
+ * can reuse part of them.
+ */
+function applyReplacer(replacer: SlotClassReplacer, slotProps: Record<string, any>, resolveDefaults: () => string): string {
+  return cnMerge(replacer(resolveDefaults()), ...plainClasses(slotProps.class), ...plainClasses(slotProps.className))(config) ?? ''
+}
+
+/**
+ * Wrap the slot functions returned by `tv()` so a replacer (from `:b24ui` / `class`
+ * at call time, or from `app.config.b24ui` at construction time) drops the slot's
+ * baked-in default chain and returns only its replacement. Without a replacer the
+ * original slot function runs untouched, so the common merge path is unaffected.
+ */
+function wrapSlots(slots: Record<string, any>, directives?: Record<string, SlotClassReplacer>) {
+  return new Proxy(slots, {
+    get(target, key: string) {
+      const slot = target[key]
+      if (typeof slot !== 'function') {
+        return slot
+      }
+
+      return (slotProps: Record<string, any> = {}) => {
+        const replacer = findReplacer(slotProps.class) ?? findReplacer(slotProps.className) ?? directives?.[key]
+        if (!replacer) {
+          return slot(slotProps)
+        }
+        return applyReplacer(replacer, slotProps, () => slot({ ...slotProps, class: undefined, className: undefined }))
+      }
+    }
+  })
+}
+
+/**
+ * Pull construction-time replacers authored in `app.config.b24ui.<component>` (under
+ * `slots` or the top-level `base`) out of the config so `createTV` only ever
+ * receives valid class strings. They are applied at call time in `wrapSlots`,
+ * alongside the `:b24ui` / `class` ones. The incoming config is never mutated.
+ */
+function extractDirectives(componentConfig: any): { config: any, directives?: Record<string, SlotClassReplacer> } {
+  if (!componentConfig || typeof componentConfig !== 'object') {
+    return { config: componentConfig }
+  }
+
+  let config = componentConfig
+  let directives: Record<string, SlotClassReplacer> | undefined
+
+  if (typeof componentConfig.base === 'function') {
+    directives = { base: componentConfig.base }
+    config = { ...config, base: '' }
+  }
+
+  const slots = componentConfig.slots
+  if (slots && typeof slots === 'object') {
+    const replacers = Object.entries(slots).filter(([, value]) => typeof value === 'function')
+    if (replacers.length) {
+      directives ??= {}
+      const cleaned = { ...slots }
+      for (const [slot, replacer] of replacers) {
+        directives[slot] = replacer as SlotClassReplacer
+        cleaned[slot] = ''
+      }
+      config = { ...config, slots: cleaned }
+    }
+  }
+
+  return { config, directives }
+}
+
+/**
+ * Wraps `tailwind-variants`' `tv` so slot classes can be **replaced** (not just
+ * merged) through a function form — `(defaults) => classes` — in `:b24ui`, the
+ * `class` prop and `app.config.b24ui`. The wrapper is transparent for every other
+ * usage: it preserves the `TVReturnType` (so `extend: tv(theme)` keeps working
+ * via property reads) and only intercepts the slot functions on invocation.
+ */
+export const tv = ((componentConfig?: any) => {
+  const { config: cleanConfig, directives } = extractDirectives(componentConfig)
+  const component = baseTv(cleanConfig)
+
+  return new Proxy(component, {
+    apply(target, thisArg, args) {
+      const result = Reflect.apply(target, thisArg, args)
+      if (result && typeof result === 'object') {
+        return wrapSlots(result, directives)
+      }
+
+      // Slotless components (only a `base`, no `slots`) return a string. Honor a
+      // replacer passed through `class` / `className` or a `base` directive from
+      // `app.config.b24ui`, otherwise return the merged string untouched.
+      if (typeof result === 'string') {
+        const slotProps = args[0] ?? {}
+        const replacer = findReplacer(slotProps.class) ?? findReplacer(slotProps.className) ?? directives?.base
+        if (replacer) {
+          return applyReplacer(replacer, slotProps, () => Reflect.apply(target, thisArg, [{ ...slotProps, class: undefined, className: undefined }]))
+        }
+      }
+
+      return result
+    }
+  })
+}) as unknown as WideTV

--- a/test/components/Button.spec.ts
+++ b/test/components/Button.spec.ts
@@ -117,4 +117,18 @@ describe('Button', () => {
 
     expect(await axe(wrapper.element)).toHaveNoViolations()
   })
+
+  it('replaces a slot class through a `:b24ui` function', async () => {
+    const wrapper = await mountSuspended(Button, {
+      props: {
+        label: 'Button',
+        b24ui: { label: () => 'text-3xl font-bold' }
+      }
+    })
+
+    const label = wrapper.get('[data-slot="label"]')
+    expect(label.classes()).toContain('text-3xl')
+    // A default label class (e.g. `text-clip`) is dropped, not merged.
+    expect(label.classes()).not.toContain('text-clip')
+  })
 })

--- a/test/utils/tv.spec.ts
+++ b/test/utils/tv.spec.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect } from 'vitest'
+import { tv } from '../../src/runtime/utils/tv'
+
+// Cast to a permissive local signature: the strongly-typed `tv` is what
+// components rely on, whereas these tests exercise the runtime wrapper with
+// inline themes and the `(defaults) => classes` replacer form.
+const tvt = tv as unknown as (config?: any) => (variants?: any) => {
+  base: (props?: any) => string
+  label: (props?: any) => string
+}
+
+describe('tv class replace', () => {
+  const theme = {
+    slots: { base: 'inline-flex rounded-md text-sm', label: 'truncate' },
+    variants: {
+      color: { primary: { base: 'bg-primary text-inverted' } },
+      size: { md: { base: 'px-2.5 text-sm' } }
+    },
+    compoundVariants: [{ color: 'primary', size: 'md', class: { base: 'gap-1.5' } }],
+    defaultVariants: { color: 'primary', size: 'md' }
+  }
+
+  const build = () => tvt({ extend: tvt(theme) })({ color: 'primary', size: 'md' })
+
+  it('keeps merging plain string classes (no regression)', () => {
+    const ui = build()
+    expect(ui.label({ class: 'font-bold' })).toBe('truncate font-bold')
+    // A conflicting utility is still resolved by tailwind-merge.
+    const base = ui.base({ class: 'text-lg' })
+    expect(base).toContain('text-lg')
+    expect(base).not.toContain('text-sm')
+  })
+
+  it('keeps `extend` working through the wrapper (full chain resolves)', () => {
+    const base = build().base()
+    expect(base).toContain('inline-flex')
+    expect(base).toContain('bg-primary')
+    expect(base).toContain('px-2.5')
+    expect(base).toContain('gap-1.5')
+  })
+
+  it('replaces a slot via a function in `:ui` and drops the defaults', () => {
+    expect(build().label({ class: () => 'text-3xl font-bold' })).toBe('text-3xl font-bold')
+  })
+
+  it('passes the resolved default classes to the replacer', () => {
+    let received: string | undefined
+    build().label({ class: (defaults: string) => {
+      received = defaults
+      return 'whatever'
+    } })
+    expect(received).toBe('truncate')
+  })
+
+  it('keeps plain classes passed alongside the replacer', () => {
+    expect(build().label({ class: [() => 'text-3xl', 'opacity-50'] })).toBe('text-3xl opacity-50')
+  })
+
+  it('detects a replacer as a scalar value (the `transformUI` path)', () => {
+    expect(build().base({ class: () => 'block w-full' })).toBe('block w-full')
+  })
+
+  it('detects a replacer in the `className` alias', () => {
+    expect(build().label({ className: () => 'text-3xl' })).toBe('text-3xl')
+  })
+
+  it('applies a construction-time replacer from `app.config.ui` slots', () => {
+    const ui = tvt({ extend: tvt(theme), slots: { label: () => 'text-xl' } })({ color: 'primary', size: 'md' })
+    expect(ui.label()).toBe('text-xl')
+    // A sibling slot keeps its defaults.
+    expect(ui.base()).toContain('inline-flex')
+  })
+
+  it('lets a call-time `:ui` replacer win over an `app.config.ui` one', () => {
+    const ui = tvt({ extend: tvt(theme), slots: { label: () => 'from-config' } })({ color: 'primary', size: 'md' })
+    expect(ui.label({ class: () => 'from-ui' })).toBe('from-ui')
+  })
+
+  it('replaces the base slot through a function forwarded in the class array', () => {
+    // Mirrors how components forward `class: [props.ui?.base, props.class]`.
+    expect(build().base({ class: [undefined, () => 'block w-full'] })).toBe('block w-full')
+  })
+
+  it('lets the last replacer win when several are forwarded in the class array', () => {
+    // Mirrors `[props.ui?.base, props.class]` with both set: `class` wins, like twMerge.
+    expect(build().base({ class: [() => 'block', () => 'w-full'] })).toBe('w-full')
+  })
+})
+
+describe('tv class replace (slotless component)', () => {
+  // A slotless theme has only a `base` and no `slots`, so `tv()(props)` returns
+  // a string rather than an object of slot functions (e.g. the Container theme).
+  const tvBase = tv as unknown as (config?: any) => (props?: any) => string
+  const build = () => tvBase({ extend: tvBase({ base: 'inline-flex rounded-md px-4' }) })
+
+  it('still merges plain classes', () => {
+    const result = build()({ class: 'font-bold' })
+    expect(result).toContain('inline-flex')
+    expect(result).toContain('font-bold')
+  })
+
+  it('replaces the base through a function in `:ui` / `class`', () => {
+    expect(build()({ class: () => 'block w-full' })).toBe('block w-full')
+  })
+
+  it('replaces the base through a `:ui` function forwarded in the class array', () => {
+    // Mirrors how a slotless component forwards `class: [props.ui?.base, props.class]`.
+    expect(build()({ class: [() => 'block w-full', undefined] })).toBe('block w-full')
+  })
+
+  it('passes the resolved default classes to the replacer', () => {
+    let received: string | undefined
+    build()({ class: (defaults: string) => {
+      received = defaults
+      return 'whatever'
+    } })
+    expect(received).toContain('inline-flex')
+  })
+
+  it('applies a construction-time `base` replacer from `app.config.ui`', () => {
+    const ui = tvBase({ extend: tvBase({ base: 'inline-flex px-4' }), base: () => 'block' })
+    expect(ui()).toBe('block')
+  })
+})


### PR DESCRIPTION
Port of upstream nuxt/ui [`ea576e2f`](https://github.com/nuxt/ui/commit/ea576e2f321665574c416af34e7ef04e68654a79) — `feat(theme): allow replacing slot classes with a function (#6562)`.

## Changes
A slot class can now be a function `(defaults) => classes` that **replaces** the slot's default classes (instead of merging) — via `:b24ui`, the `class` prop, or `app.config.b24ui`.
- **`types/tv.ts`**: add `SlotClassReplacer` + `SlotClass`; widen `base`/`slots` in `TVConfig` and `ComponentSlots` from `ClassValue` → `SlotClass`.
- **`useComponentProps.ts`**: `ClassValue` → `SlotClass`.
- **`utils/tv.ts`**: rewrite `tv` as a Proxy (`findReplacer` / `plainClasses` / `applyReplacer` / `wrapSlots` / `extractDirectives` + `WideTV`/`Widen`), **preserving b24ui's own `twMergeConfig`** (air class groups) and the `b24ui?.tv` config — the shared `config` is reused for `createTV` and the `cnMerge(...)(config)` calls.
- **tests**: `test/utils/tv.spec.ts` (verbatim) + a Button `:b24ui` replacer case (+34 across nuxt/vue).
- **playgrounds**: widening `slots` to `SlotClass` broke typecheck in `Matrix.vue`/`PlaygroundPage.vue` (they forward `props.b24ui?.root|body` inside a `ClassValue` array to `B24Card`'s `:b24ui`). Cast those forwarded values to `ClassValue` in **nuxt + demo** (dev helpers only merge strings).
- **docs**: function-form note + `:b24ui` example + `theme.unstyled` tip in the `### b24ui prop` section.

### Deviation
Skipped upstream's larger global-config / "Theme component" doc restructure in `3.components.md` and the `skills/nuxt-ui/...design-system.md` edit — b24ui's theme doc and skills (`skills/b24-ui-nuxt/`) are structured differently. The runtime feature + per-component note are covered.

## Verification (pnpm 11.5.2, gate ON)
dev:prepare · lint · typecheck (incl. docs + both playgrounds) · test (**5086 passed**, 6 skipped) · module build — all green.

Ledger: records the merge sha for the previous port (#182, `52367b1a`) and advances the sync cursor to `ea576e2f`.

https://claude.ai/code/session_01Qz7EXMncvEGiCj4WbmYgJo

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qz7EXMncvEGiCj4WbmYgJo)_