### PR TITLE
perf(components): drop the redundant inner in component extend

### DIFF
--- a/.sync/log/3bf1a92a9d3aa47ee7f02c1b2363363bc906f313.md
+++ b/.sync/log/3bf1a92a9d3aa47ee7f02c1b2363363bc906f313.md
@@ -1,0 +1,29 @@
+# Port: perf(components): drop the redundant inner in component extend (#6647)
+
+**Upstream:** `3bf1a92a9d3aa47ee7f02c1b2363363bc906f313` (nuxt/ui)
+**Decision:** port
+
+## Upstream change
+In every component the theme is composed as
+`tv({ extend: tv(theme), … })(…)`. The inner `tv(theme)` wrapper is redundant —
+`tv`'s `extend` accepts a raw theme object directly — so it is dropped:
+`extend: tv(theme)` → `extend: theme`. The outer `tv({ … })(…)` call is
+unchanged, so `tv` stays imported and used.
+
+## b24ui port — direct 1:1 (mechanical)
+b24ui uses the identical pattern (`tv({ extend: tv(theme), ...(appConfig.b24ui?.<name> || {}) })(…)`).
+Replaced `extend: tv(theme)` → `extend: theme` across all **162** occurrences
+in `src/runtime/{components,components/prose,components/content,vue/overrides/*}`
+(one line per file, 162 files, +162/−162). Upstream touched 163 files; the
+1-file delta is just the diverging component set (no behavioural meaning).
+
+No renames (no `ui`→`b24ui`/icon/color tokens in the diff). The only b24ui
+surface difference is the `appConfig.b24ui?.<name>` spread (vs upstream
+`appConfig.ui?.<name>`), which is pre-existing and untouched.
+
+## Tests
+Behaviour-preserving (same resolved theme) → no runtime/markup change, no
+snapshot churn. Full suite unchanged (225 files, 5143 passed / 6 skipped).
+
+## Verify (CI=true)
+`dev:prepare` · `lint` · `typecheck` · `test` · `build` — all green.

--- a/.sync/nuxt-ui.json
+++ b/.sync/nuxt-ui.json
@@ -2,7 +2,7 @@
   "upstream": "nuxt/ui",
   "branch": "v4",
   "sync_enabled": false,
-  "cursor": "7eab4bcb78f17b9eed365d617aa3ef3874c21bac",
+  "cursor": "3bf1a92a9d3aa47ee7f02c1b2363363bc906f313",
   "_cursor_note": "cursor = last upstream commit ported into b24ui (oldest-first, manual cadence). sync_enabled stays false until Phase 2 (porter workflow #67 + CLAUDE_CODE_OAUTH_TOKEN) is wired and trusted. `processed` is maintained per port from now on (backfilled #68-#72 on 2026-06-09).",
   "stats": {
     "queue_depth": 0,
@@ -779,10 +779,16 @@
       "summary": "fix(Separator): forward fall-through attributes to root (#6641) — Separator.vue: add defineOptions({ inheritAttrs: false }) + change root <Separator> binding v-bind=rootProps -> v-bind={...rootProps, ...$attrs} so fall-through attrs land on the actual root. Direct 1:1 (b24ui matched pre-change; useForwardProps rootProps + reka <Separator> root unchanged; no ui/icon/color renames). +attr-forwarding spec mirroring #218 (d3b5f1d3) (targets [data-slot=root] since Separator is multi-root). 2 snapshots updated (Separator + -vue): the existing 'with color success' renderEach case passes `color` which is NOT a SeparatorProps member = a fall-through attr; pre-fix multi-root dropped it, post-fix $attrs forwards it to root -> snapshot now carries color=air-primary-success (the fix demonstrating itself)"
     },
     "7eab4bcb78f17b9eed365d617aa3ef3874c21bac": {
+      "pr": 227,
+      "b24ui_sha": "575c8dee",
+      "decision": "port",
+      "summary": "perf(types): import cross-component types from source, not the barrel (#6646) — replace `import type {...} from '../types'` barrel imports with per-source imports (owning component .vue, e.g. ButtonProps from ./Button.vue; or specific ../types/* module, e.g. Messages from ../types/locale) across 119 consumer files in src/runtime/{components,composables,utils,dictionary,locale,vue/...}; +eslint no-restricted-imports guard on ../types & ../../types for components/**/*.vue + composables/**/*.ts, with useComponentProps.ts exempted (keeps `import type * as ComponentTypes from '../types'`). Adapted, not 1:1: resolved each type->source against b24ui's OWN exports (IconComponent->../types/icons since b24ui has no Icon.vue; own component set; curated 20 locale files vs upstream 62 per §2). 0 unresolved / 0 ambiguous names. Rule appended via existing .append chain (bitrix24-ui/ namespace). Types-only, no snapshot churn. 120 files, +284/-120. Rebased onto main after v2.9.0 release (#226) landed mid-CI"
+    },
+    "3bf1a92a9d3aa47ee7f02c1b2363363bc906f313": {
       "pr": null,
       "b24ui_sha": "pending-merge",
       "decision": "port",
-      "summary": "perf(types): import cross-component types from source, not the barrel (#6646) — replace `import type {...} from '../types'` barrel imports with per-source imports (owning component .vue, e.g. ButtonProps from ./Button.vue; or specific ../types/* module, e.g. Messages from ../types/locale) across 119 consumer files in src/runtime/{components,composables,utils,dictionary,locale,vue/...}; +eslint no-restricted-imports guard on ../types & ../../types for components/**/*.vue + composables/**/*.ts, with useComponentProps.ts exempted (keeps `import type * as ComponentTypes from '../types'`). Adapted, not 1:1: resolved each type->source against b24ui's OWN exports (IconComponent->../types/icons since b24ui has no Icon.vue; own component set; curated 20 locale files vs upstream 62 per §2). 0 unresolved / 0 ambiguous names. Rule appended via existing .append chain (bitrix24-ui/ namespace). Types-only, no snapshot churn. 120 files, +284/-120"
+      "summary": "perf(components): drop the redundant inner in component extend (#6647) — replace `extend: tv(theme)` -> `extend: theme` across all 162 occurrences in src/runtime/{components,components/prose,components/content,vue/overrides/*} (tv's extend takes a raw theme object; inner tv() wrapper redundant). Outer tv({...})(...) unchanged so tv stays imported. Direct 1:1 mechanical (1 line/file, 162 files, +162/-162; upstream 163, delta = diverging component set). appConfig.b24ui?.<name> spread pre-existing/untouched. Behaviour-preserving, no snapshot churn"
     }
   }
 }

--- a/src/runtime/components/Accordion.vue
+++ b/src/runtime/components/Accordion.vue
@@ -104,7 +104,7 @@ const appConfig = useAppConfig() as Accordion['AppConfig']
 const rootProps = useForwardProps(reactivePick(props, 'as', 'collapsible', 'defaultValue', 'disabled', 'modelValue', 'unmountOnHide'), emits)
 
 // eslint-disable-next-line vue/no-dupe-keys
