### PR TITLE
docs(tabs): add bottom tab bar example

### DIFF
--- a/.sync/icon-map.json
+++ b/.sync/icon-map.json
@@ -1,10 +1,14 @@
 {
   "$schema-note": "Map upstream iconify names (nuxt/ui defaults) to b24-icons components. Flat, alphabetical. Seed values verified against current src/runtime/components usage; extend during porting (see PORTING.md §4).",
+  "i-lucide-activity": "@bitrix24/b24icons-vue/main/ActivityIcon",
   "i-lucide-check": "@bitrix24/b24icons-vue/main/CheckIcon",
   "i-lucide-chevron-down": "@bitrix24/b24icons-vue/outline/ChevronDownSIcon",
+  "i-lucide-house": "@bitrix24/b24icons-vue/main/HomePageIcon",
   "i-lucide-loader-circle": "@bitrix24/b24icons-vue/animated/LoaderWaitIcon",
   "i-lucide-menu": "@bitrix24/b24icons-vue/outline/HamburgerMenuIcon",
   "i-lucide-minus": "@bitrix24/b24icons-vue/actions/Minus20Icon",
+  "i-lucide-settings": "@bitrix24/b24icons-vue/main/SettingsIcon",
   "i-lucide-triangle-alert": "@bitrix24/b24icons-vue/main/WarningIcon",
+  "i-lucide-user": "@bitrix24/b24icons-vue/common-b24/UserIcon",
   "i-lucide-x": "@bitrix24/b24icons-vue/actions/Cross20Icon"
 }

--- a/.sync/log/92b7e13fede96f0c34591579333f4caaf1d2ee55.md
+++ b/.sync/log/92b7e13fede96f0c34591579333f4caaf1d2ee55.md
@@ -1,0 +1,30 @@
+# Port: docs(tabs): add bottom tab bar example (#6585)
+
+**Upstream:** `92b7e13fede96f0c34591579333f4caaf1d2ee55` (nuxt/ui)
+**Decision:** port (docs-only)
+
+## Upstream change
+New docs example `TabsBottomTabBarExample.vue` (a mobile-style bottom tab bar
+via the `ui` prop: `list: justify-around w-full`, `trigger: grow flex-col …`,
+`label: text-[10px]/3`, with `:content="false"` and lucide icons) + a "With
+bottom tab bar" section in `docs/.../tabs.md`.
+
+## b24ui adaptation
+Docs-only, rewritten to b24ui idiom:
+- `docs/app/components/content/examples/tabs/TabsBottomTabBarExample.vue`:
+  `UTabs` → `B24Tabs`, `ui` prop → `b24ui`, `TabsItem` from
+  `@bitrix24/b24ui-nuxt`, iconify strings → b24-icons components:
+  - `i-lucide-house` → `main/HomePageIcon`
+  - `i-lucide-activity` → `main/ActivityIcon`
+  - `i-lucide-settings` → `main/SettingsIcon`
+  - `i-lucide-user` → `common-b24/UserIcon`
+  (added all four to `.sync/icon-map.json`). Same layout classes
+  (`list`/`trigger`/`label`) and `:content="false"`.
+- `docs/content/docs/2.components/tabs.md`: added the "### With bottom tab bar"
+  section after "With content slot", using b24ui's inline example syntax
+  `:component-example{name="tabs-bottom-tab-bar-example" collapse}` and `b24ui`
+  prop wording.
+
+## Verification (pnpm 11.6.0, gate ON)
+dev:prepare · lint · typecheck (incl. docs) · module build — green. Docs-only;
+no `src` change, no snapshot churn.

--- a/.sync/nuxt-ui.json
+++ b/.sync/nuxt-ui.json
@@ -2,7 +2,7 @@
   "upstream": "nuxt/ui",
   "branch": "v4",
   "sync_enabled": false,
-  "cursor": "7225e9f451e405d6b07de8ee44b93a11a50b55a8",
+  "cursor": "92b7e13fede96f0c34591579333f4caaf1d2ee55",
   "_cursor_note": "cursor = last upstream commit ported into b24ui (oldest-first, manual cadence). sync_enabled stays false until Phase 2 (porter workflow #67 + CLAUDE_CODE_OAUTH_TOKEN) is wired and trusted. `processed` is maintained per port from now on (backfilled #68-#72 on 2026-06-09).",
   "stats": {
     "queue_depth": 0,
@@ -635,10 +635,16 @@
       "summary": "feat(vite): add root option to override .nuxt-ui directory location (#6595) — add root?: string to Bitrix24UIOptions (unplugin.ts) and use it in templates.ts: writeTemplates(path.resolve(options.root || config.root || '.')). Lets electron-vite-style setups point the generated .b24ui-nuxt theme-templates dir at the project root. Builds on #198 (238e2917). +docs root section in vue installation (adapted: .b24ui-nuxt/bitrix24UIPluginVite, dropped upstream 4.9+ badge). No snapshot churn"
     },
     "7225e9f451e405d6b07de8ee44b93a11a50b55a8": {
+      "pr": 206,
+      "b24ui_sha": "c7cf2698",
+      "decision": "port",
+      "summary": "fix(module): remove inline script in SPA mode for strict CSP (#6577) — colors.ts: in SPA mode the temporary <style data-bitrix24-ui-colors> was removed via an inline <script> (CSP violation); replace with injectHead().hooks.hookOnce('dom:rendered', removeTemporaryColorsStyle) where the fn does querySelector('[data-bitrix24-ui-colors]')?.remove(). +import injectHead from #imports. vue/stubs/base.ts: export injectHead from @unhead/vue too. Direct 1:1 (same plugin/SPA path, only the data-attribute name differs). No snapshot churn"
+    },
+    "92b7e13fede96f0c34591579333f4caaf1d2ee55": {
       "pr": null,
       "b24ui_sha": "pending-merge",
       "decision": "port",
-      "summary": "fix(module): remove inline script in SPA mode for strict CSP (#6577) — colors.ts: in SPA mode the temporary <style data-bitrix24-ui-colors> was removed via an inline <script> (CSP violation); replace with injectHead().hooks.hookOnce('dom:rendered', removeTemporaryColorsStyle) where the fn does querySelector('[data-bitrix24-ui-colors]')?.remove(). +import injectHead from #imports. vue/stubs/base.ts: export injectHead from @unhead/vue too. Direct 1:1 (same plugin/SPA path, only the data-attribute name differs). No snapshot churn"
+      "summary": "docs(tabs): add bottom tab bar example (#6585) — docs-only. New example TabsBottomTabBarExample.vue (B24Tabs, b24ui prop, :content=false, list/trigger/label classes for a mobile bottom tab bar) with b24-icons (i-lucide-house->main/HomePageIcon, activity->main/ActivityIcon, settings->main/SettingsIcon, user->common-b24/UserIcon; added to icon-map.json). +tabs.md 'With bottom tab bar' section (inline :component-example syntax). UTabs->B24Tabs, ui->b24ui. No src change, no snapshot churn"
     }
   }
 }

