### PR TITLE
chore(sync): skip upstream focus-style uniformization (#6576)

### DIFF
--- a/.sync/log/b026ca2cdb0e4d6aff6d271a95e2d7e5e1bd7e3f.md
+++ b/.sync/log/b026ca2cdb0e4d6aff6d271a95e2d7e5e1bd7e3f.md
@@ -1,0 +1,31 @@
+# Port: feat(theme): uniformize focus styles across components (#6576)
+
+**Upstream:** `b026ca2cdb0e4d6aff6d271a95e2d7e5e1bd7e3f` (nuxt/ui)
+**Decision:** skip
+
+## Upstream change
+Large theme change (~50 `src/theme/*` files, 200+ files incl. snapshots):
+replaces nuxt/ui's per-component focus styling with one uniform pattern —
+`outline-{color}/25 focus-visible:outline-3` (+ `focus-visible:ring-{color}`
+where a ring is kept) — built on `options.theme.colors` loops and semantic
+tokens (`outline-inverted`, `ring-accented`, `bg-{color}`, …). Also adds a
+base `a:focus-visible { outline-offset: 0 }` reset (`index.css`) and
+`overflow: hidden` to the accordion/collapsible `@keyframes` (`keyframes.css`).
+
+## b24ui decision — skip (maintainer call)
+Not portable 1:1 and **skipped** per maintainer decision (no source change):
+- b24ui has its **own focus system in air-design tokens**
+  (`focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-(--b24ui-border-color)`,
+  `--ui-color-design-selection-content`, `style-blurred-bg-input`, …),
+  intentionally different from nuxt/ui's generic `outline`/`ring` model.
+- b24ui has **no `options.theme.colors`** — the upstream per-color compound
+  structure (`outline-${color}/25`, `bg-${color}`) has no equivalent.
+- Adopting upstream's model would overwrite b24ui's air design system focus
+  styles (a design regression), so it is not done as part of the sync.
+
+Whether b24ui wants a uniform focus model expressed in air tokens (and the two
+generic, design-agnostic bits — the `a:focus-visible` reset and the keyframes
+`overflow: hidden`) is tracked separately in **issue #191** for a deliberate
+design pass.
+
+No file change — bookkeeping only (ledger marks this `skip`, advances cursor).

--- a/.sync/nuxt-ui.json
+++ b/.sync/nuxt-ui.json
@@ -2,7 +2,7 @@
   "upstream": "nuxt/ui",
   "branch": "v4",
   "sync_enabled": false,
-  "cursor": "eacd6b19c9b48244cd270a3a3a39900f259a3791",
+  "cursor": "b026ca2cdb0e4d6aff6d271a95e2d7e5e1bd7e3f",
   "_cursor_note": "cursor = last upstream commit ported into b24ui (oldest-first, manual cadence). sync_enabled stays false until Phase 2 (porter workflow #67 + CLAUDE_CODE_OAUTH_TOKEN) is wired and trusted. `processed` is maintained per port from now on (backfilled #68-#72 on 2026-06-09).",
   "stats": {
     "queue_depth": 0,
@@ -539,10 +539,16 @@
       "summary": "chore(deps): update nuxt framework to ^4.4.8 (#6578) — nuxt/@nuxt/kit/@nuxt/schema ^4.4.7->^4.4.8 (root/docs/playgrounds nuxt+demo mirrored; repl/vue don't pin); @nuxt/kit override ^4.4.8; lockfile regen under gate (resolves 4.4.8). @nuxt/icon n/a"
     },
     "eacd6b19c9b48244cd270a3a3a39900f259a3791": {
-      "pr": null,
-      "b24ui_sha": "pending-merge",
+      "pr": 190,
+      "b24ui_sha": "651ff066",
       "decision": "port",
       "summary": "docs(search): init index on nuxt ready — docs/app/components/search/Search.vue: drop const {open}=useContentSearch() and replace watch(open, init) with onNuxtReady(init) (build index on ready). Direct 1:1; status kept (:search-status). Docs-only"
+    },
+    "b026ca2cdb0e4d6aff6d271a95e2d7e5e1bd7e3f": {
+      "pr": null,
+      "b24ui_sha": "pending-merge",
+      "decision": "skip",
+      "summary": "feat(theme): uniformize focus styles across components (#6576) — SKIPPED (maintainer call): rewrites focus styling across ~50 themes to nuxt/ui's outline-3/outline-{color}/25 + theme.colors model. b24ui has its own air-token focus system (ring-(--b24ui-border-color), --ui-color-design-selection-content, …) and no theme.colors; adopting upstream would regress the air design. Generic bits (a:focus-visible reset, keyframes overflow:hidden) also deferred. Tracked in issue #191"
     }
   }
 }


### PR DESCRIPTION
Records upstream nuxt/ui [`b026ca2c`](https://github.com/nuxt/ui/commit/b026ca2cdb0e4d6aff6d271a95e2d7e5e1bd7e3f) — `feat(theme): uniformize focus styles across components (#6576)` — as **skipped**.

## Decision: skip (maintainer call)

The upstream change rewrites focus styling across ~50 theme files to nuxt/ui's uniform `outline-3` / `outline-{color}/25` model, built on `options.theme.colors` loops and semantic tokens (`outline-inverted`, `ring-accented`, `bg-{color}`, …).

**b24ui has its own focus-styling system in air-design tokens** (`focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-(--b24ui-border-color)`, `--ui-color-design-selection-content`, …) and **no `theme.colors`** — adopting upstream's model would overwrite the air design system (a regression), so it's not ported.

Whether b24ui wants a uniform focus model expressed in air tokens (plus the two generic, design-agnostic bits — the `a:focus-visible { outline-offset: 0 }` reset and the accordion/collapsible keyframes `overflow: hidden`) is tracked in **#191** for a deliberate design pass.

## Changes
Bookkeeping only — `.sync/` ledger + log entry. Records the merge sha for the previous port (#190, `eacd6b19`) and advances the sync cursor to `b026ca2c`.

https://claude.ai/code/session_01Qz7EXMncvEGiCj4WbmYgJo

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qz7EXMncvEGiCj4WbmYgJo)_