### PR TITLE
fix(CommandPalette): only scroll to highlighted item when focused

### DIFF
--- a/.sync/log/02259a6ae963408b2a971722b9b66d225a0505f3.md
+++ b/.sync/log/02259a6ae963408b2a971722b9b66d225a0505f3.md
@@ -1,0 +1,31 @@
+# Port: fix(CommandPalette): only scroll to highlighted item when focused (#6579)
+
+**Upstream:** `02259a6ae963408b2a971722b9b66d225a0505f3` (nuxt/ui)
+**Decision:** port
+
+## Upstream change
+`watch(filteredGroups, …)` previously always called `highlightFirstItem()`
+after results render. When results resolve asynchronously (e.g. `useLazyFetch`)
+while the palette is below the fold, `highlightFirstItem()` scrolls the
+highlighted item into view, which scrolls the whole page to a palette the user
+never interacted with. The fix only re-highlights *with* scroll when the
+palette already contains focus; otherwise it highlights the selected item
+without scrolling (`highlightSelected(undefined, false)`).
+
+## b24ui adaptation
+Direct 1:1 — b24ui's `CommandPalette.vue` matched the upstream pre-change
+exactly (same reka-ui `ListboxRoot` ref exposing `highlightFirstItem` /
+`highlightSelected`), no `ui→b24ui` / icon / color rewrites needed.
+- `src/runtime/components/CommandPalette.vue`: guard the re-highlight in
+  `watch(filteredGroups)` with `rootEl.contains(document.activeElement)` —
+  `highlightFirstItem()` when focused, else `highlightSelected(undefined, false)`.
+- `test/components/CommandPalette.spec.ts`: ported the upstream spec verbatim
+  (b24ui already uses the `groups` prop shape) — asserts results arriving
+  without focus re-highlight (`[data-highlighted]`) but do not call
+  `scrollIntoView`, and that a results change *with* focus does scroll. Added
+  `vi` to the vitest import.
+
+Builds on the earlier #76 (`efd7b8ec`) re-highlight-after-debounce port.
+
+## Verification (pnpm 11.5.2, gate ON)
+frozen install · dev:prepare · lint · typecheck · test · module build.

--- a/.sync/nuxt-ui.json
+++ b/.sync/nuxt-ui.json
@@ -2,7 +2,7 @@
   "upstream": "nuxt/ui",
   "branch": "v4",
   "sync_enabled": false,
-  "cursor": "ca3c72eb6606da882a6aba5c9f35a3ff0dddf820",
+  "cursor": "02259a6ae963408b2a971722b9b66d225a0505f3",
   "_cursor_note": "cursor = last upstream commit ported into b24ui (oldest-first, manual cadence). sync_enabled stays false until Phase 2 (porter workflow #67 + CLAUDE_CODE_OAUTH_TOKEN) is wired and trusted. `processed` is maintained per port from now on (backfilled #68-#72 on 2026-06-09).",
   "stats": {
     "queue_depth": 0,
@@ -557,10 +557,16 @@
       "summary": "chore(deps): update reka-ui to v2.9.10 (#6584) — direct 1:1 exact-version bump in root package.json (2.9.9->2.9.10); lockfile regen under gate (resolves 2.9.10). A second reka-ui@2.9.9 stays for transitive @nuxt/ui@4.7.1 (its own pin) — expected in the fork"
     },
     "ca3c72eb6606da882a6aba5c9f35a3ff0dddf820": {
-      "pr": null,
-      "b24ui_sha": "pending-merge",
+      "pr": 195,
+      "b24ui_sha": "06ea4ebd",
       "decision": "skip",
       "summary": "feat(Calendar): add month and year selection (#6582) — SKIPPED (maintainer call): largest single-component change (Calendar.vue +296, calendar.ts +102, docs +226, ~4800-line snapshot regen). Component logic ports mechanically but the theme does not: upstream calendar.ts is built on theme.colors loops + nuxt/ui semantic tokens, while b24ui's calendar.ts is air-design-token based with no theme.colors — the new `view` variant, daySizes/pickerSizes compounds, month/year cellTrigger styling and headingLabel slot need a deliberate air-design pass, not a 1:1 translation. No upstream-dep blocker (reka-ui 2.9.10 already exposes Month/YearPicker namespaced, #193). Tracked in issue #194"
+    },
+    "02259a6ae963408b2a971722b9b66d225a0505f3": {
+      "pr": null,
+      "b24ui_sha": "pending-merge",
+      "decision": "port",
+      "summary": "fix(CommandPalette): only scroll to highlighted item when focused (#6579) — CommandPalette.vue: guard the watch(filteredGroups) re-highlight with rootEl.contains(document.activeElement) — highlightFirstItem() only when the palette has focus, else highlightSelected(undefined, false) so async results (useLazyFetch) below the fold don't scroll the whole page. Direct 1:1 (b24ui matched the pre-change; same reka ListboxRoot API). +spec (results without focus re-highlight but don't scrollIntoView; with focus do). Builds on #76 (efd7b8ec)"
     }
   }
 }

