### PR TITLE
chore(deps): update vue-tsc to ^3.3.4

### DIFF
--- a/.sync/log/8c433975c87717716f5f718d617eef6d1eef180f.md
+++ b/.sync/log/8c433975c87717716f5f718d617eef6d1eef180f.md
@@ -1,0 +1,27 @@
+# Port: chore(deps): update vue-tsc to ^3.3.4 (#6573)
+
+**Upstream:** `8c433975c87717716f5f718d617eef6d1eef180f` (nuxt/ui)
+**Decision:** port
+
+## Upstream change
+- `vue-tsc` ^3.3.3 → ^3.3.4 (root, playgrounds/nuxt, playgrounds/vue);
+  `vue-component-type-helpers` ^3.3.3 → ^3.3.4 (root) + lockfile regen.
+- `ChatPrompt.vue`: consolidate the two `@keydown.enter` / `@keydown.esc`
+  handlers into one `@keydown="onKeydown"` (vue-tsc ≥3.3 rejects the duplicate
+  `onKeydown` key, TS1117).
+
+## b24ui adaptation
+- bumps: `vue-tsc` → ^3.3.4 in root + `playgrounds/{nuxt,vue,demo}` (demo
+  mirrored per invariant); `vue-component-type-helpers` → ^3.3.4 (root).
+  lockfile regen under the gate (resolves to aged `3.3.4`).
+- **`ChatPrompt.vue` — no-op:** b24ui already has the single `onKeydown`
+  handler (Escape → blur, Enter → handleEnter) with the same `@keydown` binding
+  — it was applied in #108 (the earlier vue-tsc 3.3 TS1117 fix). Behaviourally
+  identical to upstream's new version (order of the Enter/Escape checks differs,
+  no effect).
+
+## Verification (pnpm 11.5.2, gate ON)
+frozen install · dev:prepare · lint · typecheck · test (5088 passed, 6
+skipped) · module build — all green.
+
+Platform note: b24ui CI is `ubuntu-latest` only; dev-tooling dep bump.

--- a/.sync/nuxt-ui.json
+++ b/.sync/nuxt-ui.json
@@ -2,7 +2,7 @@
   "upstream": "nuxt/ui",
   "branch": "v4",
   "sync_enabled": false,
-  "cursor": "e8d18c37a0ebfe527ddc8fc38846d68f52e273be",
+  "cursor": "8c433975c87717716f5f718d617eef6d1eef180f",
   "_cursor_note": "cursor = last upstream commit ported into b24ui (oldest-first, manual cadence). sync_enabled stays false until Phase 2 (porter workflow #67 + CLAUDE_CODE_OAUTH_TOKEN) is wired and trusted. `processed` is maintained per port from now on (backfilled #68-#72 on 2026-06-09).",
   "stats": {
     "queue_depth": 0,
@@ -521,10 +521,16 @@
       "summary": "fix(SelectMenu): bind id and aria attributes on trigger (#6572) — SelectMenu.vue: move :id + $attrs/ariaAttrs from ComboboxRoot onto ComboboxTrigger (focusable element); ComboboxRoot v-bind -> (rootProps as any). 10 snapshots updated (id/aria move root->trigger)"
     },
     "e8d18c37a0ebfe527ddc8fc38846d68f52e273be": {
+      "pr": 187,
+      "b24ui_sha": "f8cefc1b",
+      "decision": "port",
+      "summary": "fix(Select): open menu on label click (#6575) — Select.vue: onTriggerClick(open) re-dispatches pointerdown so a <label for> click opens the menu; @click on SelectTrigger. +label spec (B24FormField+B24Select, +2). Skipped upstream's theme replaceFocus removal: b24ui select.ts replaceFocus is a no-op woven into air compounds, select-menu.ts is active b24ui-specific focus swap — tied to focus-uniformization (b026ca2c), not this fix. No snapshot churn"
+    },
+    "8c433975c87717716f5f718d617eef6d1eef180f": {
       "pr": null,
       "b24ui_sha": "pending-merge",
       "decision": "port",
-      "summary": "fix(Select): open menu on label click (#6575) — Select.vue: onTriggerClick(open) re-dispatches pointerdown so a <label for> click opens the menu; @click on SelectTrigger. +label spec (B24FormField+B24Select, +2). Skipped upstream's theme replaceFocus removal: b24ui select.ts replaceFocus is a no-op woven into air compounds, select-menu.ts is active b24ui-specific focus swap — tied to focus-uniformization (b026ca2c), not this fix. No snapshot churn"
+      "summary": "chore(deps): update vue-tsc to ^3.3.4 (#6573) — vue-tsc ^3.3.3->^3.3.4 (root + playgrounds nuxt/vue/demo, demo mirrored) + vue-component-type-helpers ^3.3.4 (root); lockfile regen under gate (3.3.4). ChatPrompt.vue keydown consolidation is a no-op — b24ui already has the single onKeydown handler from #108"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -200,7 +200,7 @@
     "unplugin-auto-import": "^21.0.0",
     "unplugin-vue-components": "^32.1.0",
     "vaul-vue": "0.4.1",
-    "vue-component-type-helpers": "^3.3.3"
+    "vue-component-type-helpers": "^3.3.4"
   },
   "devDependencies": {
     "@nuxt/eslint-config": "^1.15.2",
@@ -219,7 +219,7 @@
     "vitest-axe": "^0.1.0",
     "vitest-environment-nuxt": "^2.0.0",
     "vue": "^3.5.35",
-    "vue-tsc": "^3.3.3",
+    "vue-tsc": "^3.3.4",
     "@types/canvas-confetti": "^1.9.0",
     "@types/node": "^25.3.0"
   },