-const b24ui = computed(() => tv({ extend: tv(theme), ...(appConfig.b24ui?.accordion || {}) })({
+const b24ui = computed(() => tv({ extend: theme, ...(appConfig.b24ui?.accordion || {}) })({
   disabled: props.disabled
 }))
 </script>

--- a/src/runtime/components/Advice.vue
+++ b/src/runtime/components/Advice.vue
@@ -55,7 +55,7 @@ const { isLeading, leadingIconName } = useComponentIcons(
 )
 
 // eslint-disable-next-line vue/no-dupe-keys
-const b24ui = computed(() => tv({ extend: tv(theme), ...(appConfig.b24ui?.advice || {}) })({
+const b24ui = computed(() => tv({ extend: theme, ...(appConfig.b24ui?.advice || {}) })({
   angle: props.angle
 }))
 </script>

--- a/src/runtime/components/Alert.vue
+++ b/src/runtime/components/Alert.vue
@@ -104,7 +104,7 @@ const { t } = useLocale()
 const appConfig = useAppConfig() as Alert['AppConfig']
 
 // eslint-disable-next-line vue/no-dupe-keys
-const b24ui = computed(() => tv({ extend: tv(theme), ...(appConfig.b24ui?.alert || {}) })({
+const b24ui = computed(() => tv({ extend: theme, ...(appConfig.b24ui?.alert || {}) })({
   color: props.color,
   inverted: Boolean(props.inverted),
   size: props.size,

--- a/src/runtime/components/Avatar.vue
+++ b/src/runtime/components/Avatar.vue
@@ -81,7 +81,7 @@ const appConfig = useAppConfig() as Avatar['AppConfig']
 const { size, color } = useAvatarGroup(_props)
 
 // eslint-disable-next-line vue/no-dupe-keys
-const b24ui = computed(() => tv({ extend: tv(theme), ...(appConfig.b24ui?.avatar || {}) })({
+const b24ui = computed(() => tv({ extend: theme, ...(appConfig.b24ui?.avatar || {}) })({
   size: size.value ?? props.size,
   color: color.value ?? props.color
 }))

--- a/src/runtime/components/AvatarGroup.vue
+++ b/src/runtime/components/AvatarGroup.vue
@@ -50,7 +50,7 @@ const props = useComponentProps('avatarGroup', _props)
 const appConfig = useAppConfig() as AvatarGroup['AppConfig']
 
 // eslint-disable-next-line vue/no-dupe-keys
-const b24ui = computed(() => tv({ extend: tv(theme), ...(appConfig.b24ui?.avatarGroup || {}) })({
+const b24ui = computed(() => tv({ extend: theme, ...(appConfig.b24ui?.avatarGroup || {}) })({
   size: props.size,
   color: props.color
 }))

--- a/src/runtime/components/Badge.vue
+++ b/src/runtime/components/Badge.vue
@@ -86,7 +86,7 @@ const { orientation, size: fieldGroupSize } = useFieldGroup<BadgeProps>(_props)
 const { isLeading, leadingIconName } = useComponentIcons(props)
 
 // eslint-disable-next-line vue/no-dupe-keys
-const b24ui = computed(() => tv({ extend: tv(theme), ...(appConfig.b24ui?.badge || {}) })({
+const b24ui = computed(() => tv({ extend: theme, ...(appConfig.b24ui?.badge || {}) })({
   color: props.color,
   inverted: Boolean(props.inverted),
   size: fieldGroupSize.value ?? props.size,

--- a/src/runtime/components/Banner.vue
+++ b/src/runtime/components/Banner.vue
@@ -92,7 +92,7 @@ const appConfig = useAppConfig() as Banner['AppConfig']
 const prefix = usePrefix()
 
 // eslint-disable-next-line vue/no-dupe-keys
-const b24ui = computed(() => tv({ extend: tv(theme), ...(appConfig.b24ui?.banner || {}) })({
+const b24ui = computed(() => tv({ extend: theme, ...(appConfig.b24ui?.banner || {}) })({
   color: props.color,
   to: !!props.to
 }))

--- a/src/runtime/components/Breadcrumb.vue
+++ b/src/runtime/components/Breadcrumb.vue
@@ -93,7 +93,7 @@ const appConfig = useAppConfig() as Breadcrumb['AppConfig']
 const separatorIcon = computed(() => props.separatorIcon || (dir.value === 'rtl' ? icons.chevronLeft : icons.chevronRight))
 
 // eslint-disable-next-line vue/no-dupe-keys
-const b24ui = computed(() => tv({ extend: tv(theme), ...(appConfig.b24ui?.breadcrumb || {}) })({
+const b24ui = computed(() => tv({ extend: theme, ...(appConfig.b24ui?.breadcrumb || {}) })({
   color: props.color
 }))
 </script>

--- a/src/runtime/components/Button.vue
+++ b/src/runtime/components/Button.vue
@@ -155,7 +155,7 @@ const isLabel = computed(() => {
 
 // eslint-disable-next-line vue/no-dupe-keys
 const b24ui = computed(() => tv({
-  extend: tv(theme),
+  extend: theme,
   ...defu({
     variants: {
       active: {

--- a/src/runtime/components/Calendar.vue
+++ b/src/runtime/components/Calendar.vue
@@ -154,7 +154,7 @@ const prevYearIcon = computed(() => props.prevYearIcon || (dir.value === 'rtl' ?
 const prevMonthIcon = computed(() => props.prevMonthIcon || (dir.value === 'rtl' ? icons.chevronRight : icons.chevronLeft))
 
 // eslint-disable-next-line vue/no-dupe-keys
-const b24ui = computed(() => tv({ extend: tv(theme), ...(appConfig.b24ui?.calendar || {}) })({
+const b24ui = computed(() => tv({ extend: theme, ...(appConfig.b24ui?.calendar || {}) })({
   color: props.color,
   size: props.size,
   weekNumbers: props.weekNumbers

--- a/src/runtime/components/Card.vue
+++ b/src/runtime/components/Card.vue
@@ -46,7 +46,7 @@ const props = useComponentProps('card', _props)
 const appConfig = useAppConfig() as Card['AppConfig']
 
 // eslint-disable-next-line vue/no-dupe-keys
-const b24ui = computed(() => tv({ extend: tv(theme), ...(appConfig.b24ui?.card || {}) })({
+const b24ui = computed(() => tv({ extend: theme, ...(appConfig.b24ui?.card || {}) })({
   variant: props.variant
 }))
 </script>

--- a/src/runtime/components/ChatMessage.vue
+++ b/src/runtime/components/ChatMessage.vue
@@ -88,7 +88,7 @@ const textParts = computed(() => props.parts?.filter((part): part is TextUIPart 
 const messageProps = computed(() => omit(props, ['as', 'icon', 'avatar', 'variant', 'color', 'side', 'actions', 'compact', 'class', 'b24ui']))
 
 // eslint-disable-next-line vue/no-dupe-keys
-const b24ui = computed(() => tv({ extend: tv(theme), ...(appConfig.b24ui?.chatMessage || {}) })({
+const b24ui = computed(() => tv({ extend: theme, ...(appConfig.b24ui?.chatMessage || {}) })({
   variant: props.variant,
   color: props.color,
   side: props.side,

--- a/src/runtime/components/ChatMessages.vue
+++ b/src/runtime/components/ChatMessages.vue
@@ -123,7 +123,7 @@ const userProps = toRef(() => defu(props.user, { side: 'right' as const, variant
 const assistantProps = toRef(() => defu(props.assistant, { side: 'left' as const, variant: 'message' as const }))
 
 // eslint-disable-next-line vue/no-dupe-keys
-const b24ui = computed(() => tv({ extend: tv(theme), ...(appConfig.b24ui?.chatMessages || {}) })({
+const b24ui = computed(() => tv({ extend: theme, ...(appConfig.b24ui?.chatMessages || {}) })({
   compact: props.compact
 }))
 

--- a/src/runtime/components/ChatPalette.vue
+++ b/src/runtime/components/ChatPalette.vue
@@ -37,7 +37,7 @@ const props = useComponentProps('chatPalette', _props)
 const appConfig = useAppConfig() as ChatPalette['AppConfig']
 
 // eslint-disable-next-line vue/no-dupe-keys
-const b24ui = computed(() => tv({ extend: tv(theme), ...(appConfig.b24ui?.chatPalette || {}) })())
+const b24ui = computed(() => tv({ extend: theme, ...(appConfig.b24ui?.chatPalette || {}) })())
 </script>
 
 <template>

--- a/src/runtime/components/ChatPrompt.vue
+++ b/src/runtime/components/ChatPrompt.vue
@@ -83,7 +83,7 @@ const textareaProps = useForwardProps(reactivePick(props, 'rows', 'autofocus', '
 const getProxySlots = () => omit(slots, ['header', 'footer', 'default'])
 
 // eslint-disable-next-line vue/no-dupe-keys
-const b24ui = computed(() => tv({ extend: tv(theme), ...(appConfig.b24ui?.chatPrompt || {}) })({
+const b24ui = computed(() => tv({ extend: theme, ...(appConfig.b24ui?.chatPrompt || {}) })({
   variant: props.variant
 }))
 

--- a/src/runtime/components/ChatPromptSubmit.vue
+++ b/src/runtime/components/ChatPromptSubmit.vue
@@ -129,7 +129,7 @@ const statusButtonProps = computed(() => ({
 } satisfies { [key: string]: ButtonProps })[props.status])
 
 // eslint-disable-next-line vue/no-dupe-keys
-const b24ui = computed(() => tv({ extend: tv(theme), ...(appConfig.b24ui?.chatPromptSubmit || {}) })())
+const b24ui = computed(() => tv({ extend: theme, ...(appConfig.b24ui?.chatPromptSubmit || {}) })())
 </script>
 
 <template>

--- a/src/runtime/components/ChatReasoning.vue
+++ b/src/runtime/components/ChatReasoning.vue
@@ -91,7 +91,7 @@ const { t, code } = useLocale()
 const appConfig = useAppConfig() as ChatReasoning['AppConfig']
 
 // eslint-disable-next-line vue/no-dupe-keys
-const b24ui = computed(() => tv({ extend: tv(theme), ...(appConfig.b24ui?.chatReasoning || {}) })({
+const b24ui = computed(() => tv({ extend: theme, ...(appConfig.b24ui?.chatReasoning || {}) })({
   chevron: props.chevron
 }))
 

--- a/src/runtime/components/ChatShimmer.vue
+++ b/src/runtime/components/ChatShimmer.vue
@@ -48,7 +48,7 @@ const props = useComponentProps('chatShimmer', _props)
 const appConfig = useAppConfig() as ChatShimmer['AppConfig']
 
 // eslint-disable-next-line vue/no-dupe-keys
-const b24ui = computed(() => tv({ extend: tv(theme), ...(appConfig.b24ui?.chatShimmer || {}) }))
+const b24ui = computed(() => tv({ extend: theme, ...(appConfig.b24ui?.chatShimmer || {}) }))
 
 // eslint-disable-next-line vue/no-dupe-keys
 const spread = computed(() => (props.text || '').length * props.spread)

--- a/src/runtime/components/ChatTool.vue
+++ b/src/runtime/components/ChatTool.vue
@@ -110,7 +110,7 @@ const props = useComponentProps('chatTool', _props)
 const appConfig = useAppConfig() as ChatTool['AppConfig']
 
 // eslint-disable-next-line vue/no-dupe-keys
-const b24ui = computed(() => tv({ extend: tv(theme), ...(appConfig.b24ui?.chatTool || {}) })({
+const b24ui = computed(() => tv({ extend: theme, ...(appConfig.b24ui?.chatTool || {}) })({
   variant: props.variant,
   chevron: props.chevron,
   loading: Boolean(props.loading),

--- a/src/runtime/components/Checkbox.vue
+++ b/src/runtime/components/Checkbox.vue
@@ -84,7 +84,7 @@ const forwardedAttrs = computed(() => {
 })
 
 // eslint-disable-next-line vue/no-dupe-keys
-const b24ui = computed(() => tv({ extend: tv(theme), ...(appConfig.b24ui?.checkbox || {}) })({
+const b24ui = computed(() => tv({ extend: theme, ...(appConfig.b24ui?.checkbox || {}) })({
   size: size.value ?? props.size,
   color: color.value ?? props.color,
   variant: props.variant,

--- a/src/runtime/components/Chip.vue
+++ b/src/runtime/components/Chip.vue
@@ -95,7 +95,7 @@ const show = defineModel<boolean>('show', { default: true })
 const appConfig = useAppConfig() as Chip['AppConfig']
 
 // eslint-disable-next-line vue/no-dupe-keys
-const b24ui = computed(() => tv({ extend: tv(theme), ...(appConfig.b24ui?.chip || {}) })({
+const b24ui = computed(() => tv({ extend: theme, ...(appConfig.b24ui?.chip || {}) })({
   color: props.color,
   inverted: Boolean(props.inverted),
   size: props.size, // size.value ?? props.size

--- a/src/runtime/components/Collapsible.vue
+++ b/src/runtime/components/Collapsible.vue
@@ -47,7 +47,7 @@ const appConfig = useAppConfig() as Collapsible['AppConfig']
 const rootProps = useForwardProps(reactivePick(props, 'as', 'defaultOpen', 'open', 'disabled', 'unmountOnHide'), emits)
 
 // eslint-disable-next-line vue/no-dupe-keys
-const b24ui = computed(() => tv({ extend: tv(theme), ...(appConfig.b24ui?.collapsible || {}) })())
+const b24ui = computed(() => tv({ extend: theme, ...(appConfig.b24ui?.collapsible || {}) })())
 </script>
 
 <template>

--- a/src/runtime/components/ColorPicker.vue
+++ b/src/runtime/components/ColorPicker.vue
@@ -93,7 +93,7 @@ const modelValue = defineModel<string>(undefined)
 const appConfig = useAppConfig() as ColorPicker['AppConfig']
 
 // eslint-disable-next-line vue/no-dupe-keys
-const b24ui = computed(() => tv({ extend: tv(theme), ...(appConfig.b24ui?.colorPicker || {}) })({
+const b24ui = computed(() => tv({ extend: theme, ...(appConfig.b24ui?.colorPicker || {}) })({
   size: props.size
 }))
 

--- a/src/runtime/components/CommandPalette.vue
+++ b/src/runtime/components/CommandPalette.vue
@@ -305,7 +305,7 @@ const [DefineItemTemplate, ReuseItemTemplate] = createReusableTemplate<{ item: C
 })
 
 // eslint-disable-next-line vue/no-dupe-keys
-const b24ui = computed(() => tv({ extend: tv(theme), ...(appConfig.b24ui?.commandPalette || {}) })({
+const b24ui = computed(() => tv({ extend: theme, ...(appConfig.b24ui?.commandPalette || {}) })({
   size: props.size,
   virtualize: !!props.virtualize
 }))

--- a/src/runtime/components/Container.vue
+++ b/src/runtime/components/Container.vue
@@ -37,7 +37,7 @@ const props = useComponentProps('container', _props)
 const appConfig = useAppConfig() as Container['AppConfig']
 
 // eslint-disable-next-line vue/no-dupe-keys
-const b24ui = computed(() => tv({ extend: tv(theme), ...(appConfig.b24ui?.container || {}) }))
+const b24ui = computed(() => tv({ extend: theme, ...(appConfig.b24ui?.container || {}) }))
 </script>
 
 <template>

--- a/src/runtime/components/ContextMenu.vue
+++ b/src/runtime/components/ContextMenu.vue
@@ -138,7 +138,7 @@ const contentProps = toRef(() => props.content)
 const getProxySlots = () => omit(slots, ['default'])
 
 // eslint-disable-next-line vue/no-dupe-keys
-const b24ui = computed(() => tv({ extend: tv(theme), ...(appConfig.b24ui?.contextMenu || {}) })({}))
+const b24ui = computed(() => tv({ extend: theme, ...(appConfig.b24ui?.contextMenu || {}) })({}))
 </script>
 
 <template>

--- a/src/runtime/components/Countdown.vue
+++ b/src/runtime/components/Countdown.vue
@@ -123,7 +123,7 @@ const { isLeading, leadingIconName } = useComponentIcons(
 const appConfig = useAppConfig() as Countdown['AppConfig']
 
 // eslint-disable-next-line vue/no-dupe-keys
-const b24ui = computed(() => tv({ extend: tv(theme), ...(appConfig.b24ui?.countdown || {}) })({
+const b24ui = computed(() => tv({ extend: theme, ...(appConfig.b24ui?.countdown || {}) })({
   size: props.size,
   leading: Boolean(isLeading.value),
   useCircle: Boolean(props.useCircle)

--- a/src/runtime/components/DashboardGroup.vue
+++ b/src/runtime/components/DashboardGroup.vue
@@ -44,7 +44,7 @@ const nuxtApp = useNuxtApp()
 const appConfig = useAppConfig() as DashboardGroup['AppConfig']
 
 // eslint-disable-next-line vue/no-dupe-keys
-const b24ui = computed(() => tv({ extend: tv(theme), ...(appConfig.b24ui?.dashboardGroup || {}) }))
+const b24ui = computed(() => tv({ extend: theme, ...(appConfig.b24ui?.dashboardGroup || {}) }))
 
 const sidebarOpen = ref(false)
 const sidebarCollapsed = ref(false)

--- a/src/runtime/components/DashboardNavbar.vue
+++ b/src/runtime/components/DashboardNavbar.vue
@@ -76,7 +76,7 @@ const dashboardContext = useDashboard({})
 const [DefineToggleTemplate, ReuseToggleTemplate] = createReusableTemplate()
 
 // eslint-disable-next-line vue/no-dupe-keys
-const b24ui = computed(() => tv({ extend: tv(theme), ...(appConfig.b24ui?.dashboardNavbar || {}) })())
+const b24ui = computed(() => tv({ extend: theme, ...(appConfig.b24ui?.dashboardNavbar || {}) })())
 </script>
 
 <template>

--- a/src/runtime/components/DashboardPanel.vue
+++ b/src/runtime/components/DashboardPanel.vue
@@ -48,7 +48,7 @@ const id = `${dashboardContext.storageKey}-panel-${props.id || useId()}`
 const { el, size, isDragging, onMouseDown, onTouchStart, onDoubleClick } = useResizable(id, toRef(() => ({ ...dashboardContext, ...props })))
 
 // eslint-disable-next-line vue/no-dupe-keys
-const b24ui = computed(() => tv({ extend: tv(theme), ...(appConfig.b24ui?.dashboardPanel || {}) })({
+const b24ui = computed(() => tv({ extend: theme, ...(appConfig.b24ui?.dashboardPanel || {}) })({
   size: !!size.value
 }))
 </script>

--- a/src/runtime/components/DashboardResizeHandle.vue
+++ b/src/runtime/components/DashboardResizeHandle.vue
@@ -36,7 +36,7 @@ const props = useComponentProps('dashboardResizeHandle', _props)
 const appConfig = useAppConfig() as DashboardResizeHandle['AppConfig']
 
 // eslint-disable-next-line vue/no-dupe-keys
-const b24ui = computed(() => tv({ extend: tv(theme), ...(appConfig.b24ui?.dashboardResizeHandle || {}) }))
+const b24ui = computed(() => tv({ extend: theme, ...(appConfig.b24ui?.dashboardResizeHandle || {}) }))
 </script>
 
 <template>

--- a/src/runtime/components/DashboardSearch.vue
+++ b/src/runtime/components/DashboardSearch.vue
@@ -132,7 +132,7 @@ const fuse = computed(() => defu({}, props.fuse, {
 }))
 
 // eslint-disable-next-line vue/no-dupe-keys
-const b24ui = computed(() => tv({ extend: tv(theme), ...(appConfig.b24ui?.dashboardSearch || {}) })({
+const b24ui = computed(() => tv({ extend: theme, ...(appConfig.b24ui?.dashboardSearch || {}) })({
   size: props.size,
   fullscreen: props.fullscreen
 }))

--- a/src/runtime/components/DashboardSearchButton.vue
+++ b/src/runtime/components/DashboardSearchButton.vue
@@ -88,7 +88,7 @@ const appConfig = useAppConfig() as DashboardSearchButton['AppConfig']
 const { toggleSearch } = useDashboard({ toggleSearch: () => {} })
 
 // eslint-disable-next-line vue/no-dupe-keys
-const b24ui = computed(() => tv({ extend: tv(theme), ...(appConfig.b24ui?.dashboardSearchButton || {}) })({
+const b24ui = computed(() => tv({ extend: theme, ...(appConfig.b24ui?.dashboardSearchButton || {}) })({
   collapsed: props.collapsed
 }))
 </script>

--- a/src/runtime/components/DashboardSidebar.vue
+++ b/src/runtime/components/DashboardSidebar.vue
@@ -129,7 +129,7 @@ watch(() => route.fullPath, () => {
 })
 
 // eslint-disable-next-line vue/no-dupe-keys
-const b24ui = computed(() => tv({ extend: tv(theme), ...(appConfig.b24ui?.dashboardSidebar || {}) })({
+const b24ui = computed(() => tv({ extend: theme, ...(appConfig.b24ui?.dashboardSidebar || {}) })({
   side: props.side
 }))
 

--- a/src/runtime/components/DashboardSidebarCollapse.vue
+++ b/src/runtime/components/DashboardSidebarCollapse.vue
@@ -47,7 +47,7 @@ const appConfig = useAppConfig() as DashboardSidebarCollapse['AppConfig']
 const { sidebarCollapsed, collapseSidebar } = useDashboard({ sidebarCollapsed: ref(false), collapseSidebar: () => {} })
 
 // eslint-disable-next-line vue/no-dupe-keys
-const b24ui = computed(() => tv({ extend: tv(theme), ...(appConfig.b24ui?.dashboardSidebarCollapse || {}) }))
+const b24ui = computed(() => tv({ extend: theme, ...(appConfig.b24ui?.dashboardSidebarCollapse || {}) }))
 </script>
 
 <template>

--- a/src/runtime/components/DashboardSidebarToggle.vue
+++ b/src/runtime/components/DashboardSidebarToggle.vue
@@ -49,7 +49,7 @@ const appConfig = useAppConfig() as DashboardSidebarToggle['AppConfig']
 const { sidebarOpen, toggleSidebar } = useDashboard({ sidebarOpen: ref(false), toggleSidebar: () => {} })
 
 // eslint-disable-next-line vue/no-dupe-keys
-const b24ui = computed(() => tv({ extend: tv(theme), ...(appConfig.b24ui?.dashboardSidebarToggle || {}) }))
+const b24ui = computed(() => tv({ extend: theme, ...(appConfig.b24ui?.dashboardSidebarToggle || {}) }))
 </script>
 
 <template>

--- a/src/runtime/components/DashboardToolbar.vue
+++ b/src/runtime/components/DashboardToolbar.vue
@@ -39,7 +39,7 @@ const props = useComponentProps('dashboardToolbar', _props)
 const appConfig = useAppConfig() as DashboardToolbar['AppConfig']
 
 // eslint-disable-next-line vue/no-dupe-keys
-const b24ui = computed(() => tv({ extend: tv(theme), ...(appConfig.b24ui?.dashboardToolbar || {}) })())
+const b24ui = computed(() => tv({ extend: theme, ...(appConfig.b24ui?.dashboardToolbar || {}) })())
 </script>
 
 <template>

--- a/src/runtime/components/DescriptionList.vue
+++ b/src/runtime/components/DescriptionList.vue
@@ -95,7 +95,7 @@ const props = useComponentProps<DescriptionListProps<T>>('descriptionList', _pro
 const appConfig = useAppConfig() as DescriptionList['AppConfig']
 
 // eslint-disable-next-line vue/no-dupe-keys
-const b24ui = computed(() => tv({ extend: tv(theme), ...(appConfig.b24ui?.descriptionList || {}) })({
+const b24ui = computed(() => tv({ extend: theme, ...(appConfig.b24ui?.descriptionList || {}) })({
   size: props.size
 }))
 

--- a/src/runtime/components/Drawer.vue
+++ b/src/runtime/components/Drawer.vue
@@ -126,7 +126,7 @@ const contentEvents = computed(() => {
 })
 
 // eslint-disable-next-line vue/no-dupe-keys
-const b24ui = computed(() => tv({ extend: tv(theme), ...(appConfig.b24ui?.drawer || {}) })({
+const b24ui = computed(() => tv({ extend: theme, ...(appConfig.b24ui?.drawer || {}) })({
   direction: props.direction,
   inset: props.inset,
   snapPoints: props.snapPoints && props.snapPoints.length > 0,

--- a/src/runtime/components/DropdownMenu.vue
+++ b/src/runtime/components/DropdownMenu.vue
@@ -172,7 +172,7 @@ const arrowProps = toRef(() => defu(typeof props.arrow === 'boolean' ? {} : prop
 const getProxySlots = () => omit(slots, ['default'])
 
 // eslint-disable-next-line vue/no-dupe-keys
-const b24ui = computed(() => tv({ extend: tv(theme), ...(appConfig.b24ui?.dropdownMenu || {}) })({}))
+const b24ui = computed(() => tv({ extend: theme, ...(appConfig.b24ui?.dropdownMenu || {}) })({}))
 </script>
 
 <template>

--- a/src/runtime/components/Editor.vue
+++ b/src/runtime/components/Editor.vue
@@ -121,7 +121,7 @@ const attrs = useAttrs()
 const appConfig = useAppConfig() as Editor['AppConfig']
 
 // eslint-disable-next-line vue/no-dupe-keys
-const b24ui = computed(() => tv({ extend: tv(theme), ...(appConfig.b24ui?.editor || {}) })({
+const b24ui = computed(() => tv({ extend: theme, ...(appConfig.b24ui?.editor || {}) })({
   placeholderMode: typeof props.placeholder === 'object' ? props.placeholder.mode : undefined
 }))
 

--- a/src/runtime/components/EditorDragHandle.vue
+++ b/src/runtime/components/EditorDragHandle.vue
@@ -74,7 +74,7 @@ const buttonProps = useForwardProps(reactiveOmit(props, 'icon', 'options', 'edit
 const appConfig = useAppConfig() as EditorDragHandle['AppConfig']
 
 // eslint-disable-next-line vue/no-dupe-keys
-const b24ui = computed(() => tv({ extend: tv(theme), ...(appConfig.b24ui?.editorDragHandle || {}) })())
+const b24ui = computed(() => tv({ extend: theme, ...(appConfig.b24ui?.editorDragHandle || {}) })())
 
 const floatingUIOptions = computed(() => defu(props.options, {
   strategy: 'absolute' as Strategy,

--- a/src/runtime/components/EditorEmojiMenu.vue
+++ b/src/runtime/components/EditorEmojiMenu.vue
@@ -43,7 +43,7 @@ const props = withDefaults(defineProps<EditorEmojiMenuProps<T>>(), {
 
 const appConfig = useAppConfig() as EditorEmojiMenu['AppConfig']
 
-const b24ui = computed(() => tv({ extend: tv(theme), ...(appConfig.b24ui?.editorEmojiMenu || {}) })({
+const b24ui = computed(() => tv({ extend: theme, ...(appConfig.b24ui?.editorEmojiMenu || {}) })({
   size: props.size
 }))
 

--- a/src/runtime/components/EditorMentionMenu.vue
+++ b/src/runtime/components/EditorMentionMenu.vue
@@ -48,7 +48,7 @@ const props = withDefaults(defineProps<EditorMentionMenuProps<T>>(), {
 
 const appConfig = useAppConfig() as EditorMentionMenu['AppConfig']
 
-const b24ui = computed(() => tv({ extend: tv(theme), ...(appConfig.b24ui?.editorMentionMenu || {}) })({
+const b24ui = computed(() => tv({ extend: theme, ...(appConfig.b24ui?.editorMentionMenu || {}) })({
   size: props.size
 }))
 

--- a/src/runtime/components/EditorSuggestionMenu.vue
+++ b/src/runtime/components/EditorSuggestionMenu.vue
@@ -68,7 +68,7 @@ const appConfig = useAppConfig() as EditorSuggestionMenu['AppConfig']
 
 const handlers = inject('editorHandlers', computed(() => createHandlers()))
 
-const b24ui = computed(() => tv({ extend: tv(theme), ...(appConfig.b24ui?.editorSuggestionMenu || {}) })({
+const b24ui = computed(() => tv({ extend: theme, ...(appConfig.b24ui?.editorSuggestionMenu || {}) })({
   size: props.size
 }))
 

--- a/src/runtime/components/EditorToolbar.vue
+++ b/src/runtime/components/EditorToolbar.vue
@@ -136,7 +136,7 @@ const options = computed(() => defu((props as any).options, {
 }))
 
 // eslint-disable-next-line vue/no-dupe-keys
-const b24ui = computed(() => tv({ extend: tv(theme), ...(appConfig.b24ui?.editorToolbar || {}) })({
+const b24ui = computed(() => tv({ extend: theme, ...(appConfig.b24ui?.editorToolbar || {}) })({
   layout: props.layout
 }))
 

--- a/src/runtime/components/Empty.vue
+++ b/src/runtime/components/Empty.vue
@@ -72,7 +72,7 @@ const props = useComponentProps('empty', _props)
 const appConfig = useAppConfig() as Empty['AppConfig']
 
 // eslint-disable-next-line vue/no-dupe-keys
-const b24ui = computed(() => tv({ extend: tv(theme), ...(appConfig.b24ui?.empty || {}) })({
+const b24ui = computed(() => tv({ extend: theme, ...(appConfig.b24ui?.empty || {}) })({
   color: props.color,
   inverted: Boolean(props.inverted),
   size: props.size

--- a/src/runtime/components/Error.vue
+++ b/src/runtime/components/Error.vue
@@ -79,7 +79,7 @@ const { t } = useLocale()
 const appConfig = useAppConfig() as Error['AppConfig']
 
 // eslint-disable-next-line vue/no-dupe-keys
-const b24ui = computed(() => tv({ extend: tv(theme), ...(appConfig.b24ui?.error || {}) })())
+const b24ui = computed(() => tv({ extend: theme, ...(appConfig.b24ui?.error || {}) })())
 
 function handleError() {
   clearError({ redirect: props.redirect })

--- a/src/runtime/components/FieldGroup.vue
+++ b/src/runtime/components/FieldGroup.vue
@@ -54,7 +54,7 @@ const props = useComponentProps('fieldGroup', _props)
 const appConfig = useAppConfig() as FieldGroup['AppConfig']
 
 // eslint-disable-next-line vue/no-dupe-keys
-const b24ui = computed(() => tv({ extend: tv(theme), ...(appConfig.b24ui?.fieldGroup || {}) }))
+const b24ui = computed(() => tv({ extend: theme, ...(appConfig.b24ui?.fieldGroup || {}) }))
 
 provide(fieldGroupInjectionKey, computed(() => ({
   orientation: props.orientation,

--- a/src/runtime/components/FileUpload.vue
+++ b/src/runtime/components/FileUpload.vue
@@ -207,7 +207,7 @@ const position = computed(() => {
 })
 
 // eslint-disable-next-line vue/no-dupe-keys
-const b24ui = computed(() => tv({ extend: tv(theme), ...(appConfig.b24ui?.fileUpload || {}) })({
+const b24ui = computed(() => tv({ extend: theme, ...(appConfig.b24ui?.fileUpload || {}) })({
   dropzone: props.dropzone,
   interactive: props.interactive,
   color: color.value ?? props.color,

--- a/src/runtime/components/Footer.vue
+++ b/src/runtime/components/Footer.vue
@@ -43,7 +43,7 @@ const props = useComponentProps('footer', _props)
 const appConfig = useAppConfig() as Footer['AppConfig']
 
 // eslint-disable-next-line vue/no-dupe-keys
-const b24ui = computed(() => tv({ extend: tv(theme), ...(appConfig.b24ui?.footer || {}) })())
+const b24ui = computed(() => tv({ extend: theme, ...(appConfig.b24ui?.footer || {}) })())
 </script>
 
 <template>

--- a/src/runtime/components/FooterColumns.vue
+++ b/src/runtime/components/FooterColumns.vue
@@ -69,7 +69,7 @@ const props = useComponentProps<FooterColumnsProps<T>>('footerColumns', _props)
 const appConfig = useAppConfig() as FooterColumns['AppConfig']
 
 // eslint-disable-next-line vue/no-dupe-keys
-const b24ui = computed(() => tv({ extend: tv(theme), ...(appConfig.b24ui?.footerColumns || {}) })())
+const b24ui = computed(() => tv({ extend: theme, ...(appConfig.b24ui?.footerColumns || {}) })())
 </script>
 
 <template>

--- a/src/runtime/components/Form.vue
+++ b/src/runtime/components/Form.vue
@@ -105,7 +105,7 @@ const props = useComponentProps<FormProps<S, T, N>>('form', _props)
 const appConfig = useAppConfig() as FormConfig['AppConfig']
 
 // eslint-disable-next-line vue/no-dupe-keys
-const b24ui = computed(() => tv({ extend: tv(theme), ...(appConfig.b24ui?.form || {}) }))
+const b24ui = computed(() => tv({ extend: theme, ...(appConfig.b24ui?.form || {}) }))
 
 const formId = props.id ?? useId() as string
 const formRef = useTemplateRef('formRef')

--- a/src/runtime/components/FormField.vue
+++ b/src/runtime/components/FormField.vue
@@ -76,7 +76,7 @@ const props = useComponentProps('formField', _props)
 const appConfig = useAppConfig() as FormField['AppConfig']
 
 // eslint-disable-next-line vue/no-dupe-keys
-const b24ui = computed(() => tv({ extend: tv(theme), ...(appConfig.b24ui?.formField || {}) })({
+const b24ui = computed(() => tv({ extend: theme, ...(appConfig.b24ui?.formField || {}) })({
   size: props.size,
   required: props.required,
   orientation: props.orientation,

--- a/src/runtime/components/Header.vue
+++ b/src/runtime/components/Header.vue
@@ -118,7 +118,7 @@ watch(() => route.fullPath, () => {
 })
 
 // eslint-disable-next-line vue/no-dupe-keys
-const b24ui = computed(() => tv({ extend: tv(theme), ...(appConfig.b24ui?.header || {}) })())
+const b24ui = computed(() => tv({ extend: theme, ...(appConfig.b24ui?.header || {}) })())
 
 const Menu = computed(() => ({
   slideover: B24Slideover,

--- a/src/runtime/components/Input.vue
+++ b/src/runtime/components/Input.vue
@@ -144,7 +144,7 @@ const isTag = computed(() => {
 })
 
 // eslint-disable-next-line vue/no-dupe-keys
-const b24ui = computed(() => tv({ extend: tv(theme), ...(appConfig.b24ui?.input || {}) })({
+const b24ui = computed(() => tv({ extend: theme, ...(appConfig.b24ui?.input || {}) })({
   type: props.type as Input['variants']['type'],
   color: color.value ?? props.color,
   size: inputSize?.value ?? props.size,

--- a/src/runtime/components/InputDate.vue
+++ b/src/runtime/components/InputDate.vue
@@ -139,7 +139,7 @@ const isTag = computed(() => {
 })
 
 // eslint-disable-next-line vue/no-dupe-keys
-const b24ui = computed(() => tv({ extend: tv(theme), ...(appConfig.b24ui?.inputDate || {}) })({
+const b24ui = computed(() => tv({ extend: theme, ...(appConfig.b24ui?.inputDate || {}) })({
   color: color.value ?? props.color,
   size: inputSize.value ?? props.size,
   loading: props.loading,

--- a/src/runtime/components/InputMenu.vue
+++ b/src/runtime/components/InputMenu.vue
@@ -344,7 +344,7 @@ const [DefineItemTemplate, ReuseItemTemplate] = createReusableTemplate<{ item: I
 })
 
 // eslint-disable-next-line vue/no-dupe-keys
-const b24ui = computed(() => tv({ extend: tv(theme), ...(appConfig.b24ui?.inputMenu || {}) })({
+const b24ui = computed(() => tv({ extend: theme, ...(appConfig.b24ui?.inputMenu || {}) })({
   color: color.value ?? props.color,
   size: inputSize?.value ?? props.size,
   loading: props.loading,

--- a/src/runtime/components/InputNumber.vue
+++ b/src/runtime/components/InputNumber.vue
@@ -154,7 +154,7 @@ const isTag = computed(() => {
 })
 
 // eslint-disable-next-line vue/no-dupe-keys
-const b24ui = computed(() => tv({ extend: tv(theme), ...(appConfig.b24ui?.inputNumber || {}) })({
+const b24ui = computed(() => tv({ extend: theme, ...(appConfig.b24ui?.inputNumber || {}) })({
   color: color.value ?? props.color,
   size: inputSize.value ?? props.size,
   highlight: highlight.value ?? props.highlight,

--- a/src/runtime/components/InputTags.vue
+++ b/src/runtime/components/InputTags.vue
@@ -126,7 +126,7 @@ const isTag = computed(() => {
 })
 
 // eslint-disable-next-line vue/no-dupe-keys
-const b24ui = computed(() => tv({ extend: tv(theme), ...(appConfig.b24ui?.inputTags || {}) })({
+const b24ui = computed(() => tv({ extend: theme, ...(appConfig.b24ui?.inputTags || {}) })({
   color: color.value ?? props.color,
   size: inputSize?.value ?? props.size,
   loading: props.loading,

--- a/src/runtime/components/InputTime.vue
+++ b/src/runtime/components/InputTime.vue
@@ -146,7 +146,7 @@ const isTag = computed(() => {
 })
 
 // eslint-disable-next-line vue/no-dupe-keys
-const b24ui = computed(() => tv({ extend: tv(theme), ...(appConfig.b24ui?.inputTime || {}) })({
+const b24ui = computed(() => tv({ extend: theme, ...(appConfig.b24ui?.inputTime || {}) })({
   color: color.value ?? props.color,
   size: inputSize.value ?? props.size,
   loading: props.loading,

--- a/src/runtime/components/Kbd.vue
+++ b/src/runtime/components/Kbd.vue
@@ -55,7 +55,7 @@ const { getKbdKey } = useKbd()
 const appConfig = useAppConfig() as Kbd['AppConfig']
 
 // eslint-disable-next-line vue/no-dupe-keys
-const b24ui = computed(() => tv({ extend: tv(theme), ...(appConfig.b24ui?.kbd || {}) })({
+const b24ui = computed(() => tv({ extend: theme, ...(appConfig.b24ui?.kbd || {}) })({
   accent: props.accent,
   size: props.size
 }))

--- a/src/runtime/components/Link.vue
+++ b/src/runtime/components/Link.vue
@@ -148,7 +148,7 @@ const nuxtApp = useNuxtApp()
 const nuxtLinkProps = useForwardProps(reactiveOmit(props, 'as', 'type', 'disabled', 'active', 'exact', 'exactQuery', 'exactHash', 'activeClass', 'inactiveClass', 'to', 'href', 'raw', 'custom', 'locale', 'class'))
 
 const b24ui = computed(() => tv({
-  extend: tv(theme),
+  extend: theme,
   ...defu({
     variants: {
       active: {

--- a/src/runtime/components/Main.vue
+++ b/src/runtime/components/Main.vue
@@ -39,7 +39,7 @@ const props = useComponentProps('main', _props)
 const appConfig = useAppConfig() as Main['AppConfig']
 
 // eslint-disable-next-line vue/no-dupe-keys
-const b24ui = computed(() => tv({ extend: tv(theme), ...(appConfig.b24ui?.main || {}) }))
+const b24ui = computed(() => tv({ extend: theme, ...(appConfig.b24ui?.main || {}) }))
 </script>
 
 <template>

--- a/src/runtime/components/Modal.vue
+++ b/src/runtime/components/Modal.vue
@@ -151,7 +151,7 @@ const contentEvents = computed(() => {
 const [DefineContentTemplate, ReuseContentTemplate] = createReusableTemplate()
 
 // eslint-disable-next-line vue/no-dupe-keys
-const b24ui = computed(() => tv({ extend: tv(theme), ...(appConfig.b24ui?.modal || {}) })({
+const b24ui = computed(() => tv({ extend: theme, ...(appConfig.b24ui?.modal || {}) })({
   transition: props.transition,
   fullscreen: props.fullscreen,
   overlayBlur: props.overlayBlur,

--- a/src/runtime/components/Navbar.vue
+++ b/src/runtime/components/Navbar.vue
@@ -47,7 +47,7 @@ const props = useComponentProps('navbar', _props)
 const appConfig = useAppConfig() as Navbar['AppConfig']
 
 // eslint-disable-next-line vue/no-dupe-keys
-const b24ui = computed(() => tv({ extend: tv(theme), ...(appConfig.b24ui?.navbar || {}) })())
+const b24ui = computed(() => tv({ extend: theme, ...(appConfig.b24ui?.navbar || {}) })())
 </script>
 
 <template>

--- a/src/runtime/components/NavbarDivider.vue
+++ b/src/runtime/components/NavbarDivider.vue
@@ -47,7 +47,7 @@ const props = useComponentProps('navbarDivider', _props)
 const appConfig = useAppConfig() as NavbarDivider['AppConfig']
 
 // eslint-disable-next-line vue/no-dupe-keys
-const b24ui = computed(() => tv({ extend: tv(theme), ...(appConfig.b24ui?.navbarDivider || {}) })())
+const b24ui = computed(() => tv({ extend: theme, ...(appConfig.b24ui?.navbarDivider || {}) })())
 </script>
 
 <template>

--- a/src/runtime/components/NavbarSection.vue
+++ b/src/runtime/components/NavbarSection.vue
@@ -47,7 +47,7 @@ const props = useComponentProps('navSection', _props)
 const appConfig = useAppConfig() as NavSection['AppConfig']
 
 // eslint-disable-next-line vue/no-dupe-keys
-const b24ui = computed(() => tv({ extend: tv(theme), ...(appConfig.b24ui?.navbarSection || {}) })())
+const b24ui = computed(() => tv({ extend: theme, ...(appConfig.b24ui?.navbarSection || {}) })())
 </script>
 
 <template>

--- a/src/runtime/components/NavbarSpacer.vue
+++ b/src/runtime/components/NavbarSpacer.vue
@@ -47,7 +47,7 @@ const props = useComponentProps('navbarSpacer', _props)
 const appConfig = useAppConfig() as NavbarSpacer['AppConfig']
 
 // eslint-disable-next-line vue/no-dupe-keys
-const b24ui = computed(() => tv({ extend: tv(theme), ...(appConfig.b24ui?.navbarSpacer || {}) })())
+const b24ui = computed(() => tv({ extend: theme, ...(appConfig.b24ui?.navbarSpacer || {}) })())
 </script>
 
 <template>

--- a/src/runtime/components/NavigationMenu.vue
+++ b/src/runtime/components/NavigationMenu.vue
@@ -294,7 +294,7 @@ const [DefineItemTemplate, ReuseItemTemplate] = createReusableTemplate<{ item: N
 })
 
 // eslint-disable-next-line vue/no-dupe-keys
-const b24ui = computed(() => tv({ extend: tv(theme), ...(appConfig.b24ui?.navigationMenu || {}) })({
+const b24ui = computed(() => tv({ extend: theme, ...(appConfig.b24ui?.navigationMenu || {}) })({
   orientation: props.orientation,
   collapsed: props.collapsed
 }))

--- a/src/runtime/components/Page.vue
+++ b/src/runtime/components/Page.vue
@@ -46,7 +46,7 @@ onBeforeUpdate(() => {
 })
 
 // eslint-disable-next-line vue/no-dupe-keys
-const b24ui = computed(() => tv({ extend: tv(theme), ...(appConfig.b24ui?.page || {}) })({
+const b24ui = computed(() => tv({ extend: theme, ...(appConfig.b24ui?.page || {}) })({
   left: hasLeft.value,
   right: hasRight.value
 }))

--- a/src/runtime/components/PageAside.vue
+++ b/src/runtime/components/PageAside.vue
@@ -40,7 +40,7 @@ const props = useComponentProps('pageAside', _props)
 const appConfig = useAppConfig() as PageAside['AppConfig']
 
 // eslint-disable-next-line vue/no-dupe-keys
-const b24ui = computed(() => tv({ extend: tv(theme), ...(appConfig.b24ui?.pageAside || {}) })())
+const b24ui = computed(() => tv({ extend: theme, ...(appConfig.b24ui?.pageAside || {}) })())
 </script>
 
 <template>

--- a/src/runtime/components/PageBody.vue
+++ b/src/runtime/components/PageBody.vue
@@ -37,7 +37,7 @@ const props = useComponentProps('pageBody', _props)
 const appConfig = useAppConfig() as PageBody['AppConfig']
 
 // eslint-disable-next-line vue/no-dupe-keys
-const b24ui = computed(() => tv({ extend: tv(theme), ...(appConfig.b24ui?.pageBody || {}) }))
+const b24ui = computed(() => tv({ extend: theme, ...(appConfig.b24ui?.pageBody || {}) }))
 </script>
 
 <template>

--- a/src/runtime/components/PageCard.vue
+++ b/src/runtime/components/PageCard.vue
@@ -98,7 +98,7 @@ const appConfig = useAppConfig() as PageCard['AppConfig']
 const prefix = usePrefix()
 
 // eslint-disable-next-line vue/no-dupe-keys
-const b24ui = computed(() => tv({ extend: tv(theme), ...(appConfig.b24ui?.pageCard || {}) })({
+const b24ui = computed(() => tv({ extend: theme, ...(appConfig.b24ui?.pageCard || {}) })({
   orientation: props.orientation,
   reverse: props.reverse,
   variant: props.variant,

--- a/src/runtime/components/PageCardGroup.vue
+++ b/src/runtime/components/PageCardGroup.vue
@@ -178,7 +178,7 @@ const currentValue = computed<PageCardGroupValue | PageCardGroupValue[] | undefi
 })
 
 // eslint-disable-next-line vue/no-dupe-keys
-const b24ui = computed(() => tv({ extend: tv(theme), ...(appConfig.b24ui?.pageCardGroup || {}) })({
+const b24ui = computed(() => tv({ extend: theme, ...(appConfig.b24ui?.pageCardGroup || {}) })({
   size: props.size,
   columns: props.columns,
   disabled: disabled.value

--- a/src/runtime/components/PageColumns.vue
+++ b/src/runtime/components/PageColumns.vue
@@ -37,7 +37,7 @@ const props = useComponentProps('pageColumns', _props)
 const appConfig = useAppConfig() as PageColumns['AppConfig']
 
 // eslint-disable-next-line vue/no-dupe-keys
-const b24ui = computed(() => tv({ extend: tv(theme), ...(appConfig.b24ui?.pageColumns || {}) }))
+const b24ui = computed(() => tv({ extend: theme, ...(appConfig.b24ui?.pageColumns || {}) }))
 </script>
 
 <template>

--- a/src/runtime/components/PageFeature.vue
+++ b/src/runtime/components/PageFeature.vue
@@ -64,7 +64,7 @@ const appConfig = useAppConfig() as PageFeature['AppConfig']
 const prefix = usePrefix()
 
 // eslint-disable-next-line vue/no-dupe-keys
-const b24ui = computed(() => tv({ extend: tv(theme), ...(appConfig.b24ui?.pageFeature || {}) })({
+const b24ui = computed(() => tv({ extend: theme, ...(appConfig.b24ui?.pageFeature || {}) })({
   orientation: props.orientation,
   title: !!props.title || !!slots.title,
   to: !!props.to || !!props.onClick

--- a/src/runtime/components/PageGrid.vue
+++ b/src/runtime/components/PageGrid.vue
@@ -37,7 +37,7 @@ const props = useComponentProps('pageGrid', _props)
 const appConfig = useAppConfig() as PageGrid['AppConfig']
 
 // eslint-disable-next-line vue/no-dupe-keys
-const b24ui = computed(() => tv({ extend: tv(theme), ...(appConfig.b24ui?.pageGrid || {}) }))
+const b24ui = computed(() => tv({ extend: theme, ...(appConfig.b24ui?.pageGrid || {}) }))
 </script>
 
 <template>

--- a/src/runtime/components/PageHeader.vue
+++ b/src/runtime/components/PageHeader.vue
@@ -50,7 +50,7 @@ const props = useComponentProps('pageHeader', _props)
 const appConfig = useAppConfig() as PageHeader['AppConfig']
 
 // eslint-disable-next-line vue/no-dupe-keys
-const b24ui = computed(() => tv({ extend: tv(theme), ...(appConfig.b24ui?.pageHeader || {}) })({
+const b24ui = computed(() => tv({ extend: theme, ...(appConfig.b24ui?.pageHeader || {}) })({
   title: !!props.title || !!slots.title
 }))
 </script>

--- a/src/runtime/components/PageLinks.vue
+++ b/src/runtime/components/PageLinks.vue
@@ -62,7 +62,7 @@ const props = useComponentProps<PageLinksProps<T>>('pageLinks', _props)
 const appConfig = useAppConfig() as PageLinks['AppConfig']
 
 // eslint-disable-next-line vue/no-dupe-keys
-const b24ui = computed(() => tv({ extend: tv(theme), ...(appConfig.b24ui?.pageLinks || {}) })())
+const b24ui = computed(() => tv({ extend: theme, ...(appConfig.b24ui?.pageLinks || {}) })())
 </script>
 
 <template>

--- a/src/runtime/components/PageList.vue
+++ b/src/runtime/components/PageList.vue
@@ -39,7 +39,7 @@ const props = useComponentProps('pageList', _props)
 const appConfig = useAppConfig() as PageList['AppConfig']
 
 // eslint-disable-next-line vue/no-dupe-keys
-const b24ui = computed(() => tv({ extend: tv(theme), ...(appConfig.b24ui?.pageList || {}) }))
+const b24ui = computed(() => tv({ extend: theme, ...(appConfig.b24ui?.pageList || {}) }))
 </script>
 
 <template>

--- a/src/runtime/components/PageSection.vue
+++ b/src/runtime/components/PageSection.vue
@@ -88,7 +88,7 @@ const appConfig = useAppConfig() as PageSection['AppConfig']
 const prefix = usePrefix()
 
 // eslint-disable-next-line vue/no-dupe-keys
-const b24ui = computed(() => tv({ extend: tv(theme), ...(appConfig.b24ui?.pageSection || {}) })({
+const b24ui = computed(() => tv({ extend: theme, ...(appConfig.b24ui?.pageSection || {}) })({
   orientation: props.orientation,
   reverse: props.reverse,
   title: !!props.title || !!slots.title,

--- a/src/runtime/components/Pagination.vue
+++ b/src/runtime/components/Pagination.vue
@@ -133,7 +133,7 @@ const nextIcon = computed(() => props.nextIcon || (dir.value === 'rtl' ? icons.c
 const lastIcon = computed(() => props.lastIcon || (dir.value === 'rtl' ? icons.chevronDoubleLeft : icons.chevronDoubleRight))
 
 // eslint-disable-next-line vue/no-dupe-keys
-const b24ui = computed(() => tv({ extend: tv(theme), ...(appConfig.b24ui?.pagination || {}) })())
+const b24ui = computed(() => tv({ extend: theme, ...(appConfig.b24ui?.pagination || {}) })())
 </script>
 
 <template>

--- a/src/runtime/components/PinInput.vue
+++ b/src/runtime/components/PinInput.vue
@@ -100,7 +100,7 @@ const rootProps = useForwardProps(reactivePick(props, 'disabled', 'id', 'mask', 
 const { emitFormInput, emitFormFocus, emitFormChange, emitFormBlur, size, color, id, name, highlight, disabled, ariaAttrs } = useFormField<PinInputProps>(_props)
 
 // eslint-disable-next-line vue/no-dupe-keys
-const b24ui = computed(() => tv({ extend: tv(theme), ...(appConfig.b24ui?.pinInput || {}) })({
+const b24ui = computed(() => tv({ extend: theme, ...(appConfig.b24ui?.pinInput || {}) })({
   color: color.value ?? props.color,
   size: size.value ?? props.size,
   highlight: highlight.value ?? props.highlight,

--- a/src/runtime/components/Popover.vue
+++ b/src/runtime/components/Popover.vue
@@ -112,7 +112,7 @@ const contentEvents = computed(() => {
 const arrowProps = toRef(() => defu(typeof props.arrow === 'boolean' ? {} : props.arrow, { width: 20, height: 10 }) as PopoverArrowProps)
 
 // eslint-disable-next-line vue/no-dupe-keys
-const b24ui = computed(() => tv({ extend: tv(theme), ...(appConfig.b24ui?.popover || {}) })({
+const b24ui = computed(() => tv({ extend: theme, ...(appConfig.b24ui?.popover || {}) })({
   side: contentProps.value.side
 }))
 

--- a/src/runtime/components/Progress.vue
+++ b/src/runtime/components/Progress.vue
@@ -169,7 +169,7 @@ function stepVariant(index: number | string) {
 }
 
 // eslint-disable-next-line vue/no-dupe-keys
-const b24ui = computed(() => tv({ extend: tv(theme), ...(appConfig.b24ui?.progress || {}) })({
+const b24ui = computed(() => tv({ extend: theme, ...(appConfig.b24ui?.progress || {}) })({
   animation: props.animation,
   size: props.size,
   color: props.color,

--- a/src/runtime/components/RadioGroup.vue
+++ b/src/runtime/components/RadioGroup.vue
@@ -120,7 +120,7 @@ const { emitFormChange, emitFormInput, color, name, size, highlight, id: _id, di
 const id = _id.value ?? useId()
 
 // eslint-disable-next-line vue/no-dupe-keys
-const b24ui = computed(() => tv({ extend: tv(theme), ...(appConfig.b24ui?.radioGroup || {}) })({
+const b24ui = computed(() => tv({ extend: theme, ...(appConfig.b24ui?.radioGroup || {}) })({
   size: size.value ?? props.size,
   color: color.value ?? props.color,
   highlight: highlight.value ?? props.highlight,

--- a/src/runtime/components/Range.vue
+++ b/src/runtime/components/Range.vue
@@ -93,7 +93,7 @@ const rangeValue = computed({
 
 const thumbs = computed(() => rangeValue.value?.length ?? 1)
 // eslint-disable-next-line vue/no-dupe-keys
-const b24ui = computed(() => tv({ extend: tv(theme), ...(appConfig.b24ui?.range || {}) })({
+const b24ui = computed(() => tv({ extend: theme, ...(appConfig.b24ui?.range || {}) })({
   disabled: disabled.value,
   size: size.value ?? props.size,
   color: color.value ?? props.color,

--- a/src/runtime/components/ScrollArea.vue
+++ b/src/runtime/components/ScrollArea.vue
@@ -111,7 +111,7 @@ const { dir } = useLocale()
 const appConfig = useAppConfig() as ScrollArea['AppConfig']
 
 // eslint-disable-next-line vue/no-dupe-keys
-const b24ui = computed(() => tv({ extend: tv(theme), ...(appConfig.b24ui?.scrollArea || {}) })({
+const b24ui = computed(() => tv({ extend: theme, ...(appConfig.b24ui?.scrollArea || {}) })({
   orientation: props.orientation
 }))
 

--- a/src/runtime/components/Select.vue
+++ b/src/runtime/components/Select.vue
@@ -229,7 +229,7 @@ const isTag = computed(() => {
 })
 
 // eslint-disable-next-line vue/no-dupe-keys
-const b24ui = computed(() => tv({ extend: tv(theme), ...(appConfig.b24ui?.select || {}) })({
+const b24ui = computed(() => tv({ extend: theme, ...(appConfig.b24ui?.select || {}) })({
   color: color.value ?? props.color,
   size: selectSize?.value ?? props.size,
   loading: props.loading,

--- a/src/runtime/components/SelectMenu.vue
+++ b/src/runtime/components/SelectMenu.vue
@@ -343,7 +343,7 @@ const isTag = computed(() => {
 })
 
 // eslint-disable-next-line vue/no-dupe-keys
-const b24ui = computed(() => tv({ extend: tv(theme), ...(appConfig.b24ui?.selectMenu || {}) })({
+const b24ui = computed(() => tv({ extend: theme, ...(appConfig.b24ui?.selectMenu || {}) })({
   color: color.value ?? props.color,
   size: selectSize?.value ?? props.size,
   loading: props.loading,

--- a/src/runtime/components/Separator.vue
+++ b/src/runtime/components/Separator.vue
@@ -89,7 +89,7 @@ const [DefineContainer, ReuseContainer] = createReusableTemplate()
 const hasContent = computed(() => !!(props.label || props.icon || props.avatar || slots.default))
 
 // eslint-disable-next-line vue/no-dupe-keys
-const b24ui = computed(() => tv({ extend: tv(theme), ...(appConfig.b24ui?.separator || {}) })({
+const b24ui = computed(() => tv({ extend: theme, ...(appConfig.b24ui?.separator || {}) })({
   accent: props.accent,
   orientation: props.orientation,
   size: props.size,

--- a/src/runtime/components/Sidebar.vue
+++ b/src/runtime/components/Sidebar.vue
@@ -198,7 +198,7 @@ function closeSidebar() {
 const hasHeader = computed(() => !!slots.header || props.title || !!slots.title || props.description || !!slots.description || !!slots.actions || canClose.value || !!slots.close)
 
 // eslint-disable-next-line vue/no-dupe-keys
-const b24ui = computed(() => tv({ extend: tv(theme), ...(appConfig.b24ui?.sidebar || {}) })({
+const b24ui = computed(() => tv({ extend: theme, ...(appConfig.b24ui?.sidebar || {}) })({
   side: props.side,
   variant: props.variant,
   collapsible: props.collapsible,

--- a/src/runtime/components/SidebarBody.vue
+++ b/src/runtime/components/SidebarBody.vue
@@ -50,7 +50,7 @@ const props = useComponentProps('sidebarBody', _props)
 const appConfig = useAppConfig() as SidebarBody['AppConfig']
 
 // eslint-disable-next-line vue/no-dupe-keys
-const b24ui = computed(() => tv({ extend: tv(theme), ...(appConfig.b24ui?.sidebarBody || {}) })({
+const b24ui = computed(() => tv({ extend: theme, ...(appConfig.b24ui?.sidebarBody || {}) })({
   scrollbarThin: Boolean(props.scrollbarThin)
 }))
 </script>

--- a/src/runtime/components/SidebarFooter.vue
+++ b/src/runtime/components/SidebarFooter.vue
@@ -45,7 +45,7 @@ const props = useComponentProps('sidebarFooter', _props)
 const appConfig = useAppConfig() as SidebarFooter['AppConfig']
 
 // eslint-disable-next-line vue/no-dupe-keys
-const b24ui = computed(() => tv({ extend: tv(theme), ...(appConfig.b24ui?.sidebarFooter || {}) })())
+const b24ui = computed(() => tv({ extend: theme, ...(appConfig.b24ui?.sidebarFooter || {}) })())
 </script>
 
 <template>

--- a/src/runtime/components/SidebarHeader.vue
+++ b/src/runtime/components/SidebarHeader.vue
@@ -45,7 +45,7 @@ const props = useComponentProps('sidebarHeader', _props)
 const appConfig = useAppConfig() as SidebarHeader['AppConfig']
 
 // eslint-disable-next-line vue/no-dupe-keys
-const b24ui = computed(() => tv({ extend: tv(theme), ...(appConfig.b24ui?.sidebarHeader || {}) })())
+const b24ui = computed(() => tv({ extend: theme, ...(appConfig.b24ui?.sidebarHeader || {}) })())
 </script>
 
 <template>

--- a/src/runtime/components/SidebarHeading.vue
+++ b/src/runtime/components/SidebarHeading.vue
@@ -45,7 +45,7 @@ const props = useComponentProps('sidebarHeading', _props)
 const appConfig = useAppConfig() as SidebarHeading['AppConfig']
 
 // eslint-disable-next-line vue/no-dupe-keys
-const b24ui = computed(() => tv({ extend: tv(theme), ...(appConfig.b24ui?.sidebarHeading || {}) })())
+const b24ui = computed(() => tv({ extend: theme, ...(appConfig.b24ui?.sidebarHeading || {}) })())
 </script>
 
 <template>

--- a/src/runtime/components/SidebarLayout.vue
+++ b/src/runtime/components/SidebarLayout.vue
@@ -101,7 +101,7 @@ const openSidebarSlideover = ref(false)
 const isLoading = ref(false)
 
 // eslint-disable-next-line vue/no-dupe-keys
-const b24ui = computed(() => tv({ extend: tv(theme), ...(appConfig.b24ui?.sidebarLayout || {}) })({
+const b24ui = computed(() => tv({ extend: theme, ...(appConfig.b24ui?.sidebarLayout || {}) })({
   useSidebar: isUseSideBar.value,
   useNavbar: isUseNavbar.value,
   useRightBar: isUseRightBar.value,

--- a/src/runtime/components/SidebarSection.vue
+++ b/src/runtime/components/SidebarSection.vue
@@ -45,7 +45,7 @@ const props = useComponentProps('sidebarSection', _props)
 const appConfig = useAppConfig() as SidebarSection['AppConfig']
 
 // eslint-disable-next-line vue/no-dupe-keys
-const b24ui = computed(() => tv({ extend: tv(theme), ...(appConfig.b24ui?.sidebarSection || {}) })())
+const b24ui = computed(() => tv({ extend: theme, ...(appConfig.b24ui?.sidebarSection || {}) })())
 </script>
 
 <template>

--- a/src/runtime/components/SidebarSpacer.vue
+++ b/src/runtime/components/SidebarSpacer.vue
@@ -45,7 +45,7 @@ const props = useComponentProps('sidebarSpacer', _props)
 const appConfig = useAppConfig() as SidebarSpacer['AppConfig']
 
 // eslint-disable-next-line vue/no-dupe-keys
-const b24ui = computed(() => tv({ extend: tv(theme), ...(appConfig.b24ui?.sidebarSpacer || {}) })())
+const b24ui = computed(() => tv({ extend: theme, ...(appConfig.b24ui?.sidebarSpacer || {}) })())
 </script>
 
 <template>

--- a/src/runtime/components/Skeleton.vue
+++ b/src/runtime/components/Skeleton.vue
@@ -36,7 +36,7 @@ const props = useComponentProps('skeleton', _props)
 const appConfig = useAppConfig() as Skeleton['AppConfig']
 
 // eslint-disable-next-line vue/no-dupe-keys
-const b24ui = computed(() => tv({ extend: tv(theme), ...(appConfig.b24ui?.skeleton || {}) })({
+const b24ui = computed(() => tv({ extend: theme, ...(appConfig.b24ui?.skeleton || {}) })({
   accent: props.accent
 }))
 </script>

--- a/src/runtime/components/Slideover.vue
+++ b/src/runtime/components/Slideover.vue
@@ -146,7 +146,7 @@ const contentEvents = computed(() => {
 })
 
 // eslint-disable-next-line vue/no-dupe-keys
-const b24ui = computed(() => tv({ extend: tv(theme), ...(appConfig.b24ui?.slideover || {}) })({
+const b24ui = computed(() => tv({ extend: theme, ...(appConfig.b24ui?.slideover || {}) })({
   transition: props.transition,
   side: props.side,
   inset: props.inset,

--- a/src/runtime/components/Stepper.vue
+++ b/src/runtime/components/Stepper.vue
@@ -104,7 +104,7 @@ const appConfig = useAppConfig() as Stepper['AppConfig']
 const rootProps = useForwardProps(reactivePick(props, 'as', 'linear'))
 
 // eslint-disable-next-line vue/no-dupe-keys
-const b24ui = computed(() => tv({ extend: tv(theme), ...(appConfig.b24ui?.stepper || {}) })({
+const b24ui = computed(() => tv({ extend: theme, ...(appConfig.b24ui?.stepper || {}) })({
   orientation: props.orientation,
   size: props.size,
   color: props.color

--- a/src/runtime/components/Switch.vue
+++ b/src/runtime/components/Switch.vue
@@ -96,7 +96,7 @@ const forwardedAttrs = computed(() => {
 })
 
 // eslint-disable-next-line vue/no-dupe-keys
-const b24ui = computed(() => tv({ extend: tv(theme), ...(appConfig.b24ui?.switch || {}) })({
+const b24ui = computed(() => tv({ extend: theme, ...(appConfig.b24ui?.switch || {}) })({
   size: size.value ?? props.size,
   color: color.value ?? props.color,
   highlight: highlight.value ?? props.highlight,

--- a/src/runtime/components/Table.vue
+++ b/src/runtime/components/Table.vue
@@ -282,7 +282,7 @@ function processColumns(columns: TableColumn<T>[]): TableColumn<T>[] {
 }
 
 // eslint-disable-next-line vue/no-dupe-keys
-const b24ui = computed(() => tv({ extend: tv(theme), ...(appConfig.b24ui?.table || {}) })({
+const b24ui = computed(() => tv({ extend: theme, ...(appConfig.b24ui?.table || {}) })({
   sticky: props.sticky,
   loading: props.loading,
   loadingColor: props.loadingColor,

--- a/src/runtime/components/TableWrapper.vue
+++ b/src/runtime/components/TableWrapper.vue
@@ -72,7 +72,7 @@ const props = useComponentProps('tableWrapper', _props)
 const appConfig = useAppConfig() as TableWrapper['AppConfig']
 
 // eslint-disable-next-line vue/no-dupe-keys
-const b24ui = computed(() => tv({ extend: tv(theme), ...(appConfig.b24ui?.tableWrapper || {}) })({
+const b24ui = computed(() => tv({ extend: theme, ...(appConfig.b24ui?.tableWrapper || {}) })({
   size: props.size,
   rounded: Boolean(props.rounded),
   zebra: Boolean(props.zebra),

--- a/src/runtime/components/Tabs.vue
+++ b/src/runtime/components/Tabs.vue
@@ -122,7 +122,7 @@ const appConfig = useAppConfig() as Tabs['AppConfig']
 const rootProps = useForwardProps(reactivePick(props, 'as', 'unmountOnHide'), emits)
 
 // eslint-disable-next-line vue/no-dupe-keys
-const b24ui = computed(() => tv({ extend: tv(theme), ...(appConfig.b24ui?.tabs || {}) })({
+const b24ui = computed(() => tv({ extend: theme, ...(appConfig.b24ui?.tabs || {}) })({
   variant: props.variant,
   size: props.size,
   orientation: props.orientation

--- a/src/runtime/components/Textarea.vue
+++ b/src/runtime/components/Textarea.vue
@@ -127,7 +127,7 @@ const isTag = computed(() => {
 })
 
 // eslint-disable-next-line vue/no-dupe-keys
-const b24ui = computed(() => tv({ extend: tv(theme), ...(appConfig.b24ui?.textarea || {}) })({
+const b24ui = computed(() => tv({ extend: theme, ...(appConfig.b24ui?.textarea || {}) })({
   color: color.value ?? props.color,
   // size: size?.value ?? props.size,
   loading: props.loading,

--- a/src/runtime/components/Timeline.vue
+++ b/src/runtime/components/Timeline.vue
@@ -93,7 +93,7 @@ const modelValue = defineModel<string | number>()
 const appConfig = useAppConfig() as Timeline['AppConfig']
 
 // eslint-disable-next-line vue/no-dupe-keys
-const b24ui = computed(() => tv({ extend: tv(theme), ...(appConfig.b24ui?.timeline || {}) })({
+const b24ui = computed(() => tv({ extend: theme, ...(appConfig.b24ui?.timeline || {}) })({
   orientation: props.orientation,
   size: props.size,
   color: props.color,

--- a/src/runtime/components/Toast.vue
+++ b/src/runtime/components/Toast.vue
@@ -112,7 +112,7 @@ const appConfig = useAppConfig() as Toast['AppConfig']
 const rootProps = useForwardProps(reactivePick(props, 'as', 'defaultOpen', 'open', 'duration', 'type'), emits)
 
 // eslint-disable-next-line vue/no-dupe-keys
-const b24ui = computed(() => tv({ extend: tv(theme), ...(appConfig.b24ui?.toast || {}) })({
+const b24ui = computed(() => tv({ extend: theme, ...(appConfig.b24ui?.toast || {}) })({
   color: props.color,
   orientation: props.orientation,
   title: !!props.title || !!slots.title

--- a/src/runtime/components/Toaster.vue
+++ b/src/runtime/components/Toaster.vue
@@ -100,7 +100,7 @@ const swipeDirection = computed(() => {
 })
 
 // eslint-disable-next-line vue/no-dupe-keys
-const b24ui = computed(() => tv({ extend: tv(theme), ...(appConfig.b24ui?.toaster || {}) })({
+const b24ui = computed(() => tv({ extend: theme, ...(appConfig.b24ui?.toaster || {}) })({
   position: props.position,
   swipeDirection: swipeDirection.value
 }))

--- a/src/runtime/components/Tooltip.vue
+++ b/src/runtime/components/Tooltip.vue
@@ -82,7 +82,7 @@ const contentProps = toRef(() => defu(props.content, providerContext.content.val
 const arrowProps = toRef(() => defu(typeof props.arrow === 'boolean' ? {} : props.arrow, { width: 20, height: 10, rounded: true }) as TooltipArrowProps)
 
 // eslint-disable-next-line vue/no-dupe-keys
-const b24ui = computed(() => tv({ extend: tv(theme), ...(appConfig.b24ui?.tooltip || {}) })({
+const b24ui = computed(() => tv({ extend: theme, ...(appConfig.b24ui?.tooltip || {}) })({
   side: contentProps.value.side
 }))
 </script>

--- a/src/runtime/components/User.vue
+++ b/src/runtime/components/User.vue
@@ -67,7 +67,7 @@ const appConfig = useAppConfig() as User['AppConfig']
 const prefix = usePrefix()
 
 // eslint-disable-next-line vue/no-dupe-keys
-const b24ui = computed(() => tv({ extend: tv(theme), ...(appConfig.b24ui?.user || {}) })({
+const b24ui = computed(() => tv({ extend: theme, ...(appConfig.b24ui?.user || {}) })({
   size: props.size,
   orientation: props.orientation,
   to: !!props.to || !!props.onClick

--- a/src/runtime/components/content/ContentSearch.vue
+++ b/src/runtime/components/content/ContentSearch.vue
@@ -194,7 +194,7 @@ const fuse = computed(() => defu({}, props.fuse, {
 } as UseFuseOptions<T>))
 
 // eslint-disable-next-line vue/no-dupe-keys
-const b24ui = computed(() => tv({ extend: tv(theme), ...(appConfig.b24ui?.contentSearch || {}) })({
+const b24ui = computed(() => tv({ extend: theme, ...(appConfig.b24ui?.contentSearch || {}) })({
   size: props.size,
   fullscreen: props.fullscreen
 }))

--- a/src/runtime/components/content/ContentSearchButton.vue
+++ b/src/runtime/components/content/ContentSearchButton.vue
@@ -88,7 +88,7 @@ const { open } = useContentSearch()
 const appConfig = useAppConfig() as ContentSearchButton['AppConfig']
 
 // eslint-disable-next-line vue/no-dupe-keys
-const b24ui = computed(() => tv({ extend: tv(theme), ...(appConfig.b24ui?.contentSearchButton || {}) })({
+const b24ui = computed(() => tv({ extend: theme, ...(appConfig.b24ui?.contentSearchButton || {}) })({
   collapsed: props.collapsed
 }))
 </script>

--- a/src/runtime/components/content/ContentSurround.vue
+++ b/src/runtime/components/content/ContentSurround.vue
@@ -84,7 +84,7 @@ const [DefineLinkTemplate, ReuseLinkTemplate] = createReusableTemplate<{ link?: 
 })
 
 // eslint-disable-next-line vue/no-dupe-keys
-const b24ui = computed(() => tv({ extend: tv(theme), ...(appConfig.b24ui?.contentSurround || {}) })())
+const b24ui = computed(() => tv({ extend: theme, ...(appConfig.b24ui?.contentSurround || {}) })())
 
 // eslint-disable-next-line vue/no-dupe-keys
 const prevIcon = computed(() => props.prevIcon || (dir.value === 'rtl' ? icons.arrowRight : icons.arrowLeft))

--- a/src/runtime/components/content/ContentToc.vue
+++ b/src/runtime/components/content/ContentToc.vue
@@ -98,7 +98,7 @@ const [DefineTriggerTemplate, ReuseTriggerTemplate] = createReusableTemplate<{ o
 
 // @memo We not support: color, highlight, highlightVariant, highlightColor
 // eslint-disable-next-line vue/no-dupe-keys
-const b24ui = computed(() => tv({ extend: tv(theme), ...(appConfig.b24ui?.contentToc || {}) })({}))
+const b24ui = computed(() => tv({ extend: theme, ...(appConfig.b24ui?.contentToc || {}) })({}))
 
 function scrollToHeading(id: string) {
   const encodedId = encodeURIComponent(id)

--- a/src/runtime/components/prose/A.vue
+++ b/src/runtime/components/prose/A.vue
@@ -34,7 +34,7 @@ const props = useComponentProps('prose.a', _props)
 const appConfig = useAppConfig() as ProseA['AppConfig']
 
 // eslint-disable-next-line vue/no-dupe-keys
-const b24ui = computed(() => tv({ extend: tv(theme), ...(appConfig.b24ui?.prose?.a || {}) })())
+const b24ui = computed(() => tv({ extend: theme, ...(appConfig.b24ui?.prose?.a || {}) })())
 </script>
 
 <template>

--- a/src/runtime/components/prose/Accordion.vue
+++ b/src/runtime/components/prose/Accordion.vue
@@ -37,7 +37,7 @@ const props = useComponentProps('prose.accordion', _props)
 const appConfig = useAppConfig() as ProseAccordion['AppConfig']
 
 // eslint-disable-next-line vue/no-dupe-keys
-const b24ui = computed(() => tv({ extend: tv(theme), ...(appConfig.b24ui?.prose?.accordion || {}) }))
+const b24ui = computed(() => tv({ extend: theme, ...(appConfig.b24ui?.prose?.accordion || {}) }))
 
 const rerenderCount = ref(1)
 

--- a/src/runtime/components/prose/AccordionItem.vue
+++ b/src/runtime/components/prose/AccordionItem.vue
@@ -33,7 +33,7 @@ const props = useComponentProps('prose.accordionItem', _props)
 const appConfig = useAppConfig() as ProseAccordionItem['AppConfig']
 
 // eslint-disable-next-line vue/no-dupe-keys
-const b24ui = computed(() => tv({ extend: tv(theme), ...(appConfig.b24ui?.prose?.accordionItem || {}) }))
+const b24ui = computed(() => tv({ extend: theme, ...(appConfig.b24ui?.prose?.accordionItem || {}) }))
 </script>
 
 <template>

--- a/src/runtime/components/prose/Badge.vue
+++ b/src/runtime/components/prose/Badge.vue
@@ -32,7 +32,7 @@ const props = useComponentProps('prose.badge', _props)
 const appConfig = useAppConfig() as ProseBadge['AppConfig']
 
 // eslint-disable-next-line vue/no-dupe-keys
-const b24ui = computed(() => tv({ extend: tv(theme), ...(appConfig.b24ui?.prose?.badge || {}) }))
+const b24ui = computed(() => tv({ extend: theme, ...(appConfig.b24ui?.prose?.badge || {}) }))
 </script>
 
 <template>

--- a/src/runtime/components/prose/Blockquote.vue
+++ b/src/runtime/components/prose/Blockquote.vue
@@ -31,7 +31,7 @@ const props = useComponentProps('prose.blockquote', _props)
 const appConfig = useAppConfig() as ProseBlockquote['AppConfig']
 
 // eslint-disable-next-line vue/no-dupe-keys
-const b24ui = computed(() => tv({ extend: tv(theme), ...(appConfig.b24ui?.prose?.blockquote || {}) })())
+const b24ui = computed(() => tv({ extend: theme, ...(appConfig.b24ui?.prose?.blockquote || {}) })())
 </script>
 
 <template>

--- a/src/runtime/components/prose/Callout.vue
+++ b/src/runtime/components/prose/Callout.vue
@@ -46,7 +46,7 @@ const props = useComponentProps('prose.callout', _props)
 const appConfig = useAppConfig() as ProseCallout['AppConfig']
 
 // eslint-disable-next-line vue/no-dupe-keys
-const b24ui = computed(() => tv({ extend: tv(theme), ...(appConfig.b24ui?.prose?.callout || {}) })({
+const b24ui = computed(() => tv({ extend: theme, ...(appConfig.b24ui?.prose?.callout || {}) })({
   color: props.color,
   to: !!props.to
 }))

--- a/src/runtime/components/prose/Card.vue
+++ b/src/runtime/components/prose/Card.vue
@@ -52,7 +52,7 @@ const props = useComponentProps('prose.card', _props)
 const appConfig = useAppConfig() as ProseCard['AppConfig']
 
 // eslint-disable-next-line vue/no-dupe-keys
-const b24ui = computed(() => tv({ extend: tv(theme), ...(appConfig.b24ui?.prose?.card || {}) })({
+const b24ui = computed(() => tv({ extend: theme, ...(appConfig.b24ui?.prose?.card || {}) })({
   color: props.color,
   to: !!props.to,
   title: !!props.title

--- a/src/runtime/components/prose/CardGroup.vue
+++ b/src/runtime/components/prose/CardGroup.vue
@@ -31,7 +31,7 @@ const props = useComponentProps('prose.cardGroup', _props)
 const appConfig = useAppConfig() as ProseCardGroup['AppConfig']
 
 // eslint-disable-next-line vue/no-dupe-keys
-const b24ui = computed(() => tv({ extend: tv(theme), ...(appConfig.b24ui?.prose?.cardGroup || {}) }))
+const b24ui = computed(() => tv({ extend: theme, ...(appConfig.b24ui?.prose?.cardGroup || {}) }))
 </script>
 
 <template>

--- a/src/runtime/components/prose/Code.vue
+++ b/src/runtime/components/prose/Code.vue
@@ -35,7 +35,7 @@ const props = useComponentProps('prose.code', _props)
 const appConfig = useAppConfig() as ProseCode['AppConfig']
 
 // eslint-disable-next-line vue/no-dupe-keys
-const b24ui = computed(() => tv({ extend: tv(theme), ...(appConfig.b24ui?.prose?.code || {}) })({
+const b24ui = computed(() => tv({ extend: theme, ...(appConfig.b24ui?.prose?.code || {}) })({
   color: props.color
 }))
 </script>

--- a/src/runtime/components/prose/CodeCollapse.vue
+++ b/src/runtime/components/prose/CodeCollapse.vue
@@ -58,7 +58,7 @@ const { t } = useLocale()
 const appConfig = useAppConfig() as ProseCodeCollapse['AppConfig']
 
 // eslint-disable-next-line vue/no-dupe-keys
-const b24ui = computed(() => tv({ extend: tv(theme), ...(appConfig.b24ui?.prose?.codeCollapse || {}) })({
+const b24ui = computed(() => tv({ extend: theme, ...(appConfig.b24ui?.prose?.codeCollapse || {}) })({
   open: open.value
 }))
 </script>

--- a/src/runtime/components/prose/CodeGroup.vue
+++ b/src/runtime/components/prose/CodeGroup.vue
@@ -46,7 +46,7 @@ const model = defineModel<string>()
 const appConfig = useAppConfig() as ProseCodeGroup['AppConfig']
 
 // eslint-disable-next-line vue/no-dupe-keys
-const b24ui = computed(() => tv({ extend: tv(theme), ...(appConfig.b24ui?.prose?.codeGroup || {}) })())
+const b24ui = computed(() => tv({ extend: theme, ...(appConfig.b24ui?.prose?.codeGroup || {}) })())
 
 const rerenderCount = ref(1)
 

--- a/src/runtime/components/prose/CodePreview.vue
+++ b/src/runtime/components/prose/CodePreview.vue
@@ -31,7 +31,7 @@ const props = useComponentProps('prose.codePreview', _props)
 const appConfig = useAppConfig() as ProseCodePreview['AppConfig']
 
 // eslint-disable-next-line vue/no-dupe-keys
-const b24ui = computed(() => tv({ extend: tv(theme), ...(appConfig.b24ui?.prose?.codePreview || {}) })({ code: !!slots.code }))
+const b24ui = computed(() => tv({ extend: theme, ...(appConfig.b24ui?.prose?.codePreview || {}) })({ code: !!slots.code }))
 </script>
 
 <template>

--- a/src/runtime/components/prose/Collapsible.vue
+++ b/src/runtime/components/prose/Collapsible.vue
@@ -58,7 +58,7 @@ const { t } = useLocale()
 const appConfig = useAppConfig() as ProseCollapsible['AppConfig']
 
 // eslint-disable-next-line vue/no-dupe-keys
-const b24ui = computed(() => tv({ extend: tv(theme), ...(appConfig.b24ui?.prose?.collapsible || {}) })())
+const b24ui = computed(() => tv({ extend: theme, ...(appConfig.b24ui?.prose?.collapsible || {}) })())
 </script>
 
 <template>

--- a/src/runtime/components/prose/Em.vue
+++ b/src/runtime/components/prose/Em.vue
@@ -31,7 +31,7 @@ const props = useComponentProps('prose.em', _props)
 const appConfig = useAppConfig() as ProseEm['AppConfig']
 
 // eslint-disable-next-line vue/no-dupe-keys
-const b24ui = computed(() => tv({ extend: tv(theme), ...(appConfig.b24ui?.prose?.em || {}) })())
+const b24ui = computed(() => tv({ extend: theme, ...(appConfig.b24ui?.prose?.em || {}) })())
 </script>
 
 <template>

--- a/src/runtime/components/prose/Field.vue
+++ b/src/runtime/components/prose/Field.vue
@@ -52,7 +52,7 @@ const props = useComponentProps('prose.field', _props)
 const appConfig = useAppConfig() as ProseField['AppConfig']
 
 // eslint-disable-next-line vue/no-dupe-keys
-const b24ui = computed(() => tv({ extend: tv(theme), ...(appConfig.b24ui?.prose?.field || {}) })())
+const b24ui = computed(() => tv({ extend: theme, ...(appConfig.b24ui?.prose?.field || {}) })())
 </script>
 
 <template>

--- a/src/runtime/components/prose/FieldGroup.vue
+++ b/src/runtime/components/prose/FieldGroup.vue
@@ -37,7 +37,7 @@ const props = useComponentProps('prose.fieldGroup', _props)
 const appConfig = useAppConfig() as ProseFieldGroup['AppConfig']
 
 // eslint-disable-next-line vue/no-dupe-keys
-const b24ui = computed(() => tv({ extend: tv(theme), ...(appConfig.b24ui?.prose?.fieldGroup || {}) }))
+const b24ui = computed(() => tv({ extend: theme, ...(appConfig.b24ui?.prose?.fieldGroup || {}) }))
 </script>
 
 <template>

--- a/src/runtime/components/prose/H1.vue
+++ b/src/runtime/components/prose/H1.vue
@@ -39,7 +39,7 @@ const appConfig = useAppConfig() as ProseH1['AppConfig']
 const { headings } = useRuntimeConfig().public?.mdc || {}
 
 // eslint-disable-next-line vue/no-dupe-keys
-const b24ui = computed(() => tv({ extend: tv(theme), ...(appConfig.b24ui?.prose?.h1 || {}) })({
+const b24ui = computed(() => tv({ extend: theme, ...(appConfig.b24ui?.prose?.h1 || {}) })({
   accent: props.accent
 }))
 

--- a/src/runtime/components/prose/H2.vue
+++ b/src/runtime/components/prose/H2.vue
@@ -40,7 +40,7 @@ const appConfig = useAppConfig() as ProseH2['AppConfig']
 const { headings } = useRuntimeConfig().public?.mdc || {}
 
 // eslint-disable-next-line vue/no-dupe-keys
-const b24ui = computed(() => tv({ extend: tv(theme), ...(appConfig.b24ui?.prose?.h2 || {}) })({
+const b24ui = computed(() => tv({ extend: theme, ...(appConfig.b24ui?.prose?.h2 || {}) })({
   accent: props.accent
 }))
 

--- a/src/runtime/components/prose/H3.vue
+++ b/src/runtime/components/prose/H3.vue
@@ -40,7 +40,7 @@ const appConfig = useAppConfig() as ProseH3['AppConfig']
 const { headings } = useRuntimeConfig().public?.mdc || {}
 
 // eslint-disable-next-line vue/no-dupe-keys
-const b24ui = computed(() => tv({ extend: tv(theme), ...(appConfig.b24ui?.prose?.h3 || {}) })({
+const b24ui = computed(() => tv({ extend: theme, ...(appConfig.b24ui?.prose?.h3 || {}) })({
   accent: props.accent
 }))
 

--- a/src/runtime/components/prose/H4.vue
+++ b/src/runtime/components/prose/H4.vue
@@ -40,7 +40,7 @@ const appConfig = useAppConfig() as ProseH4['AppConfig']
 const { headings } = useRuntimeConfig().public?.mdc || {}
 
 // eslint-disable-next-line vue/no-dupe-keys
-const b24ui = computed(() => tv({ extend: tv(theme), ...(appConfig.b24ui?.prose?.h4 || {}) })({
+const b24ui = computed(() => tv({ extend: theme, ...(appConfig.b24ui?.prose?.h4 || {}) })({
   accent: props.accent
 }))
 

--- a/src/runtime/components/prose/H5.vue
+++ b/src/runtime/components/prose/H5.vue
@@ -38,7 +38,7 @@ const props = useComponentProps('prose.h5', _props)
 const appConfig = useAppConfig() as ProseH5['AppConfig']
 
 // eslint-disable-next-line vue/no-dupe-keys
-const b24ui = computed(() => tv({ extend: tv(theme), ...(appConfig.b24ui?.prose?.h5 || {}) })({
+const b24ui = computed(() => tv({ extend: theme, ...(appConfig.b24ui?.prose?.h5 || {}) })({
   accent: props.accent
 }))
 </script>

--- a/src/runtime/components/prose/H6.vue
+++ b/src/runtime/components/prose/H6.vue
@@ -38,7 +38,7 @@ const props = useComponentProps('prose.h6', _props)
 const appConfig = useAppConfig() as ProseH6['AppConfig']
 
 // eslint-disable-next-line vue/no-dupe-keys
-const b24ui = computed(() => tv({ extend: tv(theme), ...(appConfig.b24ui?.prose?.h6 || {}) })({
+const b24ui = computed(() => tv({ extend: theme, ...(appConfig.b24ui?.prose?.h6 || {}) })({
   accent: props.accent
 }))
 </script>

--- a/src/runtime/components/prose/Hr.vue
+++ b/src/runtime/components/prose/Hr.vue
@@ -24,7 +24,7 @@ const props = useComponentProps('prose.hr', _props)
 const appConfig = useAppConfig() as ProseHr['AppConfig']
 
 // eslint-disable-next-line vue/no-dupe-keys
-const b24ui = computed(() => tv({ extend: tv(theme), ...(appConfig.b24ui?.prose?.hr || {}) })())
+const b24ui = computed(() => tv({ extend: theme, ...(appConfig.b24ui?.prose?.hr || {}) })())
 </script>
 
 <template>

--- a/src/runtime/components/prose/Img.vue
+++ b/src/runtime/components/prose/Img.vue
@@ -47,7 +47,7 @@ const [DefineZoomedImageTemplate, ReuseZoomedImageTemplate] = createReusableTemp
 const open = ref(false)
 
 // eslint-disable-next-line vue/no-dupe-keys
-const b24ui = computed(() => tv({ extend: tv(theme), ...(appConfig.b24ui?.prose?.img || {}) })({
+const b24ui = computed(() => tv({ extend: theme, ...(appConfig.b24ui?.prose?.img || {}) })({
   zoom: props.zoom,
   open: open.value,
   width: !!props.width

--- a/src/runtime/components/prose/Kbd.vue
+++ b/src/runtime/components/prose/Kbd.vue
@@ -32,7 +32,7 @@ const props = useComponentProps('prose.kbd', _props)
 const appConfig = useAppConfig() as ProseKbd['AppConfig']
 
 // eslint-disable-next-line vue/no-dupe-keys
-const b24ui = computed(() => tv({ extend: tv(theme), ...(appConfig.b24ui?.prose?.kbd || {}) }))
+const b24ui = computed(() => tv({ extend: theme, ...(appConfig.b24ui?.prose?.kbd || {}) }))
 </script>
 
 <template>

--- a/src/runtime/components/prose/Li.vue
+++ b/src/runtime/components/prose/Li.vue
@@ -31,7 +31,7 @@ const props = useComponentProps('prose.li', _props)
 const appConfig = useAppConfig() as ProseLi['AppConfig']
 
 // eslint-disable-next-line vue/no-dupe-keys
-const b24ui = computed(() => tv({ extend: tv(theme), ...(appConfig.b24ui?.prose?.li || {}) })())
+const b24ui = computed(() => tv({ extend: theme, ...(appConfig.b24ui?.prose?.li || {}) })())
 </script>
 
 <template>

--- a/src/runtime/components/prose/Ol.vue
+++ b/src/runtime/components/prose/Ol.vue
@@ -31,7 +31,7 @@ const props = useComponentProps('prose.ol', _props)
 const appConfig = useAppConfig() as ProseOl['AppConfig']
 
 // eslint-disable-next-line vue/no-dupe-keys
-const b24ui = computed(() => tv({ extend: tv(theme), ...(appConfig.b24ui?.prose?.ol || {}) })())
+const b24ui = computed(() => tv({ extend: theme, ...(appConfig.b24ui?.prose?.ol || {}) })())
 </script>
 
 <template>

--- a/src/runtime/components/prose/P.vue
+++ b/src/runtime/components/prose/P.vue
@@ -42,7 +42,7 @@ const props = useComponentProps('prose.p', _props)
 const appConfig = useAppConfig() as ProseP['AppConfig']
 
 // eslint-disable-next-line vue/no-dupe-keys
-const b24ui = computed(() => tv({ extend: tv(theme), ...(appConfig.b24ui?.prose?.p || {}) })({
+const b24ui = computed(() => tv({ extend: theme, ...(appConfig.b24ui?.prose?.p || {}) })({
   small: Boolean(props.small),
   accent: props.accent
 }))

--- a/src/runtime/components/prose/Pre.vue
+++ b/src/runtime/components/prose/Pre.vue
@@ -49,7 +49,7 @@ const appConfig = useAppConfig() as ProsePre['AppConfig']
 const baseRef = useTemplateRef('baseRef')
 
 // eslint-disable-next-line vue/no-dupe-keys
-const b24ui = computed(() => tv({ extend: tv(theme), ...(appConfig.b24ui?.prose?.pre || {}) })())
+const b24ui = computed(() => tv({ extend: theme, ...(appConfig.b24ui?.prose?.pre || {}) })())
 
 function copyCode() {
   const code = props.code ?? baseRef.value?.textContent ?? ''

--- a/src/runtime/components/prose/Prompt.vue
+++ b/src/runtime/components/prose/Prompt.vue
@@ -61,7 +61,7 @@ const appConfig = useAppConfig() as ProsePrompt['AppConfig']
 const bodyRef = useTemplateRef<HTMLElement>('bodyRef')
 
 // eslint-disable-next-line vue/no-dupe-keys
-const b24ui = computed(() => tv({ extend: tv(theme), ...(appConfig.b24ui?.prose?.prompt || {}) })())
+const b24ui = computed(() => tv({ extend: theme, ...(appConfig.b24ui?.prose?.prompt || {}) })())
 
 const iconFromIconName = computed(() => resolveIcon(props.iconName))
 

--- a/src/runtime/components/prose/Steps.vue
+++ b/src/runtime/components/prose/Steps.vue
@@ -36,7 +36,7 @@ const props = useComponentProps('prose.steps', _props)
 const appConfig = useAppConfig() as ProseSteps['AppConfig']
 
 // eslint-disable-next-line vue/no-dupe-keys
-const b24ui = computed(() => tv({ extend: tv(theme), ...(appConfig.b24ui?.prose?.steps || {}) }))
+const b24ui = computed(() => tv({ extend: theme, ...(appConfig.b24ui?.prose?.steps || {}) }))
 </script>
 
 <template>

--- a/src/runtime/components/prose/Strong.vue
+++ b/src/runtime/components/prose/Strong.vue
@@ -31,7 +31,7 @@ const props = useComponentProps('prose.strong', _props)
 const appConfig = useAppConfig() as ProseStrong['AppConfig']
 
 // eslint-disable-next-line vue/no-dupe-keys
-const b24ui = computed(() => tv({ extend: tv(theme), ...(appConfig.b24ui?.prose?.strong || {}) })())
+const b24ui = computed(() => tv({ extend: theme, ...(appConfig.b24ui?.prose?.strong || {}) })())
 </script>
 
 <template>

--- a/src/runtime/components/prose/Table.vue
+++ b/src/runtime/components/prose/Table.vue
@@ -61,7 +61,7 @@ const props = useComponentProps('prose.table', _props)
 const appConfig = useAppConfig() as ProseTable['AppConfig']
 
 // eslint-disable-next-line vue/no-dupe-keys
-const b24ui = computed(() => tv({ extend: tv(theme), ...(appConfig.b24ui?.prose?.table || {}) })())
+const b24ui = computed(() => tv({ extend: theme, ...(appConfig.b24ui?.prose?.table || {}) })())
 </script>
 
 <template>

--- a/src/runtime/components/prose/Tabs.vue
+++ b/src/runtime/components/prose/Tabs.vue
@@ -51,7 +51,7 @@ const model = defineModel<string>()
 const appConfig = useAppConfig() as ProseTabs['AppConfig']
 
 // eslint-disable-next-line vue/no-dupe-keys
-const b24ui = computed(() => tv({ extend: tv(theme), ...(appConfig.b24ui?.prose?.tabs || {}) }))
+const b24ui = computed(() => tv({ extend: theme, ...(appConfig.b24ui?.prose?.tabs || {}) }))
 
 const rerenderCount = ref(1)
 

--- a/src/runtime/components/prose/TabsItem.vue
+++ b/src/runtime/components/prose/TabsItem.vue
@@ -33,7 +33,7 @@ const props = useComponentProps('prose.tabsItem', _props)
 const appConfig = useAppConfig() as ProseTabsItem['AppConfig']
 
 // eslint-disable-next-line vue/no-dupe-keys
-const b24ui = computed(() => tv({ extend: tv(theme), ...(appConfig.b24ui?.prose?.tabsItem || {}) }))
+const b24ui = computed(() => tv({ extend: theme, ...(appConfig.b24ui?.prose?.tabsItem || {}) }))
 </script>
 
 <template>

--- a/src/runtime/components/prose/Tbody.vue
+++ b/src/runtime/components/prose/Tbody.vue
@@ -31,7 +31,7 @@ const props = useComponentProps('prose.tbody', _props)
 const appConfig = useAppConfig() as ProseTbody['AppConfig']
 
 // eslint-disable-next-line vue/no-dupe-keys
-const b24ui = computed(() => tv({ extend: tv(theme), ...(appConfig.b24ui?.prose?.tbody || {}) })())
+const b24ui = computed(() => tv({ extend: theme, ...(appConfig.b24ui?.prose?.tbody || {}) })())
 </script>
 
 <template>

--- a/src/runtime/components/prose/Td.vue
+++ b/src/runtime/components/prose/Td.vue
@@ -32,7 +32,7 @@ const props = useComponentProps('prose.td', _props)
 const appConfig = useAppConfig() as ProseTd['AppConfig']
 
 // eslint-disable-next-line vue/no-dupe-keys
-const b24ui = computed(() => tv({ extend: tv(theme), ...(appConfig.b24ui?.prose?.td || {}) })({
+const b24ui = computed(() => tv({ extend: theme, ...(appConfig.b24ui?.prose?.td || {}) })({
   align: props.align
 }))
 </script>

--- a/src/runtime/components/prose/Th.vue
+++ b/src/runtime/components/prose/Th.vue
@@ -32,7 +32,7 @@ const props = useComponentProps('prose.th', _props)
 const appConfig = useAppConfig() as ProseTh['AppConfig']
 
 // eslint-disable-next-line vue/no-dupe-keys
-const b24ui = computed(() => tv({ extend: tv(theme), ...(appConfig.b24ui?.prose?.th || {}) })({
+const b24ui = computed(() => tv({ extend: theme, ...(appConfig.b24ui?.prose?.th || {}) })({
   align: props.align
 }))
 </script>

--- a/src/runtime/components/prose/Thead.vue
+++ b/src/runtime/components/prose/Thead.vue
@@ -31,7 +31,7 @@ const props = useComponentProps('prose.thead', _props)
 const appConfig = useAppConfig() as ProseThead['AppConfig']
 
 // eslint-disable-next-line vue/no-dupe-keys
-const b24ui = computed(() => tv({ extend: tv(theme), ...(appConfig.b24ui?.prose?.thead || {}) })())
+const b24ui = computed(() => tv({ extend: theme, ...(appConfig.b24ui?.prose?.thead || {}) })())
 </script>
 
 <template>

--- a/src/runtime/components/prose/Tr.vue
+++ b/src/runtime/components/prose/Tr.vue
@@ -31,7 +31,7 @@ const props = useComponentProps('prose.tr', _props)
 const appConfig = useAppConfig() as ProseTr['AppConfig']
 
 // eslint-disable-next-line vue/no-dupe-keys
-const b24ui = computed(() => tv({ extend: tv(theme), ...(appConfig.b24ui?.prose?.tr || {}) })())
+const b24ui = computed(() => tv({ extend: theme, ...(appConfig.b24ui?.prose?.tr || {}) })())
 </script>
 
 <template>

--- a/src/runtime/components/prose/Ul.vue
+++ b/src/runtime/components/prose/Ul.vue
@@ -31,7 +31,7 @@ const props = useComponentProps('prose.ul', _props)
 const appConfig = useAppConfig() as ProseUl['AppConfig']
 
 // eslint-disable-next-line vue/no-dupe-keys
-const b24ui = computed(() => tv({ extend: tv(theme), ...(appConfig.b24ui?.prose?.ul || {}) })())
+const b24ui = computed(() => tv({ extend: theme, ...(appConfig.b24ui?.prose?.ul || {}) })())
 </script>
 
 <template>

--- a/src/runtime/utils/tv.ts
+++ b/src/runtime/utils/tv.ts
@@ -221,7 +221,7 @@ function extractDirectives(componentConfig: any): { config: any, directives?: Re
  * Wraps `tailwind-variants`' `tv` so slot classes can be **replaced** (not just
  * merged) through a function form — `(defaults) => classes` — in `:b24ui`, the
  * `class` prop and `app.config.b24ui`. The wrapper is transparent for every other
- * usage: it preserves the `TVReturnType` (so `extend: tv(theme)` keeps working
+ * usage: it preserves the `TVReturnType` (so `extend: theme` keeps working
  * via property reads) and only intercepts the slot functions on invocation.
  */
 export const tv = ((componentConfig?: any) => {

--- a/src/runtime/vue/overrides/inertia/Link.vue
+++ b/src/runtime/vue/overrides/inertia/Link.vue
@@ -99,7 +99,7 @@ const appConfig = useAppConfig() as Link['AppConfig']
 const routerLinkProps = useForwardProps(reactiveOmit(props, 'as', 'type', 'disabled', 'active', 'exact', 'activeClass', 'inactiveClass', 'to', 'href', 'raw', 'custom', 'class', 'noRel'))
 
 const b24ui = computed(() => tv({
-  extend: tv(theme),
+  extend: theme,
   ...defu({
     variants: {
       active: {

--- a/src/runtime/vue/overrides/none/Link.vue
+++ b/src/runtime/vue/overrides/none/Link.vue
@@ -96,7 +96,7 @@ defineSlots<LinkSlots>()
 const appConfig = useAppConfig() as Link['AppConfig']
 
 const b24ui = computed(() => tv({
-  extend: tv(theme),
+  extend: theme,
   ...defu({
     variants: {
       active: {

--- a/src/runtime/vue/overrides/vue-router/Link.vue
+++ b/src/runtime/vue/overrides/vue-router/Link.vue
@@ -94,7 +94,7 @@ const appConfig = useAppConfig() as Link['AppConfig']
 const routerLinkProps = useForwardProps(reactiveOmit(props, 'as', 'type', 'disabled', 'active', 'exact', 'exactQuery', 'exactHash', 'activeClass', 'inactiveClass', 'to', 'href', 'raw', 'custom', 'class', 'noRel'))
 
 const b24ui = computed(() => tv({
-  extend: tv(theme),
+  extend: theme,
   ...defu({
     variants: {
       active: {


### PR DESCRIPTION
## Upstream
[`3bf1a92`](https://github.com/nuxt/ui/commit/3bf1a92a9d3aa47ee7f02c1b2363363bc906f313) — `perf(components): drop the redundant inner in component extend (#6647)`

## Change — direct 1:1 (mechanical)
Every component composes its theme as `tv({ extend: tv(theme), … })(…)`. `tv`'s `extend` accepts a raw theme object directly, so the inner `tv(theme)` wrapper is redundant:

```diff
- const b24ui = computed(() => tv({ extend: tv(theme), ...(appConfig.b24ui?.accordion || {}) })({
+ const b24ui = computed(() => tv({ extend: theme, ...(appConfig.b24ui?.accordion || {}) })({
```

Applied to all **162** occurrences across `src/runtime/{components,components/prose,components/content,vue/overrides/*}` — exactly one line per file (162 files, +162/−162). The outer `tv({ … })(…)` call is unchanged, so `tv` stays imported and used. (Upstream touched 163 files; the 1-file delta is just the diverging component set.)

## Tests
Behaviour-preserving (identical resolved theme) → no runtime/markup change, **no snapshot churn**. Full suite unchanged (225 files, 5143 passed / 6 skipped).

## Verify (CI=true)
`dev:prepare` · `lint` · `typecheck` · `test` · `build` — all green.

## Ledger
- `.sync/log/3bf1a92….md` — port rationale
- `.sync/nuxt-ui.json` — add `3bf1a92` as `port`, advance cursor; reconcile prior `7eab4bc` → PR #227 / `575c8dee`. (`3bf1a92` itself stays `pending-merge`, reconciled next port.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JS8ypVfQSFzYVZzkTHhURb)_