### PR TITLE
docs(search): init index on nuxt ready

### DIFF
--- a/.sync/log/eacd6b19c9b48244cd270a3a3a39900f259a3791.md
+++ b/.sync/log/eacd6b19c9b48244cd270a3a3a39900f259a3791.md
@@ -1,0 +1,22 @@
+# Port: docs(search): init index on nuxt ready
+
+**Upstream:** `eacd6b19c9b48244cd270a3a3a39900f259a3791` (nuxt/ui)
+**Decision:** port
+
+## Upstream change
+`docs/app/components/search/Search.vue`: replace the lazy
+`watch(open, … init())` (init the search collection the first time the palette
+opens) with `onNuxtReady(init)` — build the index as soon as Nuxt is ready, and
+drop the now-unused `const { open } = useContentSearch()`.
+
+## b24ui adaptation
+Direct 1:1 — b24ui's docs `Search.vue` matched the upstream pre-change:
+- removed `const { open } = useContentSearch()`;
+- replaced the `watch(open, …)` block with `onNuxtReady(init)`.
+`status` is still used (`:search-status="status"`), so the destructure is kept.
+
+## Verification (pnpm 11.5.2, gate ON)
+dev:prepare · lint · typecheck (incl. `nuxt typecheck docs`) · module build —
+all green. Docs-only.
+
+Platform note: b24ui CI is `ubuntu-latest` only.

--- a/.sync/nuxt-ui.json
+++ b/.sync/nuxt-ui.json
@@ -2,7 +2,7 @@
   "upstream": "nuxt/ui",
   "branch": "v4",
   "sync_enabled": false,
-  "cursor": "76bcd3b7cf36d81e10536513e32a371314111828",
+  "cursor": "eacd6b19c9b48244cd270a3a3a39900f259a3791",
   "_cursor_note": "cursor = last upstream commit ported into b24ui (oldest-first, manual cadence). sync_enabled stays false until Phase 2 (porter workflow #67 + CLAUDE_CODE_OAUTH_TOKEN) is wired and trusted. `processed` is maintained per port from now on (backfilled #68-#72 on 2026-06-09).",
   "stats": {
     "queue_depth": 0,
@@ -533,10 +533,16 @@
       "summary": "chore(deps): update vue-tsc to ^3.3.4 (#6573) — vue-tsc ^3.3.3->^3.3.4 (root + playgrounds nuxt/vue/demo, demo mirrored) + vue-component-type-helpers ^3.3.4 (root); lockfile regen under gate (3.3.4). ChatPrompt.vue keydown consolidation is a no-op — b24ui already has the single onKeydown handler from #108"
     },
     "76bcd3b7cf36d81e10536513e32a371314111828": {
+      "pr": 189,
+      "b24ui_sha": "9627ad47",
+      "decision": "port",
+      "summary": "chore(deps): update nuxt framework to ^4.4.8 (#6578) — nuxt/@nuxt/kit/@nuxt/schema ^4.4.7->^4.4.8 (root/docs/playgrounds nuxt+demo mirrored; repl/vue don't pin); @nuxt/kit override ^4.4.8; lockfile regen under gate (resolves 4.4.8). @nuxt/icon n/a"
+    },
+    "eacd6b19c9b48244cd270a3a3a39900f259a3791": {
       "pr": null,
       "b24ui_sha": "pending-merge",
       "decision": "port",
-      "summary": "chore(deps): update nuxt framework to ^4.4.8 (#6578) — nuxt/@nuxt/kit/@nuxt/schema ^4.4.7->^4.4.8 (root/docs/playgrounds nuxt+demo mirrored; repl/vue don't pin); @nuxt/kit override ^4.4.8; lockfile regen under gate (resolves 4.4.8). @nuxt/icon n/a"
+      "summary": "docs(search): init index on nuxt ready — docs/app/components/search/Search.vue: drop const {open}=useContentSearch() and replace watch(open, init) with onNuxtReady(init) (build index on ready). Direct 1:1; status kept (:search-status). Docs-only"
     }
   }
 }

--- a/docs/app/components/search/Search.vue
+++ b/docs/app/components/search/Search.vue
@@ -12,7 +12,6 @@ const { status, search, init } = useSearchCollection('docs', {
 })
 
 const { links, groups, searchTerm } = useSearch()
-const { open } = useContentSearch()
 const { track } = useAnalytics()
 
 const fuse = {
@@ -23,11 +22,7 @@ const fuse = {
   }
 }
 
-watch(open, (value) => {
-  if (value && status.value === 'idle') {
-    init()
-  }
-})
+onNuxtReady(init)
 
 watchDebounced(searchTerm, (term) => {
   if (term) {


### PR DESCRIPTION
Port of upstream nuxt/ui [`eacd6b19`](https://github.com/nuxt/ui/commit/eacd6b19c9b48244cd270a3a3a39900f259a3791) — `docs(search): init index on nuxt ready`.

## Changes
- **`docs/app/components/search/Search.vue`**: build the search index via `onNuxtReady(init)` instead of lazily on first palette open (`watch(open, … init())`), and drop the now-unused `const { open } = useContentSearch()`. Direct 1:1 (b24ui matched the pre-change; `status` is kept for `:search-status`).

## Verification (pnpm 11.5.2, gate ON)
dev:prepare · lint · typecheck (incl. docs) · module build — all green. Docs-only.

Ledger: records the merge sha for the previous port (#189, `76bcd3b7`) and advances the sync cursor to `eacd6b19`.

https://claude.ai/code/session_01Qz7EXMncvEGiCj4WbmYgJo

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qz7EXMncvEGiCj4WbmYgJo)_