### PR TITLE
feat(components): allow hiding icon with false

### DIFF
--- a/.sync/log/09eb639a33460e1ece8fcfc7dd9c2f523af9b0b4.md
+++ b/.sync/log/09eb639a33460e1ece8fcfc7dd9c2f523af9b0b4.md
@@ -1,0 +1,40 @@
+# Port: feat(components): allow hiding `icon` with `false` (#6597)
+
+**Upstream:** `09eb639a33460e1ece8fcfc7dd9c2f523af9b0b4` (nuxt/ui)
+**Decision:** port
+
+## Upstream change
+Five components let `icon` be `false` to hide it: `ChatPromptSubmit`,
+`CommandPalette`, `DashboardSearchButton`, `FileUpload`,
+`content/ContentSearchButton`. Prop type `IconProps['name']` →
+`IconProps['name'] | false`; usage `props.icon || default` →
+`props.icon === false ? undefined : (props.icon ?? default)` (FileUpload wraps
+the icon/avatar in `v-if="props.icon !== false"`). +spec per component.
+
+## b24ui adaptation
+Same intent, expressed in b24ui's icon system (`IconComponent` from
+`dictionary/icons`, jsDoc `@IconComponent`), not iconify `IconProps['name']`:
+- type `icon?: IconComponent` → `icon?: IconComponent | false` (+ "Set to
+  `false` to hide the icon." in each jsDoc).
+- `ChatPromptSubmit.vue`: ready `icon: props.icon || icons.imSend` →
+  `props.icon === false ? undefined : (props.icon ?? icons.imSend)`.
+- `CommandPalette.vue`: input `:icon` → `props.icon === false ? undefined :
+  (props.icon ?? icons.search)`.
+- `DashboardSearchButton.vue` / `content/ContentSearchButton.vue`: button
+  `:icon` → same `=== false ? undefined : (?? icons.search)`.
+- `FileUpload.vue`: wrap the `<Component>`/`<B24Avatar>` in
+  `<template v-if="props.icon !== false">` and use `props.icon ?? icons.upload`.
+
+### Test selector deviation (b24-icons vs iconify)
+Upstream asserts on `[data-slot="leadingIcon"]`. In b24ui, a `@bitrix24/b24icons`
+component renders its **own** root `<svg data-slot="icon">`, which overrides the
+`data-slot="leadingIcon"` set by Button/Input — so the surfaced selector is
+`[data-slot="icon"]` (confirmed by render). b24ui specs therefore assert
+`[data-slot="icon"]` (FileUpload already used `icon`/`avatar`). For the
+CommandPalette spec, items also render `data-slot="icon"`, so the test uses
+icon-less items to isolate the input's leading icon.
+
+## Verification (pnpm 11.6.0, gate ON)
+dev:prepare · lint · typecheck · test (5101 passed, 6 skipped — +11 cases) ·
+module build — all green. No snapshot churn (defaults unchanged; only the
+`icon: false` path is new).

--- a/.sync/nuxt-ui.json
+++ b/.sync/nuxt-ui.json
@@ -2,7 +2,7 @@
   "upstream": "nuxt/ui",
   "branch": "v4",
   "sync_enabled": false,
-  "cursor": "006324aeb91ae4054c314c9cb4a9d552fe04e44e",
+  "cursor": "09eb639a33460e1ece8fcfc7dd9c2f523af9b0b4",
   "_cursor_note": "cursor = last upstream commit ported into b24ui (oldest-first, manual cadence). sync_enabled stays false until Phase 2 (porter workflow #67 + CLAUDE_CODE_OAUTH_TOKEN) is wired and trusted. `processed` is maintained per port from now on (backfilled #68-#72 on 2026-06-09).",
   "stats": {
     "queue_depth": 0,
@@ -617,10 +617,16 @@
       "summary": "feat(ChatMessages): expose registerMessageRef (#6275) — ChatMessages.vue: defineExpose({ registerMessageRef }) + pass it to the default slot (<slot :register-message-ref>), and type the default slot prop (registerMessageRef: (id, element: ComponentPublicInstance|null)=>void). Direct 1:1 (ui->b24ui already applied; registerMessageRef fn + imports already present). +docs Expose section. No snapshot churn (binding/expose don't change markup)"
     },
     "006324aeb91ae4054c314c9cb4a9d552fe04e44e": {
+      "pr": 203,
+      "b24ui_sha": "a49f341f",
+      "decision": "port",
+      "summary": "feat(Modal/Slideover): add leave and enter events (#6596) — Modal.vue + Slideover.vue: add 'leave':[] and 'enter':[] to *Emits and wire @enter=emits('enter') / @leave=emits('leave') on the reka dialog content (alongside existing after:enter/after:leave). Direct 1:1 (both matched the pre-change). Docs untouched (emit tables generated from component-meta). No snapshot churn"
+    },
+    "09eb639a33460e1ece8fcfc7dd9c2f523af9b0b4": {
       "pr": null,
       "b24ui_sha": "pending-merge",
       "decision": "port",
-      "summary": "feat(Modal/Slideover): add leave and enter events (#6596) — Modal.vue + Slideover.vue: add 'leave':[] and 'enter':[] to *Emits and wire @enter=emits('enter') / @leave=emits('leave') on the reka dialog content (alongside existing after:enter/after:leave). Direct 1:1 (both matched the pre-change). Docs untouched (emit tables generated from component-meta). No snapshot churn"
+      "summary": "feat(components): allow hiding icon with false (#6597) — 5 components (ChatPromptSubmit, CommandPalette, DashboardSearchButton, FileUpload, content/ContentSearchButton): icon?: IconComponent -> IconComponent|false; usage props.icon||icons.X -> props.icon===false?undefined:(props.icon??icons.X); FileUpload wraps icon/avatar in v-if=props.icon!==false. +spec each. Test selector adapted: b24-icons render their own data-slot=icon (overrides Button/Input data-slot=leadingIcon), so specs assert [data-slot=icon]; CommandPalette spec uses icon-less items to isolate the input icon. No snapshot churn (defaults unchanged)"
     }
   }
 }

