### PR TITLE
docs: SEO metadata + docs-tail bookkeeping

### DIFF
--- a/.sync/log/81745fe1c89504f56443486a88ec727b7473a4bc.md
+++ b/.sync/log/81745fe1c89504f56443486a88ec727b7473a4bc.md
@@ -1,0 +1,29 @@
+# Port: docs: improve SEO metadata
+
+**Upstream:** `81745fe1c89504f56443486a88ec727b7473a4bc` (nuxt/ui)
+**Decision:** port (docs-only, partial)
+**Combined into:** the docs-tail PR (with `e327ec45` + `ed4712c6` + `e4989f7c`).
+
+## Upstream change
+- `docs/app/pages/docs/[...slug].vue`: refactor the framework title suffix.
+- `docs/server/routes/sitemap.xml.get.ts`: drop `<lastmod>` (and the build-date
+  `today` const) — a serverless function has no truthful per-page date, and a
+  uniform build date is a signal search engines ignore.
+- `docs/server/routes/raw/[...slug].md.get.ts` + `raw/index.md.get.ts`: drop the
+  `last_updated` front-matter line (same rationale).
+- `docs/content/docs/2.components/table.md`: add an SEO description sentence.
+
+## b24ui adaptation
+Ported the applicable parts 1:1; the `[...slug].vue` change is **N/A**
+(b24ui has no `docs/app/pages/docs/[...slug].vue`).
+- `sitemap.xml.get.ts`: removed the `today` const and `<lastmod>${today}</lastmod>`
+  from the `<url>` template, added the explanatory comment (kept b24ui's
+  `baseUrl`/trailing-slash `loc`).
+- `raw/[...slug].md.get.ts` + `raw/index.md.get.ts`: removed the `last_updated`
+  front-matter line.
+- `table.md`: added the same SEO sentence after the TanStack-Table intro
+  paragraph (before the first `::component-example`).
+
+## Verification (pnpm 11.6.0, gate ON)
+dev:prepare · lint · typecheck · module build — green. Docs-only; no `src`
+change, no snapshot churn.

--- a/.sync/log/e327ec459bc1d22655a23bf0f2a25061cac059e8.md
+++ b/.sync/log/e327ec459bc1d22655a23bf0f2a25061cac059e8.md
@@ -1,0 +1,21 @@
+# Port: docs(content): update badges
+
+**Upstream:** `e327ec459bc1d22655a23bf0f2a25061cac059e8` (nuxt/ui)
+**Decision:** no-op
+**Combined into:** the docs-tail PR (with `81745fe1` + `ed4712c6` + `e4989f7c`).
+
+## Upstream change
+Flips version badges across several docs pages from `:badge{label="Soon"}` to
+`:badge{label="4.9+"}` (theme/css-variables, calendar, pin-input, scroll-area,
+use-tour) and `navigation.badge: Soon` → `New`, marking features shipped in
+nuxt/ui's v4.9 release.
+
+## b24ui decision — no-op
+These are **nuxt/ui version badges** tied to the upstream `4.9` release.
+b24ui has its own versioning (`2.x`) and does not carry `4.9+` release labels.
+The specific `Soon` → `4.9+` lines the commit edits don't exist in b24ui's
+corresponding pages (b24ui's own `:badge{label="Soon"}` markers live on
+different sections — radio-group, content-search, checkbox-group — and reflect
+b24ui's own roadmap, not nuxt/ui's). Nothing to port.
+
+No file change — bookkeeping only.

--- a/.sync/log/e4989f7cc15bf7c8d9338b24f14aaeb08ef328a6.md
+++ b/.sync/log/e4989f7cc15bf7c8d9338b24f14aaeb08ef328a6.md
@@ -1,0 +1,15 @@
+# Port: docs(community): add json-render item
+
+**Upstream:** `e4989f7cc15bf7c8d9338b24f14aaeb08ef328a6` (nuxt/ui)
+**Decision:** no-op
+**Combined into:** the docs-tail PR (with `e327ec45` + `81745fe1` + `ed4712c6`).
+
+## Upstream change
+Adds a `json-render` entry to `docs/content/community.yml` (the nuxt/ui
+community showcase list).
+
+## b24ui decision — no-op
+b24ui has no `docs/content/community.yml` — it doesn't maintain a nuxt/ui-style
+community showcase. The added entry is nuxt/ui-specific. N/A.
+
+No file change — bookkeeping only.

--- a/.sync/log/ed4712c62ca347ab6fc9287648ec3a01c8a88dd0.md
+++ b/.sync/log/ed4712c62ca347ab6fc9287648ec3a01c8a88dd0.md
@@ -1,0 +1,15 @@
+# Port: docs: rename framework for typecheck
+
+**Upstream:** `ed4712c62ca347ab6fc9287648ec3a01c8a88dd0` (nuxt/ui)
+**Decision:** no-op
+**Combined into:** the docs-tail PR (with `e327ec45` + `81745fe1` + `e4989f7c`).
+
+## Upstream change
+Renames the local `framework` variable to `frameworkSuffix` in
+`docs/app/pages/docs/[...slug].vue` (avoids a typecheck shadowing issue).
+
+## b24ui decision — no-op
+b24ui has no `docs/app/pages/docs/[...slug].vue` (its docs app routes the
+component pages differently), so there is nothing to rename. N/A.
+
+No file change — bookkeeping only.

