### PR TITLE
chore(release): v2.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,86 @@
 # Changelog
 
+## [2.9.0](https://github.com/bitrix24/b24ui/compare/v2.8.0...v2.9.0) (2026-06-27)
+
+### Features
+
+* **useTour:** new composable for guided tours
+* **module:** add `theme.unstyled` option
+* **theme:** allow replacing slot classes with a function
+* **vite:** add `root` option to override `.b24ui-nuxt` directory location
+* **components:** allow hiding icon with `false`
+* **ChatMessage:** add `body` slot and improve actions alignment
+* **ChatMessages:** expose `registerMessageRef`
+* **ContentSearch:** add async search support via `search` / `searchStatus`
+* **ContentSearch/DashboardSearch:** support `unmountOnHide` prop
+* **ContentSearch/DashboardSearch:** forward input config to command palette
+* **FileUpload:** expose `removeFile` in slots
+* **Modal/Slideover:** add `leave` and `enter` events
+* **PinInput:** add `separator` prop
+* **ScrollArea:** add `shadow` prop
+* **Select/SelectMenu:** use `multiple` in theme
+* **Sidebar:** add `transition` prop
+
+### Bug Fixes
+
+* **Link:** fall back to original path when `localePath` fails
+* **Link:** set default for `locale` prop
+* **Separator:** forward fall-through attributes to root
+* **components:** forward `$attrs` to root element when `to` prop is absent
+* **components:** apply `theme.prefix` to hardcoded utility classes
+* **module:** remove inline script in SPA mode for strict CSP
+* **module:** merge custom variants into AppConfig type
+* **module:** expose component theme keys in AppConfig type
+* **module:** revert `tagPriority` to `-2` for inline style tag
+* **module:** ship stripped `#build/b24ui.css` fallback for tooling
+* **templates:** resolve vite root to an absolute path for `#build` aliases
+* **ProseCodeCollapse:** cap root max-height instead of toggling pre height
+* **ProseKbd:** type default slot as `VNode[]`
+* **ProseKbd:** add default slot and make `value` optional
+* **CommandPalette:** only scroll to highlighted item when focused
+* **Select:** open menu on label click
+* **SelectMenu:** bind `id` and aria attributes on trigger
+* **InputMenu/SelectMenu:** re-highlight first item when items change
+* **InputMenu/Select/SelectMenu:** respect `trailing: false` over default `trailingIcon`
+* **InputNumber/InputDate/InputTime/Calendar:** restore `locale` prop
+* **Tabs:** render active indicator during SSR
+* **Modal/Slideover/Drawer:** suppress reka-ui `aria-hidden` focus warning
+* **Form:** support setting the `name` attribute
+* **Form:** add `method="post"` to prevent credential leaking via GET
+* **ChatMessage:** add `wrap-break-word` to content slot
+* **ContentSearch:** preserve intermediate ancestors in breadcrumb prefix
+* **ContentToc:** apply `b24ui.trigger` prop to trigger elements
+* **Textarea:** autoresize on mount with pre-filled value
+* **FileUpload:** pass `disabled` attribute to button variant
+* **docs:** resolve prerender payload 204 and build warnings
+* **docs:** drop redundant homepage payload prerender ignore
+
+### Docs
+
+* **Chat:** refocus prompt when sidebar reopens
+* **Chat:** validate AI assistant currentPage input
+* **tabs:** add bottom tab bar example
+* **search:** init index on nuxt ready
+* **search:** improve relevance and tooltip behavior
+* **form-field:** add a warning to help field
+* **composables:** improve examples
+* **navigation:** query `description` field for content toc
+* **toast:** add `duration` prop docs and remove misleading AppConfig notes from examples
+* SEO metadata and docs-tail bookkeeping (badges / community / typecheck)
+* fix missing CSS variables on prerendered pages
+
+### CI
+
+* **deploy:** raise Node heap limit to fix docs prerender OOM
+* move playground builds out of PR CI into the deploy job
+
+### Chore
+
+* **deps:** update Nuxt to `^4.4.6`, Tiptap `^3.24.0`, reka-ui `v2.9.8`, Vite, vue-tsc `^3.3.3`, vitest-environment-nuxt v2, pnpm v11, pnpm/action-setup v6 and 25 dependency refreshes in total
+* **repl:** expose composables subpath in the playground
+* sync with nuxt/ui upstream (no-op syncs)
+* add `.cursor` to `.gitignore`
+
 ## [2.8.0](https://github.com/bitrix24/b24ui/compare/v2.7.1...v2.8.0) (2026-05-20)
 
 ### Features