--- a/src/runtime/components/ChatPromptSubmit.vue
+++ b/src/runtime/components/ChatPromptSubmit.vue
@@ -10,11 +10,11 @@ type ChatPromptSubmit = ComponentConfig<typeof theme, AppConfig, 'chatPromptSubm
 export interface ChatPromptSubmitProps extends Omit<ButtonProps, LinkPropsKeys | 'icon' | 'color'> {
   status?: ChatStatus
   /**
-   * The icon displayed in the button when the status is `ready`.
+   * The icon displayed in the button when the status is `ready`. Set to `false` to hide the icon.
    * @defaultValue icons.imSend
    * @IconComponent
    */
-  icon?: IconComponent
+  icon?: IconComponent | false
   /**
    * The color of the button when the status is `ready`.
    * @defaultValue 'air-primary'
@@ -99,7 +99,7 @@ const disabled = computed(() => props.status === 'ready' ? props.disabled : fals
 
 const statusButtonProps = computed(() => ({
   ready: {
-    icon: props.icon || icons.imSend,
+    icon: props.icon === false ? undefined : (props.icon ?? icons.imSend),
     color: props.color,
     type: 'submit' as const
   },

--- a/src/runtime/components/CommandPalette.vue
+++ b/src/runtime/components/CommandPalette.vue
@@ -74,11 +74,11 @@ export interface CommandPaletteProps<G extends CommandPaletteGroup<T> = CommandP
    */
   size?: CommandPalette['variants']['size']
   /**
-   * The icon displayed in the input.
+   * The icon displayed in the input. Set to `false` to hide the icon.
    * @defaultValue icons.search
    * @IconComponent
    */
-  icon?: IconComponent
+  icon?: IconComponent | false
   /**
    * The icon displayed on the right side of the input.
    * @defaultValue icons.search
@@ -690,7 +690,7 @@ function onSelect(e: Event, item: T) {
         :autofocus="props.autofocus"
         :loading="props.loading"
         :trailing-icon="props.trailingIcon"
-        :icon="props.icon || icons.search"
+        :icon="props.icon === false ? undefined : (props.icon ?? icons.search)"
         v-bind="typeof props.input === 'object' ? props.input : {}"
         data-slot="input"
         :class="b24ui.input({ class: props.b24ui?.input })"

--- a/src/runtime/components/DashboardSearchButton.vue
+++ b/src/runtime/components/DashboardSearchButton.vue
@@ -8,11 +8,11 @@ type DashboardSearchButton = ComponentConfig<typeof theme, AppConfig, 'dashboard
 
 export interface DashboardSearchButtonProps extends Omit<ButtonProps, LinkPropsKeys | 'icon' | 'label' | 'color'> {
   /**
-   * The icon displayed in the button.
+   * The icon displayed in the button. Set to `false` to hide the icon.
    * @defaultValue icons.search
    * @IconComponent
    */
-  icon?: IconComponent
+  icon?: IconComponent | false
   /**
    * The label displayed in the button.
    * @defaultValue t('dashboardSearchButton.label')
@@ -92,7 +92,7 @@ const b24ui = computed(() => tv({ extend: tv(theme), ...(appConfig.b24ui?.dashbo
 <template>
   <DefineButtonTemplate>
     <B24Button
-      :icon="props.icon || icons.search"
+      :icon="props.icon === false ? undefined : (props.icon ?? icons.search)"
       :label="props.label || t('dashboardSearchButton.label')"
       v-bind="{
         ...buttonProps,

--- a/src/runtime/components/FileUpload.vue
+++ b/src/runtime/components/FileUpload.vue
@@ -18,11 +18,11 @@ export interface FileUploadProps<M extends boolean = false> extends /** @vue-ign
   id?: string
   name?: string
   /**
-   * The icon to display.
+   * The icon to display. Set to `false` to hide the icon.
    * @defaultValue icons.upload
    * @IconComponent
    */
-  icon?: IconComponent
+  icon?: IconComponent | false
   label?: string
   description?: string
   /**
@@ -383,19 +383,21 @@ defineExpose({
           :class="b24ui.wrapper({ class: props.b24ui?.wrapper })"
         >
           <slot name="leading" :b24ui="b24ui">
-            <Component
-              :is="props.icon || icons.upload"
-              v-if="variant === 'button'"
-              data-slot="icon"
-              :class="b24ui.icon({ class: props.b24ui?.icon })"
-            />
-            <B24Avatar
-              v-else
-              :icon="props.icon || icons.upload"
-              :size="props.size"
-              data-slot="avatar"
-              :class="b24ui.avatar({ class: props.b24ui?.avatar })"
-            />
+            <template v-if="props.icon !== false">
+              <Component
+                :is="props.icon ?? icons.upload"
+                v-if="variant === 'button'"
+                data-slot="icon"
+                :class="b24ui.icon({ class: props.b24ui?.icon })"
+              />
+              <B24Avatar
+                v-else
+                :icon="props.icon ?? icons.upload"
+                :size="props.size"
+                data-slot="avatar"
+                :class="b24ui.avatar({ class: props.b24ui?.avatar })"
+              />
+            </template>
           </slot>
 
           <template v-if="variant !== 'button'">

--- a/src/runtime/components/content/ContentSearchButton.vue
+++ b/src/runtime/components/content/ContentSearchButton.vue
@@ -8,11 +8,11 @@ type ContentSearchButton = ComponentConfig<typeof theme, AppConfig, 'contentSear
 
 export interface ContentSearchButtonProps extends Omit<ButtonProps, LinkPropsKeys | 'icon' | 'label' | 'color'> {
   /**
-   * The icon displayed in the button.
+   * The icon displayed in the button. Set to `false` to hide the icon.
    * @defaultValue icons.search
    * @IconComponent
    */
-  icon?: IconComponent
+  icon?: IconComponent | false
   /**
    * The label displayed in the button.
    * @defaultValue t('contentSearchButton.label')
@@ -92,7 +92,7 @@ const b24ui = computed(() => tv({ extend: tv(theme), ...(appConfig.b24ui?.conten
 <template>
   <DefineButtonTemplate>
     <B24Button
-      :icon="props.icon || icons.search"
+      :icon="props.icon === false ? undefined : (props.icon ?? icons.search)"
       :label="props.label || t('contentSearchButton.label')"
       v-bind="{
         ...buttonProps,

--- a/test/components/ChatPromptSubmit.spec.ts
+++ b/test/components/ChatPromptSubmit.spec.ts
@@ -59,6 +59,14 @@ describe('ChatPromptSubmit', () => {
     expect(wrapper.find('button').attributes('disabled')).toBeUndefined()
   })
 
+  it('hides the icon when icon is false', async () => {
+    const withIcon = await mountSuspended(ChatPromptSubmit)
+    expect(withIcon.find('[data-slot="icon"]').exists()).toBe(true)
+
+    const withoutIcon = await mountSuspended(ChatPromptSubmit, { props: { icon: false } })
+    expect(withoutIcon.find('[data-slot="icon"]').exists()).toBe(false)
+  })
+
   it('passes accessibility tests', async () => {
     const wrapper = await mountSuspended(ChatPromptSubmit, {
       props: {

--- a/test/components/CommandPalette.spec.ts
+++ b/test/components/CommandPalette.spec.ts
@@ -161,6 +161,18 @@ describe('CommandPalette', () => {
     ['with footer slot', { props, slots: { footer: () => 'Footer slot' } }]
   ])
 
+  it('hides the input icon when icon is false', async () => {
+    // Use icon-less items so the only `data-slot="icon"` is the input's leading
+    // icon (b24-icons render their own `data-slot="icon"`, so item icons would
+    // otherwise also match).
+    const iconProps = { groups: [{ id: 'users', items: [{ label: 'bitrix24' }] }] } as any
+    const withIcon = await mountSuspended(CommandPalette, { props: iconProps })
+    expect(withIcon.find('[data-slot="icon"]').exists()).toBe(true)
+
+    const withoutIcon = await mountSuspended(CommandPalette, { props: { ...iconProps, icon: false } })
+    expect(withoutIcon.find('[data-slot="icon"]').exists()).toBe(false)
+  })
+
   it('passes accessibility tests', async () => {
     const wrapper = await mountSuspended(CommandPalette, {
       props: {

--- a/test/components/DashboardSearchButton.spec.ts
+++ b/test/components/DashboardSearchButton.spec.ts
@@ -15,6 +15,14 @@ describe('DashboardSearchButton', () => {
     ['with class', { props: { class: 'w-full' } }]
   ])
 
+  it('hides the icon when icon is false', async () => {
+    const withIcon = await mountSuspended(DashboardSearchButton)
+    expect(withIcon.find('[data-slot="icon"]').exists()).toBe(true)
+
+    const withoutIcon = await mountSuspended(DashboardSearchButton, { props: { icon: false } })
+    expect(withoutIcon.find('[data-slot="icon"]').exists()).toBe(false)
+  })
+
   it('passes accessibility tests', async () => {
     const wrapper = await mountSuspended(DashboardSearchButton, {
       props: {

--- a/test/components/FileUpload.spec.ts
+++ b/test/components/FileUpload.spec.ts
@@ -94,6 +94,22 @@ describe('FileUpload', () => {
     ['with file-trailing slot', { props, slots: { 'file-trailing': () => 'File trailing slot' } }]
   ])
 
+  it('hides the icon when icon is false', async () => {
+    const withIcon = await mountSuspended(FileUpload)
+    expect(withIcon.find('[data-slot="icon"]').exists()).toBe(true)
+
+    const withoutIcon = await mountSuspended(FileUpload, { props: { icon: false } })
+    expect(withoutIcon.find('[data-slot="icon"]').exists()).toBe(false)
+  })
+
+  it('hides the icon when icon is false with variant button', async () => {
+    const withIcon = await mountSuspended(FileUpload, { props: { variant: 'button' } })
+    expect(withIcon.find('[data-slot="icon"]').exists()).toBe(true)
+
+    const withoutIcon = await mountSuspended(FileUpload, { props: { variant: 'button', icon: false } })
+    expect(withoutIcon.find('[data-slot="icon"]').exists()).toBe(false)
+  })
+
   it('passes accessibility tests', async () => {
     const wrapper = await mountSuspended(FileUpload, {
       props: {

--- a/test/components/content/ContentSearchButton.spec.ts
+++ b/test/components/content/ContentSearchButton.spec.ts
@@ -1,4 +1,5 @@
-import { describe } from 'vitest'
+import { describe, it, expect } from 'vitest'
+import { mountSuspended } from '@nuxt/test-utils/runtime'
 import ContentSearchButton from '../../../src/runtime/components/content/ContentSearchButton.vue'
 import { renderEach } from '../../component-render'
 import SignIcon from '@bitrix24/b24icons-vue/main/SignIcon'
@@ -12,4 +13,12 @@ describe('ContentSearchButton', () => {
     ['without collapsed', { props: { collapsed: false } }],
     ['with class', { props: { class: 'w-full' } }]
   ])
+
+  it('hides the icon when icon is false', async () => {
+    const withIcon = await mountSuspended(ContentSearchButton, { props: { collapsed: false } })
+    expect(withIcon.find('[data-slot="icon"]').exists()).toBe(true)
+
+    const withoutIcon = await mountSuspended(ContentSearchButton, { props: { collapsed: false, icon: false } })
+    expect(withoutIcon.find('[data-slot="icon"]').exists()).toBe(false)
+  })
 })


### PR DESCRIPTION
Port of upstream nuxt/ui [`09eb639a`](https://github.com/nuxt/ui/commit/09eb639a33460e1ece8fcfc7dd9c2f523af9b0b4) — `feat(components): allow hiding icon with false (#6597)`.

## Change
Five components let `icon` be `false` to hide it: **ChatPromptSubmit**, **CommandPalette**, **DashboardSearchButton**, **FileUpload**, **content/ContentSearchButton**.

- type: `icon?: IconComponent` → `icon?: IconComponent | false` (+ "Set to `false` to hide the icon." in each jsDoc).
- usage: `props.icon || icons.X` → `props.icon === false ? undefined : (props.icon ?? icons.X)`.
- `FileUpload`: wraps the `<Component>` / `<B24Avatar>` in `<template v-if="props.icon !== false">` and uses `props.icon ?? icons.upload`.
- one spec per component.

Expressed in b24ui's icon system (`IconComponent` from `dictionary/icons`), not iconify `IconProps['name']`.

### Test selector deviation (b24-icons vs iconify)
Upstream asserts on `[data-slot="leadingIcon"]`. In b24ui a `@bitrix24/b24icons` component renders its **own** root `<svg data-slot="icon">`, which overrides the `data-slot="leadingIcon"` set by Button/Input — so the surfaced selector is `[data-slot="icon"]` (confirmed by render). The specs therefore assert `[data-slot="icon"]`. For the CommandPalette spec, items also render `data-slot="icon"`, so the test uses icon-less items to isolate the input's leading icon.

## Verification (pnpm 11.6.0, gate ON)
dev:prepare · lint · typecheck · test (**5101 passed**, 6 skipped — +11 cases) · module build — all green. Defaults unchanged (only the `icon: false` path is new) → no snapshot churn.

Ledger: records the merge sha for the previous port (#203, `006324ae`) and advances the sync cursor to `09eb639a`.

https://claude.ai/code/session_01Qz7EXMncvEGiCj4WbmYgJo

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qz7EXMncvEGiCj4WbmYgJo)_