### PR TITLE
fix(module): remove inline script in SPA mode for strict CSP

### DIFF
--- a/.sync/log/7225e9f451e405d6b07de8ee44b93a11a50b55a8.md
+++ b/.sync/log/7225e9f451e405d6b07de8ee44b93a11a50b55a8.md
@@ -1,0 +1,33 @@
+# Port: fix(module): remove inline script in SPA mode for strict CSP (#6577)
+
+**Upstream:** `7225e9f451e405d6b07de8ee44b93a11a50b55a8` (nuxt/ui)
+**Decision:** port
+
+## Upstream change
+In SPA mode the colors plugin injected a temporary `<style data-nuxt-ui-colors>`
+and removed it via an **inline `<script>`** (`headData.script`), which violates
+a strict CSP (`script-src` without `unsafe-inline`). Replace the inline script
+with a head hook:
+- `src/runtime/plugins/colors.ts`: import `injectHead`; add
+  `removeTemporaryColorsStyle()` (`document.querySelector('[data-nuxt-ui-colors]')?.remove()`);
+  `headData.script = [{ innerHTML: '…removeChild…' }]` →
+  `injectHead().hooks.hookOnce('dom:rendered', removeTemporaryColorsStyle)`.
+- `src/runtime/vue/stubs/base.ts`: also re-export `injectHead` from
+  `@unhead/vue` (for the Vue, non-Nuxt build).
+
+## b24ui adaptation
+Direct 1:1 — b24ui has the same plugin with the same SPA inline-script, only the
+data-attribute differs (`data-bitrix24-ui-colors`).
+- `src/runtime/plugins/colors.ts`: add `injectHead` to the `#imports` import;
+  add `removeTemporaryColorsStyle()` querying `[data-bitrix24-ui-colors]`;
+  replace the `headData.script` inline removeChild with
+  `injectHead().hooks.hookOnce('dom:rendered', removeTemporaryColorsStyle)`.
+- `src/runtime/vue/stubs/base.ts`: `export { useHead }` →
+  `export { injectHead, useHead }`.
+
+(b24ui's color generation is otherwise commented out — air-design tokens — but
+the SPA temporary-style path is active and identical, so the CSP fix applies.)
+
+## Verification (pnpm 11.6.0, gate ON)
+dev:prepare · lint · typecheck · test · module build — green. Runtime SPA path;
+no test/snapshot churn.

--- a/.sync/nuxt-ui.json
+++ b/.sync/nuxt-ui.json
@@ -2,7 +2,7 @@
   "upstream": "nuxt/ui",
   "branch": "v4",
   "sync_enabled": false,
-  "cursor": "cccb3d5a4a3e837173b1d31e6397efaedb032f59",
+  "cursor": "7225e9f451e405d6b07de8ee44b93a11a50b55a8",
   "_cursor_note": "cursor = last upstream commit ported into b24ui (oldest-first, manual cadence). sync_enabled stays false until Phase 2 (porter workflow #67 + CLAUDE_CODE_OAUTH_TOKEN) is wired and trusted. `processed` is maintained per port from now on (backfilled #68-#72 on 2026-06-09).",
   "stats": {
     "queue_depth": 0,
@@ -629,10 +629,16 @@
       "summary": "feat(components): allow hiding icon with false (#6597) — 5 components (ChatPromptSubmit, CommandPalette, DashboardSearchButton, FileUpload, content/ContentSearchButton): icon?: IconComponent -> IconComponent|false; usage props.icon||icons.X -> props.icon===false?undefined:(props.icon??icons.X); FileUpload wraps icon/avatar in v-if=props.icon!==false. +spec each. Test selector adapted: b24-icons render their own data-slot=icon (overrides Button/Input data-slot=leadingIcon), so specs assert [data-slot=icon]; CommandPalette spec uses icon-less items to isolate the input icon. No snapshot churn (defaults unchanged)"
     },
     "cccb3d5a4a3e837173b1d31e6397efaedb032f59": {
+      "pr": 205,
+      "b24ui_sha": "da0f6e9e",
+      "decision": "port",
+      "summary": "feat(vite): add root option to override .nuxt-ui directory location (#6595) — add root?: string to Bitrix24UIOptions (unplugin.ts) and use it in templates.ts: writeTemplates(path.resolve(options.root || config.root || '.')). Lets electron-vite-style setups point the generated .b24ui-nuxt theme-templates dir at the project root. Builds on #198 (238e2917). +docs root section in vue installation (adapted: .b24ui-nuxt/bitrix24UIPluginVite, dropped upstream 4.9+ badge). No snapshot churn"
+    },
+    "7225e9f451e405d6b07de8ee44b93a11a50b55a8": {
       "pr": null,
       "b24ui_sha": "pending-merge",
       "decision": "port",
-      "summary": "feat(vite): add root option to override .nuxt-ui directory location (#6595) — add root?: string to Bitrix24UIOptions (unplugin.ts) and use it in templates.ts: writeTemplates(path.resolve(options.root || config.root || '.')). Lets electron-vite-style setups point the generated .b24ui-nuxt theme-templates dir at the project root. Builds on #198 (238e2917). +docs root section in vue installation (adapted: .b24ui-nuxt/bitrix24UIPluginVite, dropped upstream 4.9+ badge). No snapshot churn"
+      "summary": "fix(module): remove inline script in SPA mode for strict CSP (#6577) — colors.ts: in SPA mode the temporary <style data-bitrix24-ui-colors> was removed via an inline <script> (CSP violation); replace with injectHead().hooks.hookOnce('dom:rendered', removeTemporaryColorsStyle) where the fn does querySelector('[data-bitrix24-ui-colors]')?.remove(). +import injectHead from #imports. vue/stubs/base.ts: export injectHead from @unhead/vue too. Direct 1:1 (same plugin/SPA path, only the data-attribute name differs). No snapshot churn"
     }
   }
 }

