### PR TITLE
fix(Separator): forward fall-through attributes to root

### DIFF
--- a/.sync/log/88baabcf42b115b7da1a65e5f71092a37b5c9bf3.md
+++ b/.sync/log/88baabcf42b115b7da1a65e5f71092a37b5c9bf3.md
@@ -1,0 +1,39 @@
+# Port: fix(Separator): forward fall-through attributes to root (#6641)
+
+**Upstream:** `88baabcf42b115b7da1a65e5f71092a37b5c9bf3` (nuxt/ui)
+**Decision:** port
+
+## Upstream change
+`src/runtime/components/Separator.vue`:
+- `defineOptions({ inheritAttrs: false })` so Vue stops auto-applying
+  fall-through attributes to the (wrong) first root node.
+- root `<Separator>` binding changed from `v-bind="rootProps"` to
+  `v-bind="{ ...rootProps, ...$attrs }"` so attrs land on the actual root.
+
+## b24ui port — direct 1:1
+b24ui's `Separator.vue` matched the pre-change upstream shape (same `rootProps`
+via `useForwardProps`, same reka-ui `<Separator>` root). Applied both edits
+verbatim:
+- added `defineOptions({ inheritAttrs: false })` ahead of the `withDefaults`
+  `defineProps` call in `<script setup>`;
+- `v-bind="rootProps"` → `v-bind="{ ...rootProps, ...$attrs }"` on the root.
+
+No renames needed (no `ui`→`b24ui`, icon, or color tokens in the diff). The
+upstream import lines (`UIcon`/`UAvatar`) are not part of the change and differ
+in b24ui anyway (icon via `<Component :is>`).
+
+## Tests
+Added a `forwards fall-through attributes to the root` spec mirroring the #218
+(`d3b5f1d3`) attr-forwarding pattern — mounts with `aria-label`/`data-testid`
+attrs and asserts they appear on the **root** element. (Separator renders a
+multi-root template — `DefineContainer` placeholder + reka `<Separator>` — so
+the assertion targets `[data-slot="root"]`, not `wrapper.attributes()`.)
+
+**Snapshot churn — 2 updated (`Separator.spec.ts.snap` + `-vue` variant), and
+this is the fix demonstrating itself.** The existing `renderEach` case
+`['with color success', { props: { color: 'air-primary-success' } }]` passes
+`color`, which is **not** a declared `SeparatorProps` member — so it is a
+fall-through attribute. Before this fix the component had multiple root nodes,
+so Vue dropped fall-through attrs entirely (the old snapshot had no `color`);
+after the fix `...$attrs` lands on the root, so the snapshot now carries
+`color="air-primary-success"`. Expected and correct.

--- a/.sync/nuxt-ui.json
+++ b/.sync/nuxt-ui.json
@@ -2,7 +2,7 @@
   "upstream": "nuxt/ui",
   "branch": "v4",
   "sync_enabled": false,
-  "cursor": "09fb52b73397733a61c1f53dbd035c2ba040145e",
+  "cursor": "88baabcf42b115b7da1a65e5f71092a37b5c9bf3",
   "_cursor_note": "cursor = last upstream commit ported into b24ui (oldest-first, manual cadence). sync_enabled stays false until Phase 2 (porter workflow #67 + CLAUDE_CODE_OAUTH_TOKEN) is wired and trusted. `processed` is maintained per port from now on (backfilled #68-#72 on 2026-06-09).",
   "stats": {
     "queue_depth": 0,
@@ -767,10 +767,16 @@
       "summary": "fix(Link): fall back to original path when localePath fails (#6637) — Link.vue: return localePath(path,...) -> const localizedPath=localePath(...); return localizedPath || path (empty localePath no longer yields empty to). Direct 1:1 (b24ui matched pre-change). +new test/components/nuxt/LinkLocale.spec.ts (new dir) mocking $localePath=()=>'' for Link+Button. No snapshot churn"
     },
     "09fb52b73397733a61c1f53dbd035c2ba040145e": {
-      "pr": null,
-      "b24ui_sha": "pending-merge",
+      "pr": 224,
+      "b24ui_sha": "24d80226",
       "decision": "no-op",
       "summary": "fix(ContentNavigation): key items by identity to prevent leading icon flash (#6640) — NO-OP: upstream keys the navigation v-for by `${index}-${link.path}` in src/runtime/components/content/ContentNavigation.vue (+spec). b24ui has no ContentNavigation component (git ls-files grep contentnavigation => none). Nothing to port. Bookkeeping only"
+    },
+    "88baabcf42b115b7da1a65e5f71092a37b5c9bf3": {
+      "pr": null,
+      "b24ui_sha": "pending-merge",
+      "decision": "port",
+      "summary": "fix(Separator): forward fall-through attributes to root (#6641) — Separator.vue: add defineOptions({ inheritAttrs: false }) + change root <Separator> binding v-bind=rootProps -> v-bind={...rootProps, ...$attrs} so fall-through attrs land on the actual root. Direct 1:1 (b24ui matched pre-change; useForwardProps rootProps + reka <Separator> root unchanged; no ui/icon/color renames). +attr-forwarding spec mirroring #218 (d3b5f1d3) (targets [data-slot=root] since Separator is multi-root). 2 snapshots updated (Separator + -vue): the existing 'with color success' renderEach case passes `color` which is NOT a SeparatorProps member = a fall-through attr; pre-fix multi-root dropped it, post-fix $attrs forwards it to root -> snapshot now carries color=air-primary-success (the fix demonstrating itself)"
     }
   }
 }

