### PR TITLE
fix(ProseCodeCollapse): cap root max-height instead of toggling pre height

### DIFF
--- a/.sync/log/52d3c45478d1cfc88e288a093407d459ccf5ad48.md
+++ b/.sync/log/52d3c45478d1cfc88e288a093407d459ccf5ad48.md
@@ -1,0 +1,34 @@
+# Port: fix(ProseCodeCollapse): cap root `max-height` instead of toggling pre `height` (#6565)
+
+**Upstream:** `52d3c45478d1cfc88e288a093407d459ccf5ad48` (nuxt/ui)
+**Decision:** port
+
+## Upstream change
+`src/theme/prose/code-collapse.ts` — instead of toggling the inner `<pre>`
+height (`[&_pre]:h-[200px]` ↔ `[&_pre]:h-auto`), cap the **root** `max-height`
+in the collapsed state. New shape:
+- `slots.root`: `relative my-5 bg-muted [&>div]:my-0 [&_pre]:max-h-[80vh] [&_pre]:pb-12`
+- `variants.open.true.root`: `rounded-md`
+- `variants.open.false.root`: `max-h-[200px] overflow-hidden rounded-b-md [&_pre]:overflow-hidden`
+- `variants.open.false.footer`: `inset-x-0 bottom-0 border border-t-0 border-muted bg-linear-to-t from-muted`
+
+## b24ui adaptation
+Theme port with the air-token mapping already established in this file (kept
+consistent with the existing b24ui `code-collapse.ts`, not a raw 1:1):
+- `bg-muted` → `bg-(--ui-color-design-outline-bg)`
+- `rounded-md` / `rounded-b-md` → `rounded-(--ui-border-radius-md)` /
+  `rounded-b-(--ui-border-radius-md)`
+- `pb-12` → `pb-[48px]`
+- `from-muted` → `from-(--ui-color-g-plastic-greish-bg)` (existing mapping)
+- `border-muted` → `border-(--ui-color-design-outline-stroke)` (closest air
+  outline-stroke token; not in `color-map.json`, consistent with
+  `card.ts` / `page-card.ts` muted borders — see PR deviations)
+- layout utilities (`my-5`, `[&>div]:my-0`, `max-h-*`, `overflow-hidden`,
+  `inset-x-0 bottom-0`, `border border-t-0`) ported verbatim.
+
+The footer base slot (b24ui array form) was unchanged by upstream and kept
+as-is; only `variants.open.false.footer` gained the border/anchor classes.
+
+## Verification (pnpm 11.5.2, gate ON)
+dev:prepare · lint · typecheck · test · module build — green. No snapshot
+churn (no ProseCodeCollapse render/snapshot test; theme is a static object).

--- a/.sync/nuxt-ui.json
+++ b/.sync/nuxt-ui.json
@@ -2,7 +2,7 @@
   "upstream": "nuxt/ui",
   "branch": "v4",
   "sync_enabled": false,
-  "cursor": "238e291791737b15fe94eeac6f93468cfcf932bb",
+  "cursor": "52d3c45478d1cfc88e288a093407d459ccf5ad48",
   "_cursor_note": "cursor = last upstream commit ported into b24ui (oldest-first, manual cadence). sync_enabled stays false until Phase 2 (porter workflow #67 + CLAUDE_CODE_OAUTH_TOKEN) is wired and trusted. `processed` is maintained per port from now on (backfilled #68-#72 on 2026-06-09).",
   "stats": {
     "queue_depth": 0,
@@ -575,10 +575,16 @@
       "summary": "docs(Chat): validate AI theme and inputs — PARTIAL port (docs-only). ai.post.ts: ported 1:1 — currentPage is interpolated verbatim into the system prompt (same prompt-injection surface as upstream), added safeCurrentPage server-side guard (string, <=128, no \\r\\n, /^\\/docs\\/[\\w/-]*$/) and swapped currentPage->safeCurrentPage; matches b24ui client which only sends /docs/ paths. useTheme.ts: NO-OP — b24ui already neutered AI theme application (customColors/cssVariables styles are computed(()=>''), applyThemeSettings is a track-only stub, no injectCustomColors/appConfig.ui mutation), so the untrusted sink the upstream sanitizers protect doesn't exist. No src change"
     },
     "238e291791737b15fe94eeac6f93468cfcf932bb": {
+      "pr": 198,
+      "b24ui_sha": "11c0d71c",
+      "decision": "port",
+      "summary": "fix(templates): resolve vite root to an absolute path for #build aliases (#6586) — src/plugins/templates.ts: writeTemplates(config.root || process.cwd()) -> writeTemplates(path.resolve(config.root || '.')). config.root is unresolved in the Vite config hook, so a CLI root can be relative; alias targets must be absolute (Vite 8 warns, @tailwindcss/vite rejects relative -> silently drops theme classes). Direct 1:1 (b24ui matched the pre-change; path already imported). No test/snapshot churn"
+    },
+    "52d3c45478d1cfc88e288a093407d459ccf5ad48": {
       "pr": null,
       "b24ui_sha": "pending-merge",
       "decision": "port",
-      "summary": "fix(templates): resolve vite root to an absolute path for #build aliases (#6586) — src/plugins/templates.ts: writeTemplates(config.root || process.cwd()) -> writeTemplates(path.resolve(config.root || '.')). config.root is unresolved in the Vite config hook, so a CLI root can be relative; alias targets must be absolute (Vite 8 warns, @tailwindcss/vite rejects relative -> silently drops theme classes). Direct 1:1 (b24ui matched the pre-change; path already imported). No test/snapshot churn"
+      "summary": "fix(ProseCodeCollapse): cap root max-height instead of toggling pre height (#6565) — src/theme/prose/code-collapse.ts: collapsed state now caps the root max-h-[200px] (overflow-hidden) instead of toggling [&_pre]:h-[200px]<->h-auto; root base gains my-5 [&>div]:my-0 [&_pre]:max-h-[80vh] [&_pre]:pb-[48px], open:true -> rounded, open:false -> max-h-[200px]+border footer. Theme port with the file's existing air-token mapping (bg-muted->bg-(--ui-color-design-outline-bg), rounded(-b)-md->rounded(-b)-(--ui-border-radius-md), pb-12->pb-[48px], from-muted->from-(--ui-color-g-plastic-greish-bg), border-muted->border-(--ui-color-design-outline-stroke) [closest air outline-stroke, not in color-map]). No snapshot churn"
     }
   }
 }