--- a/docs/app/app.vue
+++ b/docs/app/app.vue
@@ -51,8 +51,6 @@ provide('navigation', rootNavigation)
         ]"
       >
         <template v-if="!route.path.startsWith('/examples')">
-          <!-- Banner / -->
-
           <Header />
         </template>
 

--- a/docs/app/error.vue
+++ b/docs/app/error.vue
@@ -38,8 +38,6 @@ provide('navigation', rootNavigation)
 
     <div class="flex">
       <div class="flex-1 min-w-0" :class="[route.path.startsWith('/docs/') && 'root']">
-        <!-- <Banner /> -->
-
         <Header />
 
         <B24Error :error="error" :b24ui="{ root: 'min-h-[calc(100vh-var(--topbar-height)-var(--topbar-height))]' }" />

--- a/docs/content/docs/2.components/chat-reasoning.md
+++ b/docs/content/docs/2.components/chat-reasoning.md
@@ -16,7 +16,6 @@ links:
     avatar:
       src: /b24ui/avatar/rekaui.svg
     to: https://reka-ui.com/docs/components/collapsible
-navigation.badge: New
 ---
 
 ## Usage

--- a/docs/content/docs/2.components/chat-shimmer.md
+++ b/docs/content/docs/2.components/chat-shimmer.md
@@ -12,7 +12,6 @@ links:
   - label: Nuxt UI
     iconName: NuxtIcon
     to: https://ui.nuxt.com/docs/components/chat-shimmer
-navigation.badge: New
 ---
 
 ## Usage

--- a/docs/content/docs/2.components/chat-tool.md
+++ b/docs/content/docs/2.components/chat-tool.md
@@ -16,7 +16,6 @@ links:
     avatar:
       src: /b24ui/avatar/rekaui.svg
     to: https://reka-ui.com/docs/components/collapsible
-navigation.badge: New
 ---
 
 ## Usage

--- a/docs/content/docs/2.components/checkbox-group.md
+++ b/docs/content/docs/2.components/checkbox-group.md
@@ -332,7 +332,7 @@ props:
 
 ## Examples
 
-### Settings layout :badge{label="Soon" class="align-text-top"}
+### Settings layout
 
 Use the `card` variant together with the `#label` slot to render a settings-style picker where each option has a title, description, a "Learn more" link and a preview image. The label slot renders inside a `<span>`, so any phrasing-content layout (flex, link, image) works.
 