--- a/.sync/nuxt-ui.json
+++ b/.sync/nuxt-ui.json
@@ -2,7 +2,7 @@
   "upstream": "nuxt/ui",
   "branch": "v4",
   "sync_enabled": false,
-  "cursor": "2166ff7772130269248d526bb11f2d0897bb7fe1",
+  "cursor": "e4989f7cc15bf7c8d9338b24f14aaeb08ef328a6",
   "_cursor_note": "cursor = last upstream commit ported into b24ui (oldest-first, manual cadence). sync_enabled stays false until Phase 2 (porter workflow #67 + CLAUDE_CODE_OAUTH_TOKEN) is wired and trusted. `processed` is maintained per port from now on (backfilled #68-#72 on 2026-06-09).",
   "stats": {
     "queue_depth": 0,
@@ -647,10 +647,34 @@
       "summary": "docs(tabs): add bottom tab bar example (#6585) — docs-only. New example TabsBottomTabBarExample.vue (B24Tabs, b24ui prop, :content=false, list/trigger/label classes for a mobile bottom tab bar) with b24-icons (i-lucide-house->main/HomePageIcon, activity->main/ActivityIcon, settings->main/SettingsIcon, user->common-b24/UserIcon; added to icon-map.json). +tabs.md 'With bottom tab bar' section (inline :component-example syntax). UTabs->B24Tabs, ui->b24ui. No src change, no snapshot churn"
     },
     "2166ff7772130269248d526bb11f2d0897bb7fe1": {
+      "pr": 208,
+      "b24ui_sha": "f571f816",
+      "decision": "no-op",
+      "summary": "chore(release): v4.9.0 — NO-OP: upstream release bump (package.json version 4.8.2->4.9.0 + nuxt/ui CHANGELOG.md). b24ui has its own versioning/release cycle (currently 2.8.0, release-please style) independent of nuxt/ui 4.x and its own CHANGELOG, so nothing to port. Bookkeeping only"
+    },
+    "e327ec459bc1d22655a23bf0f2a25061cac059e8": {
       "pr": null,
       "b24ui_sha": "pending-merge",
       "decision": "no-op",
-      "summary": "chore(release): v4.9.0 — NO-OP: upstream release bump (package.json version 4.8.2->4.9.0 + nuxt/ui CHANGELOG.md). b24ui has its own versioning/release cycle (currently 2.8.0, release-please style) independent of nuxt/ui 4.x and its own CHANGELOG, so nothing to port. Bookkeeping only"
+      "summary": "docs(content): update badges — NO-OP: flips nuxt/ui version badges Soon->4.9+ (theme/css-variables, calendar, pin-input, scroll-area, use-tour) + navigation.badge Soon->New, tied to nuxt/ui's v4.9 release. b24ui has its own versioning (2.x), doesn't carry 4.9+ labels, and the edited lines don't exist in b24ui's corresponding pages. Combined into the docs-tail PR"
+    },
+    "81745fe1c89504f56443486a88ec727b7473a4bc": {
+      "pr": null,
+      "b24ui_sha": "pending-merge",
+      "decision": "port",
+      "summary": "docs: improve SEO metadata — docs-only, partial. sitemap.xml.get.ts: drop <lastmod>/today const (+comment). raw/[...slug].md.get.ts + raw/index.md.get.ts: drop last_updated front-matter. table.md: +SEO description sentence. The docs/app/pages/docs/[...slug].vue framework-suffix change is N/A (file absent in b24ui). Combined into the docs-tail PR"
+    },
+    "ed4712c62ca347ab6fc9287648ec3a01c8a88dd0": {
+      "pr": null,
+      "b24ui_sha": "pending-merge",
+      "decision": "no-op",
+      "summary": "docs: rename framework for typecheck — NO-OP: renames a local var in docs/app/pages/docs/[...slug].vue, which b24ui doesn't have. Combined into the docs-tail PR"
+    },
+    "e4989f7cc15bf7c8d9338b24f14aaeb08ef328a6": {
+      "pr": null,
+      "b24ui_sha": "pending-merge",
+      "decision": "no-op",
+      "summary": "docs(community): add json-render item — NO-OP: adds an entry to docs/content/community.yml, which b24ui doesn't maintain. Combined into the docs-tail PR"
     }
   }
 }

