### PR TITLE
docs(Chat): refocus prompt when sidebar reopens

### DIFF
--- a/.sync/log/8498238b41e1513705ae5b674c6bea35ed910662.md
+++ b/.sync/log/8498238b41e1513705ae5b674c6bea35ed910662.md
@@ -1,0 +1,27 @@
+# Port: docs(Chat): refocus prompt when sidebar reopens
+
+**Upstream:** `8498238b41e1513705ae5b674c6bea35ed910662` (nuxt/ui)
+**Decision:** port (docs-only)
+
+## Upstream change
+`docs/app/components/chat/Chat.vue`: the sidebar keeps its content mounted when
+closed (offcanvas), so the prompt's `autofocus` fires only once. Add a
+`promptRef` template ref and `watch(open, …)` that refocuses
+`promptRef.value?.textareaRef?.focus()` on `nextTick` whenever the sidebar
+reopens; add `ref="promptRef"` to the chat prompt.
+
+## b24ui adaptation
+Direct 1:1 with `UChatPrompt` → `B24ChatPrompt`. b24ui's docs `Chat.vue` matches
+the pre-change shape:
+- `open` comes from `useChat()` (sidebar open state);
+- `B24ChatPrompt` exposes `textareaRef` (`toRef(() => textareaRef.value?.textareaRef)`)
+  via `defineExpose`, so `promptRef.value?.textareaRef?.focus()` resolves to the
+  inner `<textarea>`;
+- `useTemplateRef` / `watch` / `nextTick` are Nuxt auto-imports (already used in
+  the file).
+Added the `promptRef` + `watch(open)` block after `askQuestion` and
+`ref="promptRef"` on `<B24ChatPrompt>`.
+
+## Verification (pnpm 11.8.0, gate ON)
+dev:prepare · lint · typecheck · module build — green. Docs-only; no `src`
+change, no snapshot churn.

--- a/.sync/nuxt-ui.json
+++ b/.sync/nuxt-ui.json
@@ -2,7 +2,7 @@
   "upstream": "nuxt/ui",
   "branch": "v4",
   "sync_enabled": false,
-  "cursor": "1ea8a98f21f062a818b1da033a88a35343d24b8b",
+  "cursor": "8498238b41e1513705ae5b674c6bea35ed910662",
   "_cursor_note": "cursor = last upstream commit ported into b24ui (oldest-first, manual cadence). sync_enabled stays false until Phase 2 (porter workflow #67 + CLAUDE_CODE_OAUTH_TOKEN) is wired and trusted. `processed` is maintained per port from now on (backfilled #68-#72 on 2026-06-09).",
   "stats": {
     "queue_depth": 0,
@@ -707,10 +707,16 @@
       "summary": "fix(LocaleSelect): add missing keys in emoji mapping (#6629) — NO-OP: upstream adds be/eu/is/lo entries to nuxt/ui's getEmojiFlag languageToCountry map. b24ui's getEmojiFlag map is its own curated set (en/de/la/br/fr/it/pl/ru/ua/tr/sc/tc/ja/vn/id/ms/th/ar/kk/hi), not nuxt/ui's ISO table, so there's nothing equivalent to patch; and the added langs (be/eu/is/lo) aren't in b24ui's locale set (PORTING.md §2 locale invariant — b24ui doesn't adopt new locales). Bookkeeping only"
     },
     "1ea8a98f21f062a818b1da033a88a35343d24b8b": {
+      "pr": 214,
+      "b24ui_sha": "166cd710",
+      "decision": "port",
+      "summary": "chore(deps): update reka-ui (#6626) — reka-ui 2.9.10->2.10.0 (exact pin) + wire new reka props: Modal/Slideover forward unmountOnHide and DialogPortal :force-mount=(portalProps.disabled && unmountOnHide===false)||undefined; Popover forward enableTouch (hover); Select forward nullableValue; App omit teleportTo from ConfigProviderProps; useForwardProps cast emits for reka 2.10.0's tightened useEmitAsProps. +Modal/Slideover SSR specs, +docs Unmount (modal/slideover) & enableTouch tip (popover, adapted to b24ui MDC, dropped Soon badge). 746 snapshots regenerated (reka 2.10.0 adds dir=ltr + serialization churn; benign). lockfile regen under gate, lockfileVersion 9.0. Direct 1:1. PR #6626 siblings 54125f3f/4deb61b9 are empty marker commits (feature lives here)"
+    },
+    "8498238b41e1513705ae5b674c6bea35ed910662": {
       "pr": null,
       "b24ui_sha": "pending-merge",
       "decision": "port",
-      "summary": "chore(deps): update reka-ui (#6626) — reka-ui 2.9.10->2.10.0 (exact pin) + wire new reka props: Modal/Slideover forward unmountOnHide and DialogPortal :force-mount=(portalProps.disabled && unmountOnHide===false)||undefined; Popover forward enableTouch (hover); Select forward nullableValue; App omit teleportTo from ConfigProviderProps; useForwardProps cast emits for reka 2.10.0's tightened useEmitAsProps. +Modal/Slideover SSR specs, +docs Unmount (modal/slideover) & enableTouch tip (popover, adapted to b24ui MDC, dropped Soon badge). 746 snapshots regenerated (reka 2.10.0 adds dir=ltr + serialization churn; benign). lockfile regen under gate, lockfileVersion 9.0. Direct 1:1. PR #6626 siblings 54125f3f/4deb61b9 are empty marker commits (feature lives here)"
+      "summary": "docs(Chat): refocus prompt when sidebar reopens — docs/app/components/chat/Chat.vue: add promptRef + watch(open) that refocuses promptRef.value?.textareaRef?.focus() on nextTick when the offcanvas sidebar reopens (autofocus only fires once); +ref=promptRef on B24ChatPrompt. Direct 1:1 (UChatPrompt->B24ChatPrompt; open from useChat(); B24ChatPrompt exposes textareaRef). Docs-only, no snapshot churn"
     }
   }
 }