--- a/docs/content/docs/2.components/content-search.md
+++ b/docs/content/docs/2.components/content-search.md
@@ -94,7 +94,7 @@ const { data: files } = useLazyAsyncData('search', () => queryCollectionSearchSe
 Use the `fuse` prop to configure [useFuse](https://vueuse.org/integrations/useFuse) options passed to the underlying [CommandPalette](/docs/components/command-palette/) such as `resultLimit` (default `12`) and `fuseOptions.threshold` (default `0.1`).
 ::
 
-### Search :badge{label="Soon" class="align-text-top"}
+### Search
 
 Use the `search` prop with [`useSearchCollection`](https://content.nuxt.com/docs/utils/use-search-collection) for server-side [FTS5 full-text search](https://www.sqlite.org/fts5.html) with highlighted snippets instead of client-side filtering:
 

--- a/docs/content/docs/2.components/radio-group.md
+++ b/docs/content/docs/2.components/radio-group.md
@@ -306,7 +306,7 @@ props:
 
 ## Examples
 
-### Settings layout :badge{label="Soon" class="align-text-top"}
+### Settings layout
 
 Use the `card` variant together with the `#label` slot to render a settings-style picker where each option has a title, description, a "Learn more" link and a preview image. The label slot renders inside a `<span>`, so any phrasing-content layout (flex, link, image) works.
 

--- a/docs/content/docs/3.composables/use-scroll-shadow.md
+++ b/docs/content/docs/3.composables/use-scroll-shadow.md
@@ -1,7 +1,6 @@
 ---
 title: useScrollShadow
 description: 'A composable function to apply scroll shadow effects to any scrollable element.'
-navigation.badge: New
 ---
 
 ## Usage

--- a/docs/content/docs/3.composables/use-tour.md
+++ b/docs/content/docs/3.composables/use-tour.md
@@ -1,7 +1,6 @@
 ---
 title: useTour
 description: 'A composable to build guided tours by re-anchoring a single Popover across steps.'
-navigation.badge: New
 ---
 
 ## Usage

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bitrix24/b24ui-nuxt",
   "description": "Bitrix24 UI-Kit for developing web applications REST API for NUXT & VUE",
-  "version": "2.8.0",
+  "version": "2.9.0",
   "packageManager": "pnpm@11.8.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

Minor release **v2.9.0** — bumps `package.json` to `2.9.0` and documents 113 commits landed since `v2.8.0` (16 features, 29 fixes, plus dependency refreshes and upstream syncs).

### Features
- **useTour** — new composable for guided tours
- **module** — `theme.unstyled` option
- **theme** — replace slot classes with a function
- **vite** — `root` option to override `.b24ui-nuxt` directory location
- **components** — hide icon with `false`
- **ChatMessage** — `body` slot + improved actions alignment
- **ChatMessages** — expose `registerMessageRef`
- **ContentSearch** — async search (`search` / `searchStatus`)
- **ContentSearch/DashboardSearch** — `unmountOnHide` prop; forward input config to command palette
- **FileUpload** — expose `removeFile` in slots
- **Modal/Slideover** — `leave` and `enter` events
- **PinInput** — `separator` prop
- **ScrollArea** — `shadow` prop
- **Select/SelectMenu** — `multiple` in theme
- **Sidebar** — `transition` prop

### Bug Fixes (selection)
- **Link** — fallback when `localePath` fails; default for `locale` prop
- **components** — forward `$attrs` when no `to` prop; apply `theme.prefix` to hardcoded utility classes
- **module** — strip inline script in SPA for strict CSP; AppConfig type covers custom variants & component theme keys; `tagPriority` reverted to `-2`; stripped `#build/b24ui.css` fallback for tooling
- **CommandPalette** — only scroll to highlighted item when focused
- **Select / SelectMenu / InputMenu / InputNumber / InputDate / InputTime / Calendar / Tabs / ProseKbd / ProseCodeCollapse / Form / Modal/Slideover/Drawer / Textarea / FileUpload / ChatMessage / ContentSearch / ContentToc** — assorted correctness, accessibility, SSR and types fixes

### Docs / CI / Chore
- docs: Chat (focus + AI validation), tabs bottom-bar example, search relevance & init-on-ready, navigation TOC description, form-field warning, composables examples, toast docs, SEO metadata, prerender CSS variable fix
- CI: raise Node heap for docs prerender OOM; move playground builds to deploy job
- deps: Nuxt `^4.4.6`, Tiptap `^3.24.0`, reka-ui `v2.9.8`, Vite, vue-tsc `^3.3.3`, vitest-environment-nuxt v2, pnpm v11, pnpm/action-setup v6 + 25 non-major refreshes
- repl: expose composables subpath; upstream nuxt/ui no-op syncs; `.cursor` in `.gitignore`

## Test plan
- [ ] CI green (lint / typecheck / test / build)
- [ ] `CHANGELOG.md` 2.9.0 section reads correctly
- [ ] `package.json` version is `2.9.0`

https://claude.ai/code/session_01ReWfWJcdNVZNYH5p5VpoJa

---
_Generated by [Claude Code](https://claude.ai/code/session_01ReWfWJcdNVZNYH5p5VpoJa)_