--- a/src/runtime/components/Separator.vue
+++ b/src/runtime/components/Separator.vue
@@ -66,6 +66,8 @@ import { useForwardProps } from '../composables/useForwardProps'
 import { tv } from '../utils/tv'
 import B24Avatar from './Avatar.vue'
 
+defineOptions({ inheritAttrs: false })
+
 const _props = withDefaults(defineProps<SeparatorProps>(), {
   accent: 'default',
   orientation: 'horizontal',
@@ -106,7 +108,7 @@ const b24ui = computed(() => tv({ extend: tv(theme), ...(appConfig.b24ui?.separa
     </div>
   </DefineContainer>
 
-  <Separator v-bind="rootProps" data-slot="root" :class="b24ui.root({ class: [props.b24ui?.root, props.class] })">
+  <Separator v-bind="{ ...rootProps, ...$attrs }" data-slot="root" :class="b24ui.root({ class: [props.b24ui?.root, props.class] })">
     <ReuseContainer v-if="hasContent && props.position === 'start'" />
 
     <div data-slot="border" :class="b24ui.border({ class: props.b24ui?.border })" />

--- a/test/components/Separator.spec.ts
+++ b/test/components/Separator.spec.ts
@@ -37,4 +37,13 @@ describe('Separator', () => {
 
     expect(await axe(wrapper.element)).toHaveNoViolations()
   })
+
+  it('forwards fall-through attributes to the root', async () => {
+    const wrapper = await mountSuspended(Separator, {
+      attrs: { 'aria-label': 'test-label', 'data-testid': 'test-id' }
+    })
+    const root = wrapper.find('[data-slot="root"]')
+    expect(root.attributes('aria-label')).toBe('test-label')
+    expect(root.attributes('data-testid')).toBe('test-id')
+  })
 })

--- a/test/components/__snapshots__/Separator-vue.spec.ts.snap
+++ b/test/components/__snapshots__/Separator-vue.spec.ts.snap
@@ -31,7 +31,7 @@ exports[`Separator > renders with class correctly 1`] = `
 `;
 
 exports[`Separator > renders with color success correctly 1`] = `
-"<div data-orientation="horizontal" role="separator" data-slot="root" class="flex items-center align-center text-center w-full flex-row">
+"<div data-orientation="horizontal" role="separator" color="air-primary-success" data-slot="root" class="flex items-center align-center text-center w-full flex-row">
   <!--v-if-->
   <div data-slot="border" class="border-(--ui-color-divider-vibrant-default) w-full border-solid border-t-(length:--ui-border-width-thin)"></div>
   <!--v-if-->

--- a/test/components/__snapshots__/Separator.spec.ts.snap
+++ b/test/components/__snapshots__/Separator.spec.ts.snap
@@ -31,7 +31,7 @@ exports[`Separator > renders with class correctly 1`] = `
 `;
 
 exports[`Separator > renders with color success correctly 1`] = `
-"<div data-orientation="horizontal" role="separator" data-slot="root" class="flex items-center align-center text-center w-full flex-row">
+"<div data-orientation="horizontal" role="separator" color="air-primary-success" data-slot="root" class="flex items-center align-center text-center w-full flex-row">
   <!--v-if-->
   <div data-slot="border" class="border-(--ui-color-divider-vibrant-default) w-full border-solid border-t-(length:--ui-border-width-thin)"></div>
   <!--v-if-->


### PR DESCRIPTION
## Upstream
[`88baabcf`](https://github.com/nuxt/ui/commit/88baabcf42b115b7da1a65e5f71092a37b5c9bf3) — `fix(Separator): forward fall-through attributes to root (#6641)`

Rebased onto `main` after #224 merged — this PR now contains only the Separator change.

## Change — direct 1:1 port
b24ui's `Separator.vue` matched the pre-change upstream shape, so the fix applies verbatim:
- `defineOptions({ inheritAttrs: false })`
- root `<Separator>` binding `v-bind="rootProps"` → `v-bind="{ ...rootProps, ...$attrs }"` so fall-through attrs reach the actual root.

No `ui`→`b24ui` / icon / color renames in this diff.

## Tests
- Added a `forwards fall-through attributes to the root` spec (mirrors the #218 / `d3b5f1d3` attr-forwarding pattern). Separator renders a multi-root template (`DefineContainer` placeholder + reka `<Separator>`), so the assertion targets `[data-slot="root"]` rather than `wrapper.attributes()`.

## Deviations / snapshot churn
**2 snapshots updated — and this is the fix demonstrating itself.** The existing `renderEach` case `['with color success', { props: { color: 'air-primary-success' } }]` passes `color`, which is **not** a declared `SeparatorProps` member, so it's a fall-through attribute. Before the fix, the multi-root template made Vue drop fall-through attrs entirely (old snapshot had no `color`); after the fix, `...$attrs` lands on the root, so the snapshot now carries `color="air-primary-success"`. Expected and correct.

## Verify (CI=true)
`pnpm dev:prepare` · `lint` · `typecheck` · `test` (5143 passed / 6 skipped, 225 files) · `build` — all green.

## Ledger
- `.sync/log/88baabcf….md` — port rationale
- `.sync/nuxt-ui.json` — add `88baabcf` as `port`, advance cursor to `88baabcf` (= upstream v4 HEAD), **and reconcile `09fb52b7` → PR #224 / `24d80226`**. (`88baabcf` itself stays `pending-merge`, reconciled by the next port per cadence.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)