### PR TITLE
chore(sync): no-op upstream docs icon clientBundle scan

### DIFF
--- a/.sync/log/f2fa61fd55de7c78006865a8f785b2dcf346d371.md
+++ b/.sync/log/f2fa61fd55de7c78006865a8f785b2dcf346d371.md
@@ -1,0 +1,18 @@
+# Port: docs(nuxt.config): scan `.ts` and `.navigation.yml` for client icon bundle
+
+**Upstream:** `f2fa61fd55de7c78006865a8f785b2dcf346d371` (nuxt/ui)
+**Decision:** no-op
+
+## Upstream change
+`docs/nuxt.config.ts`: widens the `@nuxt/icon` `clientBundle.scan` glob — from
+`scan: true` to an explicit `globInclude` that also picks up `.ts` (nav icons in
+`app/composables/*.ts`) and dot-files (`.navigation.yml`), so the client icon
+bundle includes those references.
+
+## b24ui decision — no-op
+b24ui's `docs/nuxt.config.ts` has **no `@nuxt/icon` `clientBundle`/`scan`
+config** (no `clientBundle`, `icon:`, or `app/assets/icons` block). b24ui's docs
+render icons via `@bitrix24/b24icons-vue` components, not `@nuxt/icon`'s
+iconify client-bundle scanning, so there is nothing to widen. N/A.
+
+No file change — bookkeeping only.

--- a/.sync/nuxt-ui.json
+++ b/.sync/nuxt-ui.json
@@ -2,7 +2,7 @@
   "upstream": "nuxt/ui",
   "branch": "v4",
   "sync_enabled": false,
-  "cursor": "d3b5f1d3f966e92f9194e1e114f5c84ea1e8cbaa",
+  "cursor": "f2fa61fd55de7c78006865a8f785b2dcf346d371",
   "_cursor_note": "cursor = last upstream commit ported into b24ui (oldest-first, manual cadence). sync_enabled stays false until Phase 2 (porter workflow #67 + CLAUDE_CODE_OAUTH_TOKEN) is wired and trusted. `processed` is maintained per port from now on (backfilled #68-#72 on 2026-06-09).",
   "stats": {
     "queue_depth": 0,
@@ -737,10 +737,16 @@
       "summary": "feat(ContentSearch/DashboardSearch): support unmountOnHide prop (#6523) — DashboardSearch.vue + content/ContentSearch.vue: add unmountOnHide to Pick<ModalProps> and to the modalProps reactivePick; docs Search.vue +:unmount-on-hide=false. Direct 1:1 (b24ui matched pre-change). Builds on 1ea8a98f (#214) Modal unmountOnHide. No snapshot churn"
     },
     "d3b5f1d3f966e92f9194e1e114f5c84ea1e8cbaa": {
-      "pr": null,
-      "b24ui_sha": "pending-merge",
+      "pr": 218,
+      "b24ui_sha": "723d5e3c",
       "decision": "port",
       "summary": "fix(components): forward $attrs to root element when to prop is absent (#6628) — add v-bind=!props.to?$attrs:{} on root of Banner/PageFeature/User/prose Callout/prose Card; PageCard already bound v-bind=$attrs unconditionally (fork divergence, double-applied with to) -> made conditional. +attr-forwarding specs (Banner/PageCard/PageFeature/User) + new prose/Callout.spec + prose/Card.spec. BlogPost/ChangelogVersion N/A (absent in b24ui). PageFeature/User Primitive reflowed multiline for max-attributes-per-line. No snapshot churn"
+    },
+    "f2fa61fd55de7c78006865a8f785b2dcf346d371": {
+      "pr": null,
+      "b24ui_sha": "pending-merge",
+      "decision": "no-op",
+      "summary": "docs(nuxt.config): scan .ts and .navigation.yml for client icon bundle — NO-OP: upstream widens @nuxt/icon clientBundle.scan glob in docs/nuxt.config.ts (scan:true -> globInclude incl. ts + dot .navigation.yml). b24ui docs has no @nuxt/icon clientBundle/scan config (renders via @bitrix24/b24icons-vue components, not iconify client-bundle scan), so nothing to widen. Bookkeeping only"
     }
   }
 }


### PR DESCRIPTION
Records upstream nuxt/ui [`f2fa61fd`](https://github.com/nuxt/ui/commit/f2fa61fd55de7c78006865a8f785b2dcf346d371) — `docs(nuxt.config): scan .ts and .navigation.yml for client icon bundle` — as a **no-op**.

## Decision: no-op
Upstream widens the `@nuxt/icon` `clientBundle.scan` glob in `docs/nuxt.config.ts` (`scan: true` → an explicit `globInclude` that also picks up `.ts` and the dot-file `.navigation.yml`).

**b24ui's `docs/nuxt.config.ts` has no `@nuxt/icon` `clientBundle`/`scan` config** — its docs render icons via `@bitrix24/b24icons-vue` components, not `@nuxt/icon`'s iconify client-bundle scanning. There's nothing to widen.

## Changes
Bookkeeping only — `.sync/` ledger + log entry. Records the merge sha for the previous port (#218, `d3b5f1d3`) and advances the sync cursor to `f2fa61fd`.

🎯 `f2fa61fd` is the current upstream/v4 HEAD — after this merges, the b24ui sync is fully caught up.

https://claude.ai/code/session_01Qz7EXMncvEGiCj4WbmYgJo

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qz7EXMncvEGiCj4WbmYgJo)_