### PR TITLE
chore(deps): update reka-ui to v2.9.10

### DIFF
--- a/.sync/log/39d53ae54b9d810dc691c4fbe1ac6205df5f6e05.md
+++ b/.sync/log/39d53ae54b9d810dc691c4fbe1ac6205df5f6e05.md
@@ -1,0 +1,21 @@
+# Port: chore(deps): update reka-ui to v2.9.10 (#6584)
+
+**Upstream:** `39d53ae54b9d810dc691c4fbe1ac6205df5f6e05` (nuxt/ui)
+**Decision:** port
+
+## Upstream change
+root `package.json`: `reka-ui` `2.9.9` → `2.9.10` (exact pin) + lockfile regen.
+
+## b24ui adaptation
+Direct 1:1 — b24ui pins `reka-ui` at the same exact version in root.
+- `reka-ui` `2.9.9` → `2.9.10`.
+- lockfile regen under the active minimumReleaseAge gate (resolves to `2.9.10`).
+- Note: a second `reka-ui@2.9.9` remains in the lock for the transitive
+  `@nuxt/ui@4.7.1` (its own pin) — expected in the fork, not a dedupe miss;
+  b24ui's own reka-ui is `2.9.10`.
+
+## Verification (pnpm 11.5.2, gate ON)
+frozen install · dev:prepare · lint · typecheck · test (5088 passed, 6
+skipped) · module build — all green.
+
+Platform note: b24ui CI is `ubuntu-latest` only; dep bump.

--- a/.sync/nuxt-ui.json
+++ b/.sync/nuxt-ui.json
@@ -2,7 +2,7 @@
   "upstream": "nuxt/ui",
   "branch": "v4",
   "sync_enabled": false,
