### PR TITLE
feat(vite): add root option to override .b24ui-nuxt directory location

### DIFF
--- a/.sync/log/cccb3d5a4a3e837173b1d31e6397efaedb032f59.md
+++ b/.sync/log/cccb3d5a4a3e837173b1d31e6397efaedb032f59.md
@@ -1,0 +1,28 @@
+# Port: feat(vite): add `root` option to override `.nuxt-ui` directory location (#6595)
+
+**Upstream:** `cccb3d5a4a3e837173b1d31e6397efaedb032f59` (nuxt/ui)
+**Decision:** port
+
+## Upstream change
+Adds a `root` option to `NuxtUIOptions` (`src/unplugin.ts`) and uses it in the
+templates plugin: `writeTemplates(path.resolve(config.root || '.'))` →
+`writeTemplates(path.resolve(options.root || config.root || '.'))`. Lets
+setups like `electron-vite` (where the renderer's `config.root` is a
+sub-directory Tailwind doesn't scan) point the generated theme-templates
+directory at the project root. +docs section in the Vue installation guide.
+
+## b24ui adaptation
+Direct 1:1, with b24ui naming. Builds on the #198 (`238e2917`) `path.resolve`
+change.
+- `src/unplugin.ts`: add `root?: string` to `Bitrix24UIOptions` (jsDoc points
+  at b24ui's `.b24ui-nuxt` dir and the b24ui docs anchor).
+- `src/plugins/templates.ts`: `writeTemplates(path.resolve(options.root ||
+  config.root || '.'))` (`options` is `Bitrix24UIOptions` here).
+- `docs/.../2.installation/2.vue.md`: added the "### `root`" section after
+  `scanPackages`, rewritten for b24ui (`.b24ui-nuxt`, `bitrix24UIPluginVite`
+  from `@bitrix24/b24ui-nuxt/vite`). Dropped upstream's `4.9+` version badge —
+  b24ui's option sections don't carry version badges.
+
+## Verification (pnpm 11.6.0, gate ON)
+dev:prepare · lint · typecheck · test · module build — green. Build-time
+plugin option; no test/snapshot churn.

--- a/.sync/nuxt-ui.json
+++ b/.sync/nuxt-ui.json
@@ -2,7 +2,7 @@
   "upstream": "nuxt/ui",
   "branch": "v4",
   "sync_enabled": false,
-  "cursor": "09eb639a33460e1ece8fcfc7dd9c2f523af9b0b4",
+  "cursor": "cccb3d5a4a3e837173b1d31e6397efaedb032f59",
   "_cursor_note": "cursor = last upstream commit ported into b24ui (oldest-first, manual cadence). sync_enabled stays false until Phase 2 (porter workflow #67 + CLAUDE_CODE_OAUTH_TOKEN) is wired and trusted. `processed` is maintained per port from now on (backfilled #68-#72 on 2026-06-09).",
   "stats": {
     "queue_depth": 0,
@@ -623,10 +623,16 @@
       "summary": "feat(Modal/Slideover): add leave and enter events (#6596) — Modal.vue + Slideover.vue: add 'leave':[] and 'enter':[] to *Emits and wire @enter=emits('enter') / @leave=emits('leave') on the reka dialog content (alongside existing after:enter/after:leave). Direct 1:1 (both matched the pre-change). Docs untouched (emit tables generated from component-meta). No snapshot churn"
     },
     "09eb639a33460e1ece8fcfc7dd9c2f523af9b0b4": {
+      "pr": 204,
+      "b24ui_sha": "c2ea493d",
+      "decision": "port",
+      "summary": "feat(components): allow hiding icon with false (#6597) — 5 components (ChatPromptSubmit, CommandPalette, DashboardSearchButton, FileUpload, content/ContentSearchButton): icon?: IconComponent -> IconComponent|false; usage props.icon||icons.X -> props.icon===false?undefined:(props.icon??icons.X); FileUpload wraps icon/avatar in v-if=props.icon!==false. +spec each. Test selector adapted: b24-icons render their own data-slot=icon (overrides Button/Input data-slot=leadingIcon), so specs assert [data-slot=icon]; CommandPalette spec uses icon-less items to isolate the input icon. No snapshot churn (defaults unchanged)"
+    },
+    "cccb3d5a4a3e837173b1d31e6397efaedb032f59": {
       "pr": null,
       "b24ui_sha": "pending-merge",
       "decision": "port",
-      "summary": "feat(components): allow hiding icon with false (#6597) — 5 components (ChatPromptSubmit, CommandPalette, DashboardSearchButton, FileUpload, content/ContentSearchButton): icon?: IconComponent -> IconComponent|false; usage props.icon||icons.X -> props.icon===false?undefined:(props.icon??icons.X); FileUpload wraps icon/avatar in v-if=props.icon!==false. +spec each. Test selector adapted: b24-icons render their own data-slot=icon (overrides Button/Input data-slot=leadingIcon), so specs assert [data-slot=icon]; CommandPalette spec uses icon-less items to isolate the input icon. No snapshot churn (defaults unchanged)"
+      "summary": "feat(vite): add root option to override .nuxt-ui directory location (#6595) — add root?: string to Bitrix24UIOptions (unplugin.ts) and use it in templates.ts: writeTemplates(path.resolve(options.root || config.root || '.')). Lets electron-vite-style setups point the generated .b24ui-nuxt theme-templates dir at the project root. Builds on #198 (238e2917). +docs root section in vue installation (adapted: .b24ui-nuxt/bitrix24UIPluginVite, dropped upstream 4.9+ badge). No snapshot churn"
     }
   }
 }