--- a/docs/app/components/content/examples/tabs/TabsBottomTabBarExample.vue
+++ b/docs/app/components/content/examples/tabs/TabsBottomTabBarExample.vue
@@ -1,0 +1,39 @@
+<script setup lang="ts">
+import type { TabsItem } from '@bitrix24/b24ui-nuxt'
+import HomePageIcon from '@bitrix24/b24icons-vue/main/HomePageIcon'
+import ActivityIcon from '@bitrix24/b24icons-vue/main/ActivityIcon'
+import SettingsIcon from '@bitrix24/b24icons-vue/main/SettingsIcon'
+import UserIcon from '@bitrix24/b24icons-vue/common-b24/UserIcon'
+
+const items: TabsItem[] = [
+  {
+    label: 'Home',
+    icon: HomePageIcon
+  },
+  {
+    label: 'Activity',
+    icon: ActivityIcon
+  },
+  {
+    label: 'Settings',
+    icon: SettingsIcon
+  },
+  {
+    label: 'Profile',
+    icon: UserIcon
+  }
+]
+</script>
+
+<template>
+  <B24Tabs
+    :items="items"
+    :content="false"
+    :b24ui="{
+      list: 'justify-around w-full',
+      trigger: 'grow flex-col gap-1 py-1',
+      label: 'text-[10px]/3'
+    }"
+    class="w-full"
+  />
+</template>

--- a/docs/content/docs/2.components/tabs.md
+++ b/docs/content/docs/2.components/tabs.md
@@ -197,6 +197,12 @@ Use the `#content` slot to customize the content of each item.
 
 :component-example{name="tabs-content-slot-example" collapse}
 
+### With bottom tab bar
+
+Use the `b24ui` prop to transform the Tabs into a mobile-style bottom tab bar with icons and small labels, similar to YouTube or Instagram.
+
+:component-example{name="tabs-bottom-tab-bar-example" collapse}
+
 ### With custom slot
 
 Use the `slot` property to customize a specific item.


### PR DESCRIPTION
Port of upstream nuxt/ui [`92b7e13f`](https://github.com/nuxt/ui/commit/92b7e13fede96f0c34591579333f4caaf1d2ee55) — `docs(tabs): add bottom tab bar example (#6585)`. **Docs-only.**

## Change
A mobile-style bottom tab bar example (à la YouTube/Instagram) via the `b24ui` prop, plus a "With bottom tab bar" section in the Tabs docs.

- **`docs/app/components/content/examples/tabs/TabsBottomTabBarExample.vue`** (new): `B24Tabs` with `:content="false"` and `b24ui: { list: 'justify-around w-full', trigger: 'grow flex-col gap-1 py-1', label: 'text-[10px]/3' }`. `TabsItem` from `@bitrix24/b24ui-nuxt`; iconify strings → b24-icons components:
  - `i-lucide-house` → `main/HomePageIcon`
  - `i-lucide-activity` → `main/ActivityIcon`
  - `i-lucide-settings` → `main/SettingsIcon`
  - `i-lucide-user` → `common-b24/UserIcon`
- **`docs/content/docs/2.components/tabs.md`**: "### With bottom tab bar" section after "With content slot", using b24ui's inline `:component-example{name="tabs-bottom-tab-bar-example" collapse}` syntax.
- **`.sync/icon-map.json`**: added the four new icon mappings.

`UTabs → B24Tabs`, `ui → b24ui`.

## Verification (pnpm 11.6.0, gate ON)
dev:prepare · lint · typecheck (incl. docs) · module build — all green. Docs-only; no `src` change, no snapshot churn.

Ledger: records the merge sha for the previous port (#206, `7225e9f4`) and advances the sync cursor to `92b7e13f`.

https://claude.ai/code/session_01Qz7EXMncvEGiCj4WbmYgJo

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qz7EXMncvEGiCj4WbmYgJo)_