-  "cursor": "b026ca2cdb0e4d6aff6d271a95e2d7e5e1bd7e3f",
+  "cursor": "39d53ae54b9d810dc691c4fbe1ac6205df5f6e05",
   "_cursor_note": "cursor = last upstream commit ported into b24ui (oldest-first, manual cadence). sync_enabled stays false until Phase 2 (porter workflow #67 + CLAUDE_CODE_OAUTH_TOKEN) is wired and trusted. `processed` is maintained per port from now on (backfilled #68-#72 on 2026-06-09).",
   "stats": {
     "queue_depth": 0,
@@ -545,10 +545,16 @@
       "summary": "docs(search): init index on nuxt ready — docs/app/components/search/Search.vue: drop const {open}=useContentSearch() and replace watch(open, init) with onNuxtReady(init) (build index on ready). Direct 1:1; status kept (:search-status). Docs-only"
     },
     "b026ca2cdb0e4d6aff6d271a95e2d7e5e1bd7e3f": {
-      "pr": null,
-      "b24ui_sha": "pending-merge",
+      "pr": 192,
+      "b24ui_sha": "6b11d5d4",
       "decision": "skip",
       "summary": "feat(theme): uniformize focus styles across components (#6576) — SKIPPED (maintainer call): rewrites focus styling across ~50 themes to nuxt/ui's outline-3/outline-{color}/25 + theme.colors model. b24ui has its own air-token focus system (ring-(--b24ui-border-color), --ui-color-design-selection-content, …) and no theme.colors; adopting upstream would regress the air design. Generic bits (a:focus-visible reset, keyframes overflow:hidden) also deferred. Tracked in issue #191"
+    },
+    "39d53ae54b9d810dc691c4fbe1ac6205df5f6e05": {
+      "pr": null,
+      "b24ui_sha": "pending-merge",
+      "decision": "port",
+      "summary": "chore(deps): update reka-ui to v2.9.10 (#6584) — direct 1:1 exact-version bump in root package.json (2.9.9->2.9.10); lockfile regen under gate (resolves 2.9.10). A second reka-ui@2.9.9 stays for transitive @nuxt/ui@4.7.1 (its own pin) — expected in the fork"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -189,7 +189,7 @@
     "motion-v": "^2.2.1",
     "ohash": "^2.0.11",
     "pathe": "^2.0.3",
-    "reka-ui": "2.9.9",
+    "reka-ui": "2.9.10",
     "scule": "^1.3.0",
     "tailwind-merge": "^3.6.0",
     "tailwind-variants": "^3.2.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -185,8 +185,8 @@ importers:
         specifier: ^2.0.3
         version: 2.0.3
       reka-ui:
-        specifier: 2.9.9
-        version: 2.9.9(vue@3.5.38(typescript@6.0.3))
+        specifier: 2.9.10
+        version: 2.9.10(vue@3.5.38(typescript@6.0.3))
       scule:
         specifier: ^1.3.0
         version: 1.3.0
@@ -225,7 +225,7 @@ importers:
         version: 1.4.1(typescript@6.0.3)
       vaul-vue:
         specifier: 0.4.1
-        version: 0.4.1(reka-ui@2.9.9(vue@3.5.38(typescript@6.0.3)))(vue@3.5.38(typescript@6.0.3))
+        version: 0.4.1(reka-ui@2.9.10(vue@3.5.38(typescript@6.0.3)))(vue@3.5.38(typescript@6.0.3))
       vue-component-type-helpers:
         specifier: ^3.3.4
         version: 3.3.4
@@ -7154,6 +7154,11 @@ packages:
 
   rehype-sort-attributes@5.0.1:
     resolution: {integrity: sha512-Bxo+AKUIELcnnAZwJDt5zUDDRpt4uzhfz9d0PVGhcxYWsbFj5Cv35xuWxu5r1LeYNFNhgGqsr9Q2QiIOM/Qctg==}
+
+  reka-ui@2.9.10:
+    resolution: {integrity: sha512-yuvZVTp4fWH2G3qk+ze/x6YYlyc2Xl1d+eMUlIYrKqzTowBKteoDoN17fitURmqSUck3mc7JbcYgp49DnGu2EQ==}
+    peerDependencies:
+      vue: '>= 3.4.0'
 
   reka-ui@2.9.9:
     resolution: {integrity: sha512-/e+hdF9vP8E2kPrKR4RdgMQQsfpCr8l436Zn8GRWM3jKT9EG1lOO/UFMGBVEnrMLOVoJSjjmIFrej4tMOb+6qQ==}
@@ -15911,6 +15916,22 @@ snapshots:
       '@types/hast': 3.0.4
       unist-util-visit: 5.1.0
 
+  reka-ui@2.9.10(vue@3.5.38(typescript@6.0.3)):
+    dependencies:
+      '@floating-ui/dom': 1.7.6
+      '@floating-ui/vue': 1.1.11(vue@3.5.38(typescript@6.0.3))
+      '@internationalized/date': 3.12.2
+      '@internationalized/number': 3.6.7
+      '@tanstack/vue-virtual': 3.13.28(vue@3.5.38(typescript@6.0.3))
+      '@vueuse/core': 14.3.0(vue@3.5.38(typescript@6.0.3))
+      '@vueuse/shared': 14.3.0(vue@3.5.38(typescript@6.0.3))
+      aria-hidden: 1.2.6
+      defu: 6.1.7
+      ohash: 2.0.11
+      vue: 3.5.38(typescript@6.0.3)
+    transitivePeerDependencies:
+      - '@vue/composition-api'
+
   reka-ui@2.9.9(vue@3.5.38(typescript@6.0.3)):
     dependencies:
       '@floating-ui/dom': 1.7.6
@@ -16925,6 +16946,14 @@ snapshots:
       typescript: 6.0.3
 
   vary@1.1.2: {}
+
+  vaul-vue@0.4.1(reka-ui@2.9.10(vue@3.5.38(typescript@6.0.3)))(vue@3.5.38(typescript@6.0.3)):
+    dependencies:
+      '@vueuse/core': 10.11.1(vue@3.5.38(typescript@6.0.3))
+      reka-ui: 2.9.10(vue@3.5.38(typescript@6.0.3))
+      vue: 3.5.38(typescript@6.0.3)
+    transitivePeerDependencies:
+      - '@vue/composition-api'
 
   vaul-vue@0.4.1(reka-ui@2.9.9(vue@3.5.38(typescript@6.0.3)))(vue@3.5.38(typescript@6.0.3)):
     dependencies:


### PR DESCRIPTION
Port of upstream nuxt/ui [`39d53ae5`](https://github.com/nuxt/ui/commit/39d53ae54b9d810dc691c4fbe1ac6205df5f6e05) — `chore(deps): update reka-ui to v2.9.10 (#6584)`.

## Changes
- `reka-ui` `2.9.9` → `2.9.10` (exact pin, root `package.json`) — b24ui pins the same exact version.
- lockfile regen under the active `minimumReleaseAge` gate (resolves to `2.9.10`).
- A second `reka-ui@2.9.9` stays in the lock for the transitive `@nuxt/ui@4.7.1` (its own pin) — expected in the fork, not a dedupe miss.

## Verification (pnpm 11.5.2, gate ON)
frozen install · dev:prepare · lint · typecheck · test (**5088 passed**, 6 skipped) · module build — all green.

Ledger: records the merge sha for the previous port (#192, `b026ca2c` skip) and advances the sync cursor to `39d53ae5`.

https://claude.ai/code/session_01Qz7EXMncvEGiCj4WbmYgJo

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qz7EXMncvEGiCj4WbmYgJo)_