### PR TITLE
feat(ContentSearch/DashboardSearch): support unmountOnHide prop (#6523)

### DIFF
--- a/.sync/log/f03f98bafa972f593927bf01669369da8a30e212.md
+++ b/.sync/log/f03f98bafa972f593927bf01669369da8a30e212.md
@@ -1,0 +1,23 @@
+# Port: feat(ContentSearch/DashboardSearch): support `unmountOnHide` prop (#6523)
+
+**Upstream:** `f03f98bafa972f593927bf01669369da8a30e212` (nuxt/ui)
+**Decision:** port
+
+## Upstream change
+Surface the Modal `unmountOnHide` prop through the search wrappers:
+- `DashboardSearch.vue` / `ContentSearch.vue`: add `'unmountOnHide'` to the
+  `Pick<ModalProps, …>` interface and to the `modalProps` `reactivePick`.
+- docs `Search.vue`: pass `:unmount-on-hide="false"`.
+
+Builds on the Modal `unmountOnHide` support added in `1ea8a98f` (b24ui #214).
+
+## b24ui adaptation
+Direct 1:1 — b24ui's `DashboardSearch`/`ContentSearch` match the pre-change
+shape (same `Pick<ModalProps, …'portal'>` and `modalProps` `reactivePick`).
+- `DashboardSearch.vue`, `content/ContentSearch.vue`: added `'unmountOnHide'`
+  to both the `Pick<ModalProps>` and the `modalProps` `reactivePick`.
+- docs `app/components/search/Search.vue`: added `:unmount-on-hide="false"`.
+
+## Verification (pnpm 11.8.0, gate ON)
+dev:prepare · lint · typecheck · test · module build — green. Prop pass-through;
+no snapshot churn expected.

--- a/.sync/nuxt-ui.json
+++ b/.sync/nuxt-ui.json
@@ -2,7 +2,7 @@
   "upstream": "nuxt/ui",
   "branch": "v4",
   "sync_enabled": false,
-  "cursor": "54125f3f6ee98816b757e9c30c6bf3eaae458dc8",
+  "cursor": "f03f98bafa972f593927bf01669369da8a30e212",
   "_cursor_note": "cursor = last upstream commit ported into b24ui (oldest-first, manual cadence). sync_enabled stays false until Phase 2 (porter workflow #67 + CLAUDE_CODE_OAUTH_TOKEN) is wired and trusted. `processed` is maintained per port from now on (backfilled #68-#72 on 2026-06-09).",
   "stats": {
     "queue_depth": 0,
@@ -719,16 +719,22 @@
       "summary": "docs(Chat): refocus prompt when sidebar reopens — docs/app/components/chat/Chat.vue: add promptRef + watch(open) that refocuses promptRef.value?.textareaRef?.focus() on nextTick when the offcanvas sidebar reopens (autofocus only fires once); +ref=promptRef on B24ChatPrompt. Direct 1:1 (UChatPrompt->B24ChatPrompt; open from useChat(); B24ChatPrompt exposes textareaRef). Docs-only, no snapshot churn"
     },
     "4deb61b91cc22ec1bbda80faa35f13a267c8ad1d": {
-      "pr": null,
-      "b24ui_sha": "pending-merge",
+      "pr": 216,
+      "b24ui_sha": "77647f4b",
       "decision": "no-op",
       "summary": "feat(Modal/Slideover): support unmountOnHide prop (#6626) — NO-OP: empty marker commit (no diff in .patch). The actual unmountOnHide feature landed in 1ea8a98f (b24ui PR #214). Combined into the PR #6626 marker bookkeeping PR"
     },
     "54125f3f6ee98816b757e9c30c6bf3eaae458dc8": {
-      "pr": null,
-      "b24ui_sha": "pending-merge",
+      "pr": 216,
+      "b24ui_sha": "77647f4b",
       "decision": "no-op",
       "summary": "feat(Popover): support enableTouch prop (#6626) — NO-OP: empty marker commit (no diff in .patch). The actual enableTouch feature landed in 1ea8a98f (b24ui PR #214). Combined into the PR #6626 marker bookkeeping PR"
+    },
+    "f03f98bafa972f593927bf01669369da8a30e212": {
+      "pr": null,
+      "b24ui_sha": "pending-merge",
+      "decision": "port",
+      "summary": "feat(ContentSearch/DashboardSearch): support unmountOnHide prop (#6523) — DashboardSearch.vue + content/ContentSearch.vue: add unmountOnHide to Pick<ModalProps> and to the modalProps reactivePick; docs Search.vue +:unmount-on-hide=false. Direct 1:1 (b24ui matched pre-change). Builds on 1ea8a98f (#214) Modal unmountOnHide. No snapshot churn"
     }
   }
 }