--- a/src/runtime/plugins/colors.ts
+++ b/src/runtime/plugins/colors.ts
@@ -2,7 +2,7 @@ import { computed } from 'vue'
 // import colors from 'tailwindcss/colors'
 import type { UseHeadInput } from '@unhead/vue/types'
 // import { defineNuxtPlugin, useAppConfig, useNuxtApp, useHead } from '#imports'
-import { defineNuxtPlugin, useNuxtApp, useHead } from '#imports'
+import { defineNuxtPlugin, injectHead, useNuxtApp, useHead } from '#imports'
 
 /**
  * @see src/templates.ts -> getTemplates
@@ -25,6 +25,10 @@ function generateColor(key: string, shade: number) {
   return `--ui-${key}: var(--ui-color-${key}-${shade});`
 }
 */
+
+function removeTemporaryColorsStyle() {
+  document.querySelector('[data-bitrix24-ui-colors]')?.remove()
+}
 
 export default defineNuxtPlugin(() => {
   // const appConfig = useAppConfig()
@@ -64,9 +68,7 @@ export default defineNuxtPlugin(() => {
       style.setAttribute('data-bitrix24-ui-colors', '')
       document.head.appendChild(style)
 
-      headData.script = [{
-        innerHTML: 'document.head.removeChild(document.querySelector(\'[data-bitrix24-ui-colors]\'))'
-      }]
+      injectHead().hooks.hookOnce('dom:rendered', removeTemporaryColorsStyle)
     }
   }
 

--- a/src/runtime/vue/stubs/base.ts
+++ b/src/runtime/vue/stubs/base.ts
@@ -3,7 +3,7 @@ import type { Ref, Plugin as VuePlugin } from 'vue'
 import { createHooks } from 'hookable'
 import type { NuxtApp } from '#app'
 
-export { useHead } from '@unhead/vue'
+export { injectHead, useHead } from '@unhead/vue'
 
 export { useAppConfig } from '../composables/useAppConfig'
 export { defineShortcuts } from '../../composables/defineShortcuts'


### PR DESCRIPTION
Port of upstream nuxt/ui [`7225e9f4`](https://github.com/nuxt/ui/commit/7225e9f451e405d6b07de8ee44b93a11a50b55a8) — `fix(module): remove inline script in SPA mode for strict CSP (#6577)`.

## Problem
In SPA mode the colors plugin injected a temporary `<style data-bitrix24-ui-colors>` and removed it via an **inline `<script>`** (`headData.script`), which violates a strict CSP (`script-src` without `unsafe-inline`).

## Change
- **`src/runtime/plugins/colors.ts`**: import `injectHead` from `#imports`; add `removeTemporaryColorsStyle()` (`document.querySelector('[data-bitrix24-ui-colors]')?.remove()`); replace the inline `headData.script` with `injectHead().hooks.hookOnce('dom:rendered', removeTemporaryColorsStyle)`.
- **`src/runtime/vue/stubs/base.ts`**: also re-export `injectHead` from `@unhead/vue` (for the Vue, non-Nuxt build).

Direct 1:1 — b24ui has the same plugin and SPA path; only the data-attribute name differs (`data-bitrix24-ui-colors`). b24ui's color *generation* is otherwise commented out (air-design tokens), but the SPA temporary-style path is active and identical, so the CSP fix applies.

## Verification (pnpm 11.6.0, gate ON)
dev:prepare · lint · typecheck · test (**5101 passed**, 6 skipped) · module build — all green. Runtime SPA path; no snapshot churn.

Ledger: records the merge sha for the previous port (#205, `cccb3d5a`) and advances the sync cursor to `7225e9f4`.

https://claude.ai/code/session_01Qz7EXMncvEGiCj4WbmYgJo

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qz7EXMncvEGiCj4WbmYgJo)_