### PR TITLE
fix(components): forward $attrs to root element when `to` prop is absent (#6628)

### DIFF
--- a/.sync/log/d3b5f1d3f966e92f9194e1e114f5c84ea1e8cbaa.md
+++ b/.sync/log/d3b5f1d3f966e92f9194e1e114f5c84ea1e8cbaa.md
@@ -1,0 +1,36 @@
+# Port: fix(components): forward `$attrs` to root element when `to` prop is absent (#6628)
+
+**Upstream:** `d3b5f1d3f966e92f9194e1e114f5c84ea1e8cbaa` (nuxt/ui)
+**Decision:** port
+
+## Upstream change
+Components that conditionally render an inner `<ULink>` (when `to` is set) only
+spread `$attrs` onto that link. With `inheritAttrs: false`, when there is no
+`to` the attrs went nowhere. Fix: bind `v-bind="!props.to ? $attrs : {}"` on the
+**root** element so attrs land on the root when there's no link, and on the link
+when there is. Applied to Banner, BlogPost, ChangelogVersion, PageCard,
+PageFeature, User, prose/Callout, prose/Card; +spec for each (2 cases:
+attrs→root without `to`, attrs→link with `to`).
+
+## b24ui adaptation
+Ported the 6 components b24ui has; **BlogPost** and **ChangelogVersion** are
+**N/A** (absent in b24ui).
+- `Banner.vue`, `PageFeature.vue`, `User.vue`, `prose/Callout.vue`,
+  `prose/Card.vue`: added `v-bind="!props.to ? $attrs : {}"` on the root
+  (`Primitive` / root `<div data-slot="base">`).
+- `PageCard.vue`: b24ui's root `Primitive` already bound `v-bind="$attrs"`
+  unconditionally (a fork-only divergence that double-applied attrs to both root
+  and link when `to` was set); changed it to `v-bind="!props.to ? $attrs : {}"`
+  — same intent, fixes the duplication.
+- Tests: added the 2 attr-forwarding cases to `Banner`/`PageCard`/`PageFeature`/
+  `User` specs and created `prose/Callout.spec.ts` + `prose/Card.spec.ts`
+  (new), mirroring upstream.
+- All 6 components already had `inheritAttrs: false` + a `to` prop.
+
+Lint note: `PageFeature`/`User` root `Primitive` was single-line; the extra
+attribute tripped `vue/max-attributes-per-line`, so both were reflowed to
+multiline (matching upstream's formatting).
+
+## Verification (pnpm 11.8.0, gate ON)
+dev:prepare · lint · typecheck · test (**5139 passed**, 6 skipped — +new attr
+cases & 2 new prose specs) · module build — all green. No snapshot churn.

--- a/.sync/nuxt-ui.json
+++ b/.sync/nuxt-ui.json
@@ -2,7 +2,7 @@
   "upstream": "nuxt/ui",
   "branch": "v4",
   "sync_enabled": false,
-  "cursor": "f03f98bafa972f593927bf01669369da8a30e212",
+  "cursor": "d3b5f1d3f966e92f9194e1e114f5c84ea1e8cbaa",
   "_cursor_note": "cursor = last upstream commit ported into b24ui (oldest-first, manual cadence). sync_enabled stays false until Phase 2 (porter workflow #67 + CLAUDE_CODE_OAUTH_TOKEN) is wired and trusted. `processed` is maintained per port from now on (backfilled #68-#72 on 2026-06-09).",
   "stats": {
     "queue_depth": 0,
@@ -731,10 +731,16 @@
       "summary": "feat(Popover): support enableTouch prop (#6626) — NO-OP: empty marker commit (no diff in .patch). The actual enableTouch feature landed in 1ea8a98f (b24ui PR #214). Combined into the PR #6626 marker bookkeeping PR"
     },
     "f03f98bafa972f593927bf01669369da8a30e212": {
+      "pr": 217,
+      "b24ui_sha": "eb90f185",
+      "decision": "port",
+      "summary": "feat(ContentSearch/DashboardSearch): support unmountOnHide prop (#6523) — DashboardSearch.vue + content/ContentSearch.vue: add unmountOnHide to Pick<ModalProps> and to the modalProps reactivePick; docs Search.vue +:unmount-on-hide=false. Direct 1:1 (b24ui matched pre-change). Builds on 1ea8a98f (#214) Modal unmountOnHide. No snapshot churn"
+    },
+    "d3b5f1d3f966e92f9194e1e114f5c84ea1e8cbaa": {
       "pr": null,
       "b24ui_sha": "pending-merge",
       "decision": "port",
-      "summary": "feat(ContentSearch/DashboardSearch): support unmountOnHide prop (#6523) — DashboardSearch.vue + content/ContentSearch.vue: add unmountOnHide to Pick<ModalProps> and to the modalProps reactivePick; docs Search.vue +:unmount-on-hide=false. Direct 1:1 (b24ui matched pre-change). Builds on 1ea8a98f (#214) Modal unmountOnHide. No snapshot churn"
+      "summary": "fix(components): forward $attrs to root element when to prop is absent (#6628) — add v-bind=!props.to?$attrs:{} on root of Banner/PageFeature/User/prose Callout/prose Card; PageCard already bound v-bind=$attrs unconditionally (fork divergence, double-applied with to) -> made conditional. +attr-forwarding specs (Banner/PageCard/PageFeature/User) + new prose/Callout.spec + prose/Card.spec. BlogPost/ChangelogVersion N/A (absent in b24ui). PageFeature/User Primitive reflowed multiline for max-attributes-per-line. No snapshot churn"
     }
   }
 }