--- a/docs/content/docs/2.components/table.md
+++ b/docs/content/docs/2.components/table.md
@@ -23,6 +23,8 @@ links:
 
 The Table component is built on top of [TanStack Table](https://tanstack.com/table/latest) and is powered by the [useVueTable](https://tanstack.com/table/latest/docs/framework/vue/vue-table#usevuetable) composable to provide a flexible and fully type-safe API.
 
+It renders your data as rows and columns and supports sorting, filtering, pagination, row selection, expansion, grouping, pinning and virtualization, so you can build everything from a simple data table to a fully featured data grid.
+
 ::component-example
 ---
 source: false

--- a/docs/server/routes/raw/[...slug].md.get.ts
+++ b/docs/server/routes/raw/[...slug].md.get.ts
@@ -51,7 +51,6 @@ export default defineEventHandler(async (event) => {
     `title: ${JSON.stringify(page.title || '')}`,
     `description: ${JSON.stringify(page.description || '')}`,
     `canonical_url: ${JSON.stringify(canonicalUrl)}`,
-    `last_updated: ${JSON.stringify(new Date().toISOString().split('T')[0])}`,
     '---',
     ''
   ].join('\n')

--- a/docs/server/routes/raw/index.md.get.ts
+++ b/docs/server/routes/raw/index.md.get.ts
@@ -17,7 +17,6 @@ export default defineCachedEventHandler(async (event) => {
     `title: ${JSON.stringify(title)}`,
     `description: ${JSON.stringify(description)}`,
     `canonical_url: ${JSON.stringify(DOMAIN)}`,
-    `last_updated: ${JSON.stringify(new Date().toISOString().split('T')[0])}`,
     '---',
     '\n'
   ].join('\n')

--- a/docs/server/routes/sitemap.xml.get.ts
+++ b/docs/server/routes/sitemap.xml.get.ts
@@ -17,9 +17,11 @@ export default defineEventHandler(async (event) => {
     .order('path', 'ASC')
     .all()
 
-  const today = new Date().toISOString().split('T')[0]
+  // No `<lastmod>`: this route runs as a serverless function (no git, no source files) so a
+  // truthful per-page date is unavailable, and a uniform build date is a signal search engines
+  // learn to ignore. Omitting it lets them rely on their own crawl history instead.
   const urls = pages.map(page =>
-    `  <url>\n    <loc>${xmlEscape(`${baseUrl}${page.path}/`)}</loc>\n    <lastmod>${today}</lastmod>\n  </url>`
+    `  <url>\n    <loc>${xmlEscape(`${baseUrl}${page.path}/`)}</loc>\n  </url>`
   ).join('\n')
 
   const xml = `<?xml version="1.0" encoding="UTF-8"?>


### PR DESCRIPTION
Combined **docs-tail** port of four contiguous upstream `chore`/`docs` commits into one PR (as requested — fewer PRs):

| upstream | title | decision |
|---|---|---|
| [`81745fe1`](https://github.com/nuxt/ui/commit/81745fe1c89504f56443486a88ec727b7473a4bc) | docs: improve SEO metadata | **port** (docs-only) |
| [`e327ec45`](https://github.com/nuxt/ui/commit/e327ec459bc1d22655a23bf0f2a25061cac059e8) | docs(content): update badges | no-op |
| [`ed4712c6`](https://github.com/nuxt/ui/commit/ed4712c62ca347ab6fc9287648ec3a01c8a88dd0) | docs: rename framework for typecheck | no-op |
| [`e4989f7c`](https://github.com/nuxt/ui/commit/e4989f7cc15bf7c8d9338b24f14aaeb08ef328a6) | docs(community): add json-render item | no-op |

## `81745fe1` — ported (applicable parts)
- **`docs/server/routes/sitemap.xml.get.ts`**: drop `<lastmod>` and the build-date `today` const (a serverless route has no truthful per-page date; a uniform build date is a signal search engines ignore), with the explanatory comment.
- **`docs/server/routes/raw/[...slug].md.get.ts`** + **`raw/index.md.get.ts`**: drop the `last_updated` front-matter line.
- **`docs/content/docs/2.components/table.md`**: add the SEO description sentence.
- The `docs/app/pages/docs/[...slug].vue` framework-suffix refactor is **N/A** — b24ui has no such file.

## No-ops
- `e327ec45` flips nuxt/ui `Soon → 4.9+` **version badges** — b24ui uses its own versioning (`2.x`) and the edited lines don't exist in its pages.
- `ed4712c6` renames a var in the absent `[...slug].vue`.
- `e4989f7c` adds to the absent `docs/content/community.yml`.

## Verification (pnpm 11.6.0, gate ON)
dev:prepare · lint · typecheck · module build — all green. Docs-only; no `src` change, no snapshot churn.

Ledger: records the merge sha for the previous port (#208, `2166ff77`), advances the sync cursor to `e4989f7c`, and adds four `processed` entries.

https://claude.ai/code/session_01Qz7EXMncvEGiCj4WbmYgJo

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qz7EXMncvEGiCj4WbmYgJo)_