--- a/docs/content/docs/1.getting-started/2.installation/2.vue.md
+++ b/docs/content/docs/1.getting-started/2.installation/2.vue.md
@@ -730,3 +730,29 @@ export default defineConfig({
 ::note
 By default, only `@bitrix24/b24ui-nuxt` is scanned. Use this option when your external packages contain Vue components that use Bitrix24 UI.
 ::
+
+### `root`
+
+Use the `root` option to override the directory where Bitrix24 UI generates its `.b24ui-nuxt` directory (containing the theme templates). By default it uses Vite's `root`, but in setups like [`electron-vite`](https://electron-vite.org/) the renderer's `root` points to a sub-directory (e.g. `src/renderer`), so the templates land in `src/renderer/node_modules/.b24ui-nuxt` where Tailwind doesn't scan them, causing theme classes to be missing.
+
+```ts [electron.vite.config.ts] {12}
+import { defineConfig } from 'electron-vite'
+import vue from '@vitejs/plugin-vue'
+import bitrix24UIPluginVite from '@bitrix24/b24ui-nuxt/vite'
+
+export default defineConfig({
+  renderer: {
+    root: 'src/renderer',
+    plugins: [
+      vue(),
+      bitrix24UIPluginVite({
+        root: __dirname
+      })
+    ]
+  }
+})
+```
+
+::note
+Point `root` at your project root so the generated `.b24ui-nuxt` directory ends up in a `node_modules` that Tailwind scans.
+::

--- a/src/plugins/templates.ts
+++ b/src/plugins/templates.ts
@@ -40,7 +40,9 @@ export default function TemplatePlugin(options: Bitrix24UIOptions, appConfig: Re
         // Alias targets must be absolute: Vite 8 warns on relative targets and
         // resolvers like @tailwindcss/vite reject them, which silently drops
         // every theme class from the generated CSS.
-        const alias = await writeTemplates(path.resolve(config.root || '.'))
+        // `options.root` lets setups like `electron-vite` override the location
+        // when `config.root` points to a sub-directory Tailwind doesn't scan.
+        const alias = await writeTemplates(path.resolve(options.root || config.root || '.'))
 
         return {
           resolve: {

--- a/src/unplugin.ts
+++ b/src/unplugin.ts
@@ -76,6 +76,14 @@ export interface Bitrix24UIOptions extends Omit<ModuleOptions, 'colorMode' | 'co
    * @see https://bitrix24.github.io/b24ui/docs/getting-started/installation/vue/#scanpackages
    */
   scanPackages?: string[]
+  /**
+   * Root directory where the `.b24ui-nuxt` directory (generated theme templates) is created.
+   * Useful for setups like `electron-vite` where `config.root` points to a sub-directory
+   * (e.g. `src/renderer`) that Tailwind doesn't scan.
+   * @defaultValue `config.root`
+   * @see https://bitrix24.github.io/b24ui/docs/getting-started/installation/vue/#root
+   */
+  root?: string
 }
 
 export const runtimeDir = normalize(fileURLToPath(new URL('./runtime', import.meta.url)))


### PR DESCRIPTION
Port of upstream nuxt/ui [`cccb3d5a`](https://github.com/nuxt/ui/commit/cccb3d5a4a3e837173b1d31e6397efaedb032f59) — `feat(vite): add root option to override .nuxt-ui directory location (#6595)`. Builds on #198 (`238e2917`).

## Change
Adds a `root` option so setups like [`electron-vite`](https://electron-vite.org/) — where the renderer's `config.root` points to a sub-directory Tailwind doesn't scan — can point the generated theme-templates directory at the project root (otherwise theme classes silently go missing).

- **`src/unplugin.ts`**: add `root?: string` to `Bitrix24UIOptions`.
- **`src/plugins/templates.ts`**: `writeTemplates(path.resolve(config.root || '.'))` → `writeTemplates(path.resolve(options.root || config.root || '.'))`.
- **`docs/.../2.installation/2.vue.md`**: add the "`root`" section after `scanPackages`, rewritten for b24ui (`.b24ui-nuxt`, `bitrix24UIPluginVite` from `@bitrix24/b24ui-nuxt/vite`). Dropped upstream's `4.9+` version badge — b24ui's option sections don't carry version badges.

Direct 1:1 with b24ui naming.

## Verification (pnpm 11.6.0, gate ON)
dev:prepare · lint · typecheck · test (**5101 passed**, 6 skipped) · module build — all green. Build-time plugin option; no snapshot churn.

Ledger: records the merge sha for the previous port (#204, `09eb639a`) and advances the sync cursor to `cccb3d5a`.

https://claude.ai/code/session_01Qz7EXMncvEGiCj4WbmYgJo

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qz7EXMncvEGiCj4WbmYgJo)_