--- a/src/runtime/components/Banner.vue
+++ b/src/runtime/components/Banner.vue
@@ -152,6 +152,7 @@ function onClose() {
   <Primitive
     v-show="isVisible"
     :as="props.as"
+    v-bind="!props.to ? $attrs : {}"
     class="banner"
     :data-banner-id="id"
     data-slot="root"

--- a/src/runtime/components/PageCard.vue
+++ b/src/runtime/components/PageCard.vue
@@ -119,7 +119,7 @@ const ariaLabel = computed(() => {
     :data-orientation="props.orientation"
     data-slot="root"
     :class="b24ui.root({ class: [props.b24ui?.root, props.class] })"
-    v-bind="$attrs"
+    v-bind="!props.to ? $attrs : {}"
     @click="props.onClick"
   >
     <div data-slot="container" :class="b24ui.container({ class: props.b24ui?.container })">

--- a/src/runtime/components/PageFeature.vue
+++ b/src/runtime/components/PageFeature.vue
@@ -76,7 +76,14 @@ const ariaLabel = computed(() => {
 </script>
 
 <template>
-  <Primitive :as="props.as" :data-orientation="props.orientation" data-slot="root" :class="b24ui.root({ class: [props.b24ui?.root, props.class] })" @click="props.onClick">
+  <Primitive
+    :as="props.as"
+    v-bind="!props.to ? $attrs : {}"
+    :data-orientation="props.orientation"
+    data-slot="root"
+    :class="b24ui.root({ class: [props.b24ui?.root, props.class] })"
+    @click="props.onClick"
+  >
     <div v-if="props.icon || !!slots.leading" data-slot="leading" :class="b24ui.leading({ class: props.b24ui?.leading })">
       <slot name="leading" :b24ui="b24ui">
         <Component

--- a/src/runtime/components/User.vue
+++ b/src/runtime/components/User.vue
@@ -88,7 +88,14 @@ const chipSize = computed<ChipProps['size']>(() => {
 </script>
 
 <template>
-  <Primitive :as="props.as" :data-orientation="props.orientation" data-slot="root" :class="b24ui.root({ class: [props.b24ui?.root, props.class] })" @click="props.onClick">
+  <Primitive
+    :as="props.as"
+    v-bind="!props.to ? $attrs : {}"
+    :data-orientation="props.orientation"
+    data-slot="root"
+    :class="b24ui.root({ class: [props.b24ui?.root, props.class] })"
+    @click="props.onClick"
+  >
     <slot name="avatar" :b24ui="b24ui">
       <B24Chip v-if="props.chip && props.avatar && !['3xs'].includes(props.size || '')" inset v-bind="typeof props.chip === 'object' ? props.chip : {}" :size="chipSize">
         <B24Avatar :alt="props.name" v-bind="props.avatar" :size="props.size" data-slot="avatar" :class="b24ui.avatar({ class: props.b24ui?.avatar })" />

--- a/src/runtime/components/prose/Callout.vue
+++ b/src/runtime/components/prose/Callout.vue
@@ -57,7 +57,7 @@ const iconFromIconName = computed(() => resolveIcon(props.iconName))
 </script>
 
 <template>
-  <div data-slot="base" :class="b24ui.base({ class: props.class })">
+  <div v-bind="!props.to ? $attrs : {}" data-slot="base" :class="b24ui.base({ class: props.class })">
     <B24Link
       v-if="props.to"
       v-bind="{ to: props.to, target, ...$attrs }"

--- a/src/runtime/components/prose/Card.vue
+++ b/src/runtime/components/prose/Card.vue
@@ -80,7 +80,7 @@ const iconFromIconName = computed(() => {
 </script>
 
 <template>
-  <div data-slot="base" :class="b24ui.base({ class: [props.b24ui?.base, props.class] })">
+  <div v-bind="!props.to ? $attrs : {}" data-slot="base" :class="b24ui.base({ class: [props.b24ui?.base, props.class] })">
     <B24Link
       v-if="props.to"
       :aria-label="ariaLabel"

--- a/test/components/Banner.spec.ts
+++ b/test/components/Banner.spec.ts
@@ -43,4 +43,22 @@ describe('Banner', () => {
 
     expect(await axe(wrapper.element)).toHaveNoViolations()
   })
+
+  it('forwards attrs to root when `to` prop is absent', async () => {
+    const wrapper = await mountSuspended(Banner, {
+      props: { title: 'Notice' },
+      attrs: { 'aria-label': 'test-label', 'data-testid': 'test-id' }
+    })
+    expect(wrapper.attributes('aria-label')).toBe('test-label')
+    expect(wrapper.attributes('data-testid')).toBe('test-id')
+  })
+
+  it('forwards attrs to link when `to` prop is set', async () => {
+    const wrapper = await mountSuspended(Banner, {
+      props: { title: 'Notice', to: 'https://github.com/benjamincanac' },
+      attrs: { 'aria-label': 'test-label' }
+    })
+    expect(wrapper.attributes('aria-label')).toBeUndefined()
+    expect(wrapper.find('a').attributes('aria-label')).toBe('test-label')
+  })
 })

--- a/test/components/PageCard.spec.ts
+++ b/test/components/PageCard.spec.ts
@@ -56,4 +56,22 @@ describe('PageCard', () => {
 
     expect(await axe(wrapper.element)).toHaveNoViolations()
   })
+
+  it('forwards attrs to root when `to` prop is absent', async () => {
+    const wrapper = await mountSuspended(PageCard, {
+      props: { title: 'Title' },
+      attrs: { 'aria-label': 'test-label', 'data-testid': 'test-id' }
+    })
+    expect(wrapper.attributes('aria-label')).toBe('test-label')
+    expect(wrapper.attributes('data-testid')).toBe('test-id')
+  })
+
+  it('forwards attrs to link when `to` prop is set', async () => {
+    const wrapper = await mountSuspended(PageCard, {
+      props: { title: 'Title', to: 'https://github.com/benjamincanac' },
+      attrs: { 'aria-label': 'test-label' }
+    })
+    expect(wrapper.attributes('aria-label')).toBeUndefined()
+    expect(wrapper.find('a').attributes('aria-label')).toBe('test-label')
+  })
 })

--- a/test/components/PageFeature.spec.ts
+++ b/test/components/PageFeature.spec.ts
@@ -44,4 +44,22 @@ describe('PageFeature', () => {
 
     expect(await axe(wrapper.element)).toHaveNoViolations()
   })
+
+  it('forwards attrs to root when `to` prop is absent', async () => {
+    const wrapper = await mountSuspended(PageFeature, {
+      props: { title: 'Title' },
+      attrs: { 'aria-label': 'test-label', 'data-testid': 'test-id' }
+    })
+    expect(wrapper.attributes('aria-label')).toBe('test-label')
+    expect(wrapper.attributes('data-testid')).toBe('test-id')
+  })
+
+  it('forwards attrs to link when `to` prop is set', async () => {
+    const wrapper = await mountSuspended(PageFeature, {
+      props: { title: 'Title', to: 'https://github.com/benjamincanac' },
+      attrs: { 'aria-label': 'test-label' }
+    })
+    expect(wrapper.attributes('aria-label')).toBeUndefined()
+    expect(wrapper.find('a').attributes('aria-label')).toBe('test-label')
+  })
 })

--- a/test/components/User.spec.ts
+++ b/test/components/User.spec.ts
@@ -45,4 +45,22 @@ describe('User', () => {
 
     expect(await axe(wrapper.element)).toHaveNoViolations()
   })
+
+  it('forwards attrs to root when `to` prop is absent', async () => {
+    const wrapper = await mountSuspended(User, {
+      props: { name: 'John Doe' },
+      attrs: { 'aria-label': 'test-label', 'data-testid': 'test-id' }
+    })
+    expect(wrapper.attributes('aria-label')).toBe('test-label')
+    expect(wrapper.attributes('data-testid')).toBe('test-id')
+  })
+
+  it('forwards attrs to link when `to` prop is set', async () => {
+    const wrapper = await mountSuspended(User, {
+      props: { name: 'John Doe', to: 'https://github.com/benjamincanac' },
+      attrs: { 'aria-label': 'test-label' }
+    })
+    expect(wrapper.attributes('aria-label')).toBeUndefined()
+    expect(wrapper.find('a').attributes('aria-label')).toBe('test-label')
+  })
 })

--- a/test/components/prose/Callout.spec.ts
+++ b/test/components/prose/Callout.spec.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest'
+import { axe } from 'vitest-axe'
+import { mountSuspended } from '@nuxt/test-utils/runtime'
+import Callout from '../../../src/runtime/components/prose/Callout.vue'
+
+describe('Callout', () => {
+  it('passes accessibility tests', async () => {
+    const wrapper = await mountSuspended(Callout, {
+      props: {}
+    })
+    expect(await axe(wrapper.element)).toHaveNoViolations()
+  })
+
+  it('forwards attrs to root when `to` prop is absent', async () => {
+    const wrapper = await mountSuspended(Callout, {
+      props: {},
+      attrs: { 'aria-label': 'test-label', 'data-testid': 'test-id' }
+    })
+    expect(wrapper.attributes('aria-label')).toBe('test-label')
+    expect(wrapper.attributes('data-testid')).toBe('test-id')
+  })
+
+  it('forwards attrs to link when `to` prop is set', async () => {
+    const wrapper = await mountSuspended(Callout, {
+      props: { to: 'https://github.com/benjamincanac' },
+      attrs: { 'aria-label': 'test-label' }
+    })
+    expect(wrapper.attributes('aria-label')).toBeUndefined()
+    expect(wrapper.find('a').attributes('aria-label')).toBe('test-label')
+  })
+})

--- a/test/components/prose/Card.spec.ts
+++ b/test/components/prose/Card.spec.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest'
+import { axe } from 'vitest-axe'
+import { mountSuspended } from '@nuxt/test-utils/runtime'
+import Card from '../../../src/runtime/components/prose/Card.vue'
+
+describe('Card', () => {
+  it('passes accessibility tests', async () => {
+    const wrapper = await mountSuspended(Card, {
+      props: {}
+    })
+    expect(await axe(wrapper.element)).toHaveNoViolations()
+  })
+
+  it('forwards attrs to root when `to` prop is absent', async () => {
+    const wrapper = await mountSuspended(Card, {
+      props: {},
+      attrs: { 'aria-label': 'test-label', 'data-testid': 'test-id' }
+    })
+    expect(wrapper.attributes('aria-label')).toBe('test-label')
+    expect(wrapper.attributes('data-testid')).toBe('test-id')
+  })
+
+  it('forwards attrs to link when `to` prop is set', async () => {
+    const wrapper = await mountSuspended(Card, {
+      props: { to: 'https://github.com/benjamincanac' },
+      attrs: { 'aria-label': 'test-label' }
+    })
+    expect(wrapper.attributes('aria-label')).toBeUndefined()
+    expect(wrapper.find('a').attributes('aria-label')).toBe('test-label')
+  })
+})


### PR DESCRIPTION
Port of upstream nuxt/ui [`d3b5f1d3`](https://github.com/nuxt/ui/commit/d3b5f1d3f966e92f9194e1e114f5c84ea1e8cbaa) — `fix(components): forward $attrs to root element when to prop is absent (#6628)`.

## Problem
Components that conditionally render an inner link (when `to` is set) only spread `$attrs` onto that link. With `inheritAttrs: false`, when there's no `to` the attrs went nowhere. Fix: bind `v-bind="!props.to ? $attrs : {}"` on the **root** element.

## Changes
- **Banner**, **PageFeature**, **User**, **prose/Callout**, **prose/Card**: add the conditional `v-bind` on the root element (`Primitive` / root `<div data-slot="base">`).
- **PageCard**: b24ui's root `Primitive` already bound `v-bind="$attrs"` **unconditionally** — a fork-only divergence that double-applied attrs to both root and link when `to` was set. Changed it to `v-bind="!props.to ? $attrs : {}"` (same intent, fixes the duplication).
- **Tests**: added the 2 attr-forwarding cases to `Banner`/`PageCard`/`PageFeature`/`User` specs and created **`prose/Callout.spec.ts`** + **`prose/Card.spec.ts`** (new), mirroring upstream.
- **BlogPost** / **ChangelogVersion** are **N/A** — absent in b24ui.

> `PageFeature`/`User` root `Primitive` was single-line; the extra attribute tripped `vue/max-attributes-per-line`, so both were reflowed to multiline (matching upstream's formatting).

## Verification (pnpm 11.8.0, gate ON)
dev:prepare · lint · typecheck · test (**5139 passed**, 6 skipped — +new attr cases & 2 new prose specs) · module build — all green. No snapshot churn.

Ledger: records the merge sha for the previous port (#217, `f03f98ba`) and advances the sync cursor to `d3b5f1d3`.

🎯 `d3b5f1d3` is the current upstream/v4 HEAD — after this merges, the b24ui sync is fully caught up again.

https://claude.ai/code/session_01Qz7EXMncvEGiCj4WbmYgJo

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qz7EXMncvEGiCj4WbmYgJo)_