--- a/docs/app/components/search/Search.vue
+++ b/docs/app/components/search/Search.vue
@@ -42,5 +42,6 @@ watchDebounced(searchTerm, (term) => {
     :color-mode="false"
     :fuse="fuse"
     :transition="false"
+    :unmount-on-hide="false"
   />
 </template>

--- a/src/runtime/components/DashboardSearch.vue
+++ b/src/runtime/components/DashboardSearch.vue
@@ -12,7 +12,7 @@ type DashboardSearch = ComponentConfig<typeof theme, AppConfig, 'dashboardSearch
 /**
  * @memo not use loadingIcon
  */
-export interface DashboardSearchProps<T extends CommandPaletteItem = CommandPaletteItem> extends Pick<ModalProps, 'title' | 'description' | 'overlay' | 'transition' | 'content' | 'dismissible' | 'fullscreen' | 'modal' | 'portal'>, Pick<CommandPaletteProps<CommandPaletteGroup<T>, T>, 'icon' | 'trailingIcon' | 'selectedIcon' | 'childrenIcon' | 'placeholder' | 'autofocus' | 'loading' | 'closeIcon' | 'back' | 'backIcon' | 'disabled' | 'highlightOnHover' | 'labelKey' | 'descriptionKey' | 'preserveGroupOrder' | 'virtualize' | 'groups'> {
+export interface DashboardSearchProps<T extends CommandPaletteItem = CommandPaletteItem> extends Pick<ModalProps, 'title' | 'description' | 'overlay' | 'transition' | 'content' | 'dismissible' | 'fullscreen' | 'modal' | 'portal' | 'unmountOnHide'>, Pick<CommandPaletteProps<CommandPaletteGroup<T>, T>, 'icon' | 'trailingIcon' | 'selectedIcon' | 'childrenIcon' | 'placeholder' | 'autofocus' | 'loading' | 'closeIcon' | 'back' | 'backIcon' | 'disabled' | 'highlightOnHover' | 'labelKey' | 'descriptionKey' | 'preserveGroupOrder' | 'virtualize' | 'groups'> {
   /**
    * @defaultValue 'md'
    */
@@ -110,7 +110,7 @@ const appConfig = useAppConfig() as DashboardSearch['AppConfig']
 
 /** @memo not use loadingIcon */
 const commandPaletteProps = useForwardProps(reactivePick(props, 'size', 'icon', 'trailingIcon', 'selectedIcon', 'childrenIcon', 'placeholder', 'autofocus', 'loading', 'close', 'closeIcon', 'back', 'backIcon', 'disabled', 'highlightOnHover', 'labelKey', 'descriptionKey', 'preserveGroupOrder', 'virtualize', 'searchDelay'))
-const modalProps = useForwardProps(reactivePick(props, 'overlay', 'transition', 'content', 'dismissible', 'fullscreen', 'modal', 'portal'))
+const modalProps = useForwardProps(reactivePick(props, 'overlay', 'transition', 'content', 'dismissible', 'fullscreen', 'modal', 'portal', 'unmountOnHide'))
 const inputProps = computed(() => {
   if (props.input === false) {
     return false

--- a/src/runtime/components/content/ContentSearch.vue
+++ b/src/runtime/components/content/ContentSearch.vue
@@ -58,7 +58,7 @@ export interface ContentSearchItem extends Omit<LinkProps, 'custom'>, CommandPal
 /**
  * @memo not use loadingIcon
  */
-export interface ContentSearchProps<T extends ContentSearchLink = ContentSearchLink> extends Pick<ModalProps, 'title' | 'description' | 'overlay' | 'transition' | 'content' | 'dismissible' | 'fullscreen' | 'modal' | 'portal'>, Pick<CommandPaletteProps<CommandPaletteGroup<ContentSearchItem>, ContentSearchItem>, 'icon' | 'trailingIcon' | 'selectedIcon' | 'childrenIcon' | 'placeholder' | 'autofocus' | 'loading' | 'closeIcon' | 'back' | 'backIcon' | 'disabled' | 'highlightOnHover' | 'labelKey' | 'descriptionKey' | 'preserveGroupOrder' | 'virtualize' | 'groups'> {
+export interface ContentSearchProps<T extends ContentSearchLink = ContentSearchLink> extends Pick<ModalProps, 'title' | 'description' | 'overlay' | 'transition' | 'content' | 'dismissible' | 'fullscreen' | 'modal' | 'portal' | 'unmountOnHide'>, Pick<CommandPaletteProps<CommandPaletteGroup<ContentSearchItem>, ContentSearchItem>, 'icon' | 'trailingIcon' | 'selectedIcon' | 'childrenIcon' | 'placeholder' | 'autofocus' | 'loading' | 'closeIcon' | 'back' | 'backIcon' | 'disabled' | 'highlightOnHover' | 'labelKey' | 'descriptionKey' | 'preserveGroupOrder' | 'virtualize' | 'groups'> {
   /**
    * @defaultValue 'md'
    */
@@ -169,7 +169,7 @@ const appConfig = useAppConfig() as ContentSearch['AppConfig']
 
 /** @memo not use loadingIcon */
 const commandPaletteProps = useForwardProps(reactivePick(props, 'size', 'icon', 'trailingIcon', 'selectedIcon', 'childrenIcon', 'placeholder', 'autofocus', 'loading', 'close', 'closeIcon', 'back', 'backIcon', 'disabled', 'highlightOnHover', 'labelKey', 'descriptionKey', 'preserveGroupOrder', 'virtualize', 'searchDelay'))
-const modalProps = useForwardProps(reactivePick(props, 'overlay', 'transition', 'content', 'dismissible', 'fullscreen', 'modal', 'portal'))
+const modalProps = useForwardProps(reactivePick(props, 'overlay', 'transition', 'content', 'dismissible', 'fullscreen', 'modal', 'portal', 'unmountOnHide'))
 const inputProps = computed(() => {
   if (props.input === false) {
     return false


### PR DESCRIPTION
Port of upstream nuxt/ui [`f03f98ba`](https://github.com/nuxt/ui/commit/f03f98bafa972f593927bf01669369da8a30e212) — `feat(ContentSearch/DashboardSearch): support unmountOnHide prop (#6523)`. Builds on the Modal `unmountOnHide` support added in #214.

## Change
- **`DashboardSearch.vue`** / **`content/ContentSearch.vue`**: add `'unmountOnHide'` to the `Pick<ModalProps, …>` interface and to the `modalProps` `reactivePick`.
- **docs `app/components/search/Search.vue`**: pass `:unmount-on-hide="false"`.

Direct 1:1 — b24ui matched the upstream pre-change shape.

## Verification (pnpm 11.8.0, gate ON)
dev:prepare · lint · typecheck · test (**5117 passed**, 6 skipped) · module build — all green. Prop pass-through; no snapshot churn.

Ledger: records the merge sha for the previous no-op markers (#216, `54125f3f`) and advances the sync cursor to `f03f98ba`.

https://claude.ai/code/session_01Qz7EXMncvEGiCj4WbmYgJo

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qz7EXMncvEGiCj4WbmYgJo)_