--- a/playgrounds/demo/package.json
+++ b/playgrounds/demo/package.json
@@ -29,6 +29,6 @@
   },
   "devDependencies": {
     "typescript": "^6.0.3",
-    "vue-tsc": "^3.3.3"
+    "vue-tsc": "^3.3.4"
   }
 }

--- a/playgrounds/nuxt/package.json
+++ b/playgrounds/nuxt/package.json
@@ -29,6 +29,6 @@
   },
   "devDependencies": {
     "typescript": "^6.0.3",
-    "vue-tsc": "^3.3.3"
+    "vue-tsc": "^3.3.4"
   }
 }

--- a/playgrounds/vue/package.json
+++ b/playgrounds/vue/package.json
@@ -25,6 +25,6 @@
     "@vitejs/plugin-vue": "^6.0.7",
     "typescript": "^6.0.3",
     "vite": "^7.3.5",
-    "vue-tsc": "^3.3.3"
+    "vue-tsc": "^3.3.4"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -227,7 +227,7 @@ importers:
         specifier: 0.4.1
         version: 0.4.1(reka-ui@2.9.9(vue@3.5.38(typescript@6.0.3)))(vue@3.5.38(typescript@6.0.3))
       vue-component-type-helpers:
-        specifier: ^3.3.3
+        specifier: ^3.3.4
         version: 3.3.4
       vue-router:
         specifier: ^4.5.0 || ^5.0.0
@@ -294,7 +294,7 @@ importers:
         specifier: ^3.5.35
         version: 3.5.38(typescript@6.0.3)
       vue-tsc:
-        specifier: ^3.3.3
+        specifier: ^3.3.4
         version: 3.3.4(typescript@6.0.3)
 
   cli:
@@ -512,7 +512,7 @@ importers:
         specifier: ^6.0.3
         version: 6.0.3
       vue-tsc:
-        specifier: ^3.3.3
+        specifier: ^3.3.4
         version: 3.3.4(typescript@6.0.3)
 
   playgrounds/nuxt:
@@ -567,7 +567,7 @@ importers:
         specifier: ^6.0.3
         version: 6.0.3
       vue-tsc:
-        specifier: ^3.3.3
+        specifier: ^3.3.4
         version: 3.3.4(typescript@6.0.3)
 
   playgrounds/repl:
@@ -635,7 +635,7 @@ importers:
         specifier: ^7.3.5
         version: 7.3.5(@types/node@25.6.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.1)(yaml@2.9.0)
       vue-tsc:
-        specifier: ^3.3.3
+        specifier: ^3.3.4
         version: 3.3.4(typescript@6.0.3)
 
 packages:


### PR DESCRIPTION
Port of upstream nuxt/ui [`8c433975`](https://github.com/nuxt/ui/commit/8c433975c87717716f5f718d617eef6d1eef180f) — `chore(deps): update vue-tsc to ^3.3.4 (#6573)`.

## Changes
- `vue-tsc` `^3.3.3` → `^3.3.4` — root `package.json`, `playgrounds/nuxt`, `playgrounds/vue`, **`playgrounds/demo` (mirrored)**.
- `vue-component-type-helpers` `^3.3.3` → `^3.3.4` (root).
- lockfile regen under the active `minimumReleaseAge` gate (resolves to aged `3.3.4`).

### Note
Upstream bundled a `ChatPrompt.vue` change consolidating two `@keydown.*` handlers into one (vue-tsc ≥3.3 TS1117). **No-op for b24ui** — the single `onKeydown` handler (Escape→blur, Enter→handleEnter) was already applied in #108.

## Verification (pnpm 11.5.2, gate ON)
frozen install · dev:prepare · lint · typecheck · test (**5088 passed**, 6 skipped) · module build — all green.

Ledger: records the merge sha for the previous port (#187, `e8d18c37`) and advances the sync cursor to `8c433975`.

https://claude.ai/code/session_01Qz7EXMncvEGiCj4WbmYgJo

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qz7EXMncvEGiCj4WbmYgJo)_