### PR TITLE
chore(sync): no-op upstream LocaleSelect emoji mapping fix

### DIFF
--- a/.sync/log/fab73ab2ecceccd6a2d4e55eabf42efe9f7c9e23.md
+++ b/.sync/log/fab73ab2ecceccd6a2d4e55eabf42efe9f7c9e23.md
@@ -1,0 +1,25 @@
+# Port: fix(LocaleSelect): add missing keys in emoji mapping (#6629)
+
+**Upstream:** `fab73ab2ecceccd6a2d4e55eabf42efe9f7c9e23` (nuxt/ui)
+**Decision:** no-op
+
+## Upstream change
+`src/runtime/components/locale/LocaleSelect.vue` — adds four entries to
+nuxt/ui's `getEmojiFlag` `languageToCountry` map: `be` → `by` (Belarusian),
+`eu` → `es` (Basque), `is` → `is` (Icelandic), `lo` → `la` (Lao), so those
+upstream locales render a flag.
+
+## b24ui decision — no-op
+Two independent reasons, both pointing to no-op:
+
+1. **Different map.** b24ui's `getEmojiFlag` map is its **own curated set**
+   (`en, de, la, br, fr, it, pl, ru, ua, tr, sc, tc, ja, vn, id, ms, th, ar,
+   kk, hi`), not nuxt/ui's ISO `languageToCountry` table. The upstream
+   "missing keys" fix targets nuxt/ui's specific map, which b24ui does not
+   share — there is nothing structurally equivalent to patch.
+2. **Locale invariant (PORTING.md §2).** The added keys are for languages
+   (`be`, `eu`, `is`, `lo`) that are **not** in b24ui's locale set. b24ui
+   maintains its own curated locales and does not adopt new ones from upstream,
+   so these flag mappings are intentionally not added.
+
+No file change — bookkeeping only.

--- a/.sync/nuxt-ui.json
+++ b/.sync/nuxt-ui.json
@@ -2,7 +2,7 @@
   "upstream": "nuxt/ui",
   "branch": "v4",
   "sync_enabled": false,
-  "cursor": "82cfef23cf27a1b41b2ec34e935201c7df52fce7",
+  "cursor": "fab73ab2ecceccd6a2d4e55eabf42efe9f7c9e23",
   "_cursor_note": "cursor = last upstream commit ported into b24ui (oldest-first, manual cadence). sync_enabled stays false until Phase 2 (porter workflow #67 + CLAUDE_CODE_OAUTH_TOKEN) is wired and trusted. `processed` is maintained per port from now on (backfilled #68-#72 on 2026-06-09).",
   "stats": {
     "queue_depth": 0,
@@ -695,10 +695,16 @@
       "summary": "chore(github): remove issue-labeler workflow and v4 version labeling — NO-OP: deletes .github/advanced-issue-labeler.yml + .github/workflows/issue-labeler.yml, neither of which b24ui has. Combined into the github-tail PR. (= upstream/v4 HEAD: sync caught up)"
     },
     "82cfef23cf27a1b41b2ec34e935201c7df52fce7": {
-      "pr": null,
-      "b24ui_sha": "pending-merge",
+      "pr": 211,
+      "b24ui_sha": "618d215c",
       "decision": "port",
       "summary": "chore(deps): update all non-major dependencies (#6625) — bumped b24ui-pinned pkgs to batch target, mirrored across root/docs/playgrounds incl. fork-only demo (nuxt<->demo parity): root @tanstack/vue-virtual 3.13.29, ai 6.0.208, happy-dom 20.10.6, vitest 4.1.9; docs @ai-sdk/mcp 1.0.52, @ai-sdk/vue 3.0.208, @regle/core+rules 1.28.0, @takumi-rs/core 1.8.7, ai 6.0.208, better-sqlite3 12.11.1, joi 18.2.3; playgrounds nuxt+demo @ai-sdk/vue 3.0.208, ai 6.0.208; packageManager pnpm@11.8.0. Skipped (not in b24ui): @ai-sdk/anthropic, @ai-sdk/gateway, @iconify-json/*. Left peerDependencies.joi ^18.0.0 untouched (upstream bumped the docs dependency joi, not the peer). lockfile regen under gate, lockfileVersion 9.0 unchanged"
+    },
+    "fab73ab2ecceccd6a2d4e55eabf42efe9f7c9e23": {
+      "pr": null,
+      "b24ui_sha": "pending-merge",
+      "decision": "no-op",
+      "summary": "fix(LocaleSelect): add missing keys in emoji mapping (#6629) — NO-OP: upstream adds be/eu/is/lo entries to nuxt/ui's getEmojiFlag languageToCountry map. b24ui's getEmojiFlag map is its own curated set (en/de/la/br/fr/it/pl/ru/ua/tr/sc/tc/ja/vn/id/ms/th/ar/kk/hi), not nuxt/ui's ISO table, so there's nothing equivalent to patch; and the added langs (be/eu/is/lo) aren't in b24ui's locale set (PORTING.md §2 locale invariant — b24ui doesn't adopt new locales). Bookkeeping only"
     }
   }
 }


### PR DESCRIPTION
Records upstream nuxt/ui [`fab73ab2`](https://github.com/nuxt/ui/commit/fab73ab2ecceccd6a2d4e55eabf42efe9f7c9e23) — `fix(LocaleSelect): add missing keys in emoji mapping (#6629)` — as a **no-op**.

## Decision: no-op
Upstream adds `be → by`, `eu → es`, `is → is`, `lo → la` to nuxt/ui's `getEmojiFlag` `languageToCountry` map. Two reasons this is a no-op for b24ui:

1. **Different map.** b24ui's `getEmojiFlag` map is its **own curated set** (`en, de, la, br, fr, it, pl, ru, ua, tr, sc, tc, ja, vn, id, ms, th, ar, kk, hi`), not nuxt/ui's ISO `languageToCountry` table — there's nothing structurally equivalent to patch.
2. **Locale invariant ([`PORTING.md` §2](https://github.com/bitrix24/b24ui/blob/main/.sync/PORTING.md)).** The added languages (`be`, `eu`, `is`, `lo`) are not in b24ui's locale set, and b24ui does not adopt new locales from upstream.

## Changes
Bookkeeping only — `.sync/` ledger + log entry. Records the merge sha for the previous port (#211, `82cfef23`) and advances the sync cursor to `fab73ab2`.

🎯 `fab73ab2` is the current upstream/v4 HEAD — after this merges, the b24ui sync is fully caught up again.

https://claude.ai/code/session_01Qz7EXMncvEGiCj4WbmYgJo

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qz7EXMncvEGiCj4WbmYgJo)_