### PR TITLE
chore(sync): skip upstream Calendar month/year selection (#6582)

### DIFF
--- a/.sync/log/ca3c72eb6606da882a6aba5c9f35a3ff0dddf820.md
+++ b/.sync/log/ca3c72eb6606da882a6aba5c9f35a3ff0dddf820.md
@@ -1,0 +1,41 @@
+# Port: feat(Calendar): add month and year selection (#6582)
+
+**Upstream:** `ca3c72eb6606da882a6aba5c9f35a3ff0dddf820` (nuxt/ui)
+**Decision:** skip
+
+## Upstream change
+Largest single-component change in the current stream:
+- `src/runtime/components/Calendar.vue` **+296**
+- `src/theme/calendar.ts` **+102**
+- `docs/.../calendar.md` **+226**, new `CalendarTodayExample.vue`,
+  playground `calendar.vue`
+- ~4,800-line snapshot regen per project.
+
+Adds a `type` prop (`date | month | year`), a drill up/down **view** state
+machine (`day → month → year`), a `viewControl` heading button that cycles
+views, month/year picker grids via reka-ui's namespaced `MonthPicker` /
+`YearPicker` (+ range variants), new emits (`update:placeholder`,
+`update:startValue`, `update:validModelValue`) and new slots (`month-cell`,
+`year-cell`, extended `heading`).
+
+## b24ui decision — skip (maintainer call)
+Not portable 1:1 and **skipped** per maintainer decision (no source change):
+- The **component logic** ports mechanically, but the **theme** does not.
+  Upstream `calendar.ts` is built on `options.theme.colors` loops + nuxt/ui
+  semantic tokens (`bg-${color}`, `text-inverted`, `ring-accented`,
+  `data-selected`, …). b24ui's `calendar.ts` is **air-design-token based**
+  with **no `theme.colors`**, so the new `view` variant, `daySizes`/
+  `pickerSizes` compounds, month/year `cellTrigger` styling and `headingLabel`
+  slot need a deliberate **air-design pass** (how month/year cells and the
+  `viewControl` button should look in b24ui), not a 1:1 translation.
+- Its size + the design decisions involved warrant a focused task rather than
+  a rushed mega-PR folded into the sync stream.
+
+No upstream-dependency blocker: reka-ui `2.9.10` (current in b24ui, ported in
+#193) already exposes `MonthPicker` / `YearPicker` / `MonthRangePicker` /
+`YearRangePicker` namespaced.
+
+The feature (ported and adapted to air design) is tracked separately in
+**issue #194** for a deliberate design pass.
+
+No file change — bookkeeping only (ledger marks this `skip`, advances cursor).

--- a/.sync/nuxt-ui.json
+++ b/.sync/nuxt-ui.json
@@ -2,7 +2,7 @@
   "upstream": "nuxt/ui",
   "branch": "v4",
   "sync_enabled": false,
-  "cursor": "39d53ae54b9d810dc691c4fbe1ac6205df5f6e05",
+  "cursor": "ca3c72eb6606da882a6aba5c9f35a3ff0dddf820",
   "_cursor_note": "cursor = last upstream commit ported into b24ui (oldest-first, manual cadence). sync_enabled stays false until Phase 2 (porter workflow #67 + CLAUDE_CODE_OAUTH_TOKEN) is wired and trusted. `processed` is maintained per port from now on (backfilled #68-#72 on 2026-06-09).",
   "stats": {
     "queue_depth": 0,
@@ -551,10 +551,16 @@
       "summary": "feat(theme): uniformize focus styles across components (#6576) — SKIPPED (maintainer call): rewrites focus styling across ~50 themes to nuxt/ui's outline-3/outline-{color}/25 + theme.colors model. b24ui has its own air-token focus system (ring-(--b24ui-border-color), --ui-color-design-selection-content, …) and no theme.colors; adopting upstream would regress the air design. Generic bits (a:focus-visible reset, keyframes overflow:hidden) also deferred. Tracked in issue #191"
     },
     "39d53ae54b9d810dc691c4fbe1ac6205df5f6e05": {
-      "pr": null,
-      "b24ui_sha": "pending-merge",
+      "pr": 193,
+      "b24ui_sha": "7a2ac559",
       "decision": "port",
       "summary": "chore(deps): update reka-ui to v2.9.10 (#6584) — direct 1:1 exact-version bump in root package.json (2.9.9->2.9.10); lockfile regen under gate (resolves 2.9.10). A second reka-ui@2.9.9 stays for transitive @nuxt/ui@4.7.1 (its own pin) — expected in the fork"
+    },
+    "ca3c72eb6606da882a6aba5c9f35a3ff0dddf820": {
+      "pr": null,
+      "b24ui_sha": "pending-merge",
+      "decision": "skip",
+      "summary": "feat(Calendar): add month and year selection (#6582) — SKIPPED (maintainer call): largest single-component change (Calendar.vue +296, calendar.ts +102, docs +226, ~4800-line snapshot regen). Component logic ports mechanically but the theme does not: upstream calendar.ts is built on theme.colors loops + nuxt/ui semantic tokens, while b24ui's calendar.ts is air-design-token based with no theme.colors — the new `view` variant, daySizes/pickerSizes compounds, month/year cellTrigger styling and headingLabel slot need a deliberate air-design pass, not a 1:1 translation. No upstream-dep blocker (reka-ui 2.9.10 already exposes Month/YearPicker namespaced, #193). Tracked in issue #194"
     }
   }
 }


### PR DESCRIPTION
Records upstream nuxt/ui [`ca3c72eb`](https://github.com/nuxt/ui/commit/ca3c72eb6606da882a6aba5c9f35a3ff0dddf820) — `feat(Calendar): add month and year selection (#6582)` — as **skipped**.

## Decision: skip (maintainer call)

The largest single-component change in the current stream (`Calendar.vue` +296, `calendar.ts` +102, docs +226, ~4,800-line snapshot regen per project). It adds a `type` prop (`date | month | year`), a drill up/down **view** state machine (`day → month → year`), a `viewControl` heading button, month/year picker grids via reka-ui's namespaced `MonthPicker` / `YearPicker` (+ range variants), new emits and slots.

The **component logic** ports mechanically, but the **theme** does not. Upstream `calendar.ts` is built on `options.theme.colors` loops + nuxt/ui semantic tokens (`bg-${color}`, `text-inverted`, `ring-accented`, `data-selected`, …), while **b24ui's `calendar.ts` is air-design-token based with no `theme.colors`**. The new `view` variant, `daySizes`/`pickerSizes` compounds, month/year `cellTrigger` styling and `headingLabel` slot need a deliberate **air-design pass** (how month/year cells and the `viewControl` button should look in b24ui), not a 1:1 translation — so it's deferred to a focused task rather than folded into the sync stream.

No upstream-dependency blocker: reka-ui `2.9.10` (current in b24ui, #193) already exposes `MonthPicker` / `YearPicker` / `MonthRangePicker` / `YearRangePicker` namespaced. The feature, adapted to air design, is tracked in **#194** for a deliberate design pass.

## Changes
Bookkeeping only — `.sync/` ledger + log entry. Advances the sync cursor to `ca3c72eb` and reconciles the previous port (#193, `39d53ae5` reka-ui `2.9.10`) with its merge sha.

https://claude.ai/code/session_01Qz7EXMncvEGiCj4WbmYgJo

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qz7EXMncvEGiCj4WbmYgJo)_