--- a/src/runtime/components/CommandPalette.vue
+++ b/src/runtime/components/CommandPalette.vue
@@ -450,7 +450,18 @@ const rootRef = useTemplateRef('rootRef')
 
 watch(filteredGroups, () => {
   nextTick(() => {
-    rootRef.value?.highlightFirstItem()
+    // Re-highlight the first item when results change (e.g. after debounced or
+    // async data renders). Only scroll it into view when the palette already has
+    // focus — otherwise results resolving while the palette is below the fold
+    // (e.g. `useLazyFetch`) would scroll the whole page to it.
+    const root = rootRef.value
+    // `$el` is on the component instance but not part of reka-ui's exposed type.
+    const rootEl = (root as unknown as { $el?: HTMLElement } | null)?.$el
+    if (rootEl?.contains(document.activeElement)) {
+      root?.highlightFirstItem()
+    } else {
+      root?.highlightSelected(undefined, false)
+    }
   })
 })
 

--- a/test/components/CommandPalette.spec.ts
+++ b/test/components/CommandPalette.spec.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
 import { axe } from 'vitest-axe'
 import { mountSuspended } from '@nuxt/test-utils/runtime'
 import { renderEach } from '../component-render'
@@ -181,5 +181,43 @@ describe('CommandPalette', () => {
         'aria-input-field-name': { enabled: false }
       }
     })).toHaveNoViolations()
+  })
+
+  // Results arriving after mount (e.g. `useLazyFetch({ server: false })`) must
+  // re-highlight the first item without scrolling the whole page to a palette
+  // that is below the fold and was never interacted with.
+  it('re-highlights without scrolling the page when results arrive without focus', async () => {
+    const scrollSpy = vi.fn()
+    const original = window.HTMLElement.prototype.scrollIntoView
+    window.HTMLElement.prototype.scrollIntoView = scrollSpy
+
+    try {
+      const wrapper = await mountSuspended(CommandPalette, {
+        props: { groups: [{ id: 'users', items: [] }], autofocus: false } as any,
+        attachTo: document.body
+      })
+      await new Promise(resolve => setTimeout(resolve, 60))
+
+      // Items arrive asynchronously while the palette is not focused
+      await wrapper.setProps({
+        groups: [{ id: 'users', items: Array.from({ length: 10 }, (_, i) => ({ label: `User ${i}` })) }]
+      } as any)
+      await new Promise(resolve => setTimeout(resolve, 60))
+
+      // First item is highlighted for keyboard entry, but the page was not scrolled to it.
+      expect(wrapper.find('[data-highlighted]').exists()).toBe(true)
+      expect(scrollSpy).not.toHaveBeenCalled()
+
+      // Once the palette has focus, a results change scrolls the highlight into view.
+      ;(wrapper.find('input').element as HTMLInputElement).focus()
+      await wrapper.setProps({
+        groups: [{ id: 'users', items: Array.from({ length: 8 }, (_, i) => ({ label: `Person ${i}` })) }]
+      } as any)
+      await new Promise(resolve => setTimeout(resolve, 60))
+
+      expect(scrollSpy).toHaveBeenCalled()
+    } finally {
+      window.HTMLElement.prototype.scrollIntoView = original
+    }
   })
 })


### PR DESCRIPTION
Port of upstream nuxt/ui [`02259a6a`](https://github.com/nuxt/ui/commit/02259a6ae963408b2a971722b9b66d225a0505f3) — `fix(CommandPalette): only scroll to highlighted item when focused (#6579)`.

## Problem
`watch(filteredGroups, …)` always called `highlightFirstItem()` after results render. When results resolve asynchronously (e.g. `useLazyFetch`) while the palette is **below the fold**, `highlightFirstItem()` scrolls the highlighted item into view — scrolling the whole page to a palette the user never interacted with.

## Changes
- **`src/runtime/components/CommandPalette.vue`**: guard the `watch(filteredGroups)` re-highlight with `rootEl.contains(document.activeElement)` — call `highlightFirstItem()` (with scroll) only when the palette already has focus, otherwise `highlightSelected(undefined, false)` (re-highlight without scrolling). Direct 1:1 — b24ui matched the upstream pre-change exactly (same reka-ui `ListboxRoot` ref API), no `ui→b24ui` / icon / color rewrites needed.
- **`test/components/CommandPalette.spec.ts`**: ported the upstream spec (b24ui already uses the `groups` prop shape) — asserts results arriving **without** focus re-highlight (`[data-highlighted]`) but do **not** call `scrollIntoView`, and that a results change **with** focus does scroll. Added `vi` to the vitest import.

Builds on the earlier #76 (`efd7b8ec`) re-highlight-after-debounce port.

## Verification (pnpm 11.5.2, gate ON)
frozen install · dev:prepare · lint · typecheck · test (**5090 passed**, 6 skipped — +2 from the new spec) · module build — all green.

Ledger: records the merge sha for the previous port (#195, `ca3c72eb` skip) and advances the sync cursor to `02259a6a`.

https://claude.ai/code/session_01Qz7EXMncvEGiCj4WbmYgJo

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qz7EXMncvEGiCj4WbmYgJo)_