--- a/src/theme/prose/code-collapse.ts
+++ b/src/theme/prose/code-collapse.ts
@@ -3,7 +3,7 @@
  */
 export default {
   slots: {
-    root: 'relative [&_pre]:h-[200px] bg-(--ui-color-design-outline-bg)',
+    root: 'relative my-5 bg-(--ui-color-design-outline-bg) [&>div]:my-0 [&_pre]:max-h-[80vh] [&_pre]:pb-[48px]',
     footer: [
       'h-[64px]',
       'absolute inset-x-px bottom-px',
@@ -16,11 +16,11 @@ export default {
   variants: {
     open: {
       true: {
-        root: '[&_pre]:h-auto [&_pre]:min-h-[200px] [&_pre]:max-h-[80vh] [&_pre]:pb-[48px]'
+        root: 'rounded-(--ui-border-radius-md)'
       },
       false: {
-        root: '[&_pre]:overflow-hidden',
-        footer: 'bg-linear-to-t from-(--ui-color-g-plastic-greish-bg)'
+        root: 'max-h-[200px] overflow-hidden rounded-b-(--ui-border-radius-md) [&_pre]:overflow-hidden',
+        footer: 'inset-x-0 bottom-0 border border-t-0 border-(--ui-color-design-outline-stroke) bg-linear-to-t from-(--ui-color-g-plastic-greish-bg)'
       }
     }
   }


### PR DESCRIPTION
Port of upstream nuxt/ui [`52d3c454`](https://github.com/nuxt/ui/commit/52d3c45478d1cfc88e288a093407d459ccf5ad48) — `fix(ProseCodeCollapse): cap root max-height instead of toggling pre height (#6565)`.

## Change
`src/theme/prose/code-collapse.ts` — the collapsed state now caps the **root** `max-height` (`max-h-[200px] overflow-hidden`) instead of toggling the inner `<pre>` height (`[&_pre]:h-[200px]` ↔ `[&_pre]:h-auto`):
- `slots.root` base gains `my-5 [&>div]:my-0 [&_pre]:max-h-[80vh] [&_pre]:pb-[48px]`
- `open:true` → rounds the root (`rounded`)
- `open:false` → `max-h-[200px] overflow-hidden` + a bordered footer

Theme port using this file's **existing air-token mapping** (kept consistent with the current b24ui theme, not a raw 1:1):

| upstream | b24ui |
|---|---|
| `bg-muted` | `bg-(--ui-color-design-outline-bg)` |
| `rounded-md` / `rounded-b-md` | `rounded-(--ui-border-radius-md)` / `rounded-b-(--ui-border-radius-md)` |
| `pb-12` | `pb-[48px]` |
| `from-muted` | `from-(--ui-color-g-plastic-greish-bg)` |
| `border-muted` | `border-(--ui-color-design-outline-stroke)` |

Layout utilities (`my-5`, `[&>div]:my-0`, `max-h-*`, `overflow-hidden`, `inset-x-0 bottom-0`, `border border-t-0`) ported verbatim.

### Deviations
- `border-muted` is **not** in `color-map.json` (that map only holds color names). Mapped to `border-(--ui-color-design-outline-stroke)` — the closest air outline-stroke token, consistent with how `card.ts` / `page-card.ts` express muted borders. Flagging for reviewer confirmation.

## Verification (pnpm 11.5.2, gate ON)
dev:prepare · lint · typecheck · test (**5090 passed**, 6 skipped) · module build — all green. No snapshot churn (no ProseCodeCollapse render/snapshot test; theme is a static object).

Ledger: records the merge sha for the previous port (#198, `238e2917`) and advances the sync cursor to `52d3c454`.

https://claude.ai/code/session_01Qz7EXMncvEGiCj4WbmYgJo

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qz7EXMncvEGiCj4WbmYgJo)_