--- a/docs/app/components/chat/Chat.vue
+++ b/docs/app/components/chat/Chat.vue
@@ -170,6 +170,17 @@ function askQuestion(question: string) {
   onSubmit()
 }
 
+// The sidebar keeps its content mounted when closed (offcanvas), so the prompt's
+// `autofocus` only fires once. Refocus it each time the sidebar reopens.
+const promptRef = useTemplateRef('promptRef')
+watch(open, (value) => {
+  if (value) {
+    nextTick(() => {
+      promptRef.value?.textareaRef?.focus()
+    })
+  }
+})
+
 const suggestions = appConfig.bxAssistant?.faqQuestions as {
   category: string
   items: string[]
@@ -323,6 +334,7 @@ defineShortcuts({
 
     <template #footer>
       <B24ChatPrompt
+        ref="promptRef"
         v-model="input"
         :error="chat.error"
         placeholder="Ask me anything..."


### PR DESCRIPTION
Port of upstream nuxt/ui [`8498238b`](https://github.com/nuxt/ui/commit/8498238b41e1513705ae5b674c6bea35ed910662) — `docs(Chat): refocus prompt when sidebar reopens`. **Docs-only.**

## Change
`docs/app/components/chat/Chat.vue`: the offcanvas sidebar keeps its content mounted when closed, so the prompt's `autofocus` fires only once. Added a `promptRef` template ref and `watch(open, …)` that refocuses `promptRef.value?.textareaRef?.focus()` on `nextTick` whenever the sidebar reopens, plus `ref="promptRef"` on the chat prompt.

Direct 1:1 with `UChatPrompt` → `B24ChatPrompt`: `open` comes from `useChat()`, `B24ChatPrompt` exposes `textareaRef` via `defineExpose`, and `useTemplateRef`/`watch`/`nextTick` are Nuxt auto-imports.

## Verification (pnpm 11.8.0, gate ON)
dev:prepare · lint · typecheck · module build — all green. Docs-only; no `src` change, no snapshot churn.

Ledger: records the merge sha for the previous port (#214, `1ea8a98f`) and advances the sync cursor to `8498238b`.

https://claude.ai/code/session_01Qz7EXMncvEGiCj4WbmYgJo

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qz7EXMncvEGiCj4WbmYgJo)_