### PR TITLE
chore(deps): update dependency reka-ui to v2.10.1

### DIFF
--- a/.sync/log/82cd5b526cf87517d931439b8ce85ed70c88cc87.md
+++ b/.sync/log/82cd5b526cf87517d931439b8ce85ed70c88cc87.md
@@ -1,0 +1,26 @@
+# Port: chore(deps): update dependency reka-ui to v2.10.1 (#6652)
+
+**Upstream:** `82cd5b526cf87517d931439b8ce85ed70c88cc87` (nuxt/ui)
+**Decision:** port
+
+## Upstream change
+Renovate patch bump of the exact-pinned `reka-ui` dependency: `2.10.0` →
+`2.10.1` in root `package.json`, plus the corresponding `pnpm-lock.yaml`
+churn (reka-ui's own entry + the `vaul-vue` transitive that depends on it).
+
+## b24ui port — direct 1:1
+`reka-ui` is pinned exactly (`2.10.0`) only in the **root** `package.json` in
+b24ui (same as upstream — playgrounds/docs pull it transitively via
+`@bitrix24/b24ui-nuxt`, none pin it directly), so §2 manifest-mirroring has no
+other targets here. Bumped root `package.json` to `2.10.1` and regenerated the
+lockfile under the CI gate (`CI=true pnpm install --lockfile-only`,
+pnpm 11.8.0). Lockfile diff is exactly the reka-ui + vaul-vue retarget
+(8/+8−), and the resolved integrity for `reka-ui@2.10.1`
+(`sha512-drcOQ4rQtDYAcGCsyQBqQg8QQ…`) matches the upstream patch byte-for-byte.
+
+## Tests
+Patch dep bump, no source/markup change → no snapshot churn. Full suite
+unchanged (225 files, 5143 passed / 6 skipped).
+
+## Verify (CI=true)
+`dev:prepare` · `lint` · `typecheck` · `test` · `build` — all green.

--- a/.sync/nuxt-ui.json
+++ b/.sync/nuxt-ui.json
@@ -2,7 +2,7 @@
   "upstream": "nuxt/ui",
   "branch": "v4",
   "sync_enabled": false,
-  "cursor": "3bf1a92a9d3aa47ee7f02c1b2363363bc906f313",
+  "cursor": "82cd5b526cf87517d931439b8ce85ed70c88cc87",
   "_cursor_note": "cursor = last upstream commit ported into b24ui (oldest-first, manual cadence). sync_enabled stays false until Phase 2 (porter workflow #67 + CLAUDE_CODE_OAUTH_TOKEN) is wired and trusted. `processed` is maintained per port from now on (backfilled #68-#72 on 2026-06-09).",
   "stats": {
     "queue_depth": 0,
@@ -785,10 +785,16 @@
       "summary": "perf(types): import cross-component types from source, not the barrel (#6646) — replace `import type {...} from '../types'` barrel imports with per-source imports (owning component .vue, e.g. ButtonProps from ./Button.vue; or specific ../types/* module, e.g. Messages from ../types/locale) across 119 consumer files in src/runtime/{components,composables,utils,dictionary,locale,vue/...}; +eslint no-restricted-imports guard on ../types & ../../types for components/**/*.vue + composables/**/*.ts, with useComponentProps.ts exempted (keeps `import type * as ComponentTypes from '../types'`). Adapted, not 1:1: resolved each type->source against b24ui's OWN exports (IconComponent->../types/icons since b24ui has no Icon.vue; own component set; curated 20 locale files vs upstream 62 per §2). 0 unresolved / 0 ambiguous names. Rule appended via existing .append chain (bitrix24-ui/ namespace). Types-only, no snapshot churn. 120 files, +284/-120. Rebased onto main after v2.9.0 release (#226) landed mid-CI"
     },
     "3bf1a92a9d3aa47ee7f02c1b2363363bc906f313": {
+      "pr": 228,
+      "b24ui_sha": "9c2a5afa",
+      "decision": "port",
+      "summary": "perf(components): drop the redundant inner in component extend (#6647) — replace `extend: tv(theme)` -> `extend: theme` across all 162 occurrences in src/runtime/{components,components/prose,components/content,vue/overrides/*} (tv's extend takes a raw theme object; inner tv() wrapper redundant). Outer tv({...})(...) unchanged so tv stays imported. Direct 1:1 mechanical (1 line/file, 162 files, +162/-162; upstream 163, delta = diverging component set). appConfig.b24ui?.<name> spread pre-existing/untouched. Behaviour-preserving, no snapshot churn"
+    },
+    "82cd5b526cf87517d931439b8ce85ed70c88cc87": {
       "pr": null,
       "b24ui_sha": "pending-merge",
       "decision": "port",
-      "summary": "perf(components): drop the redundant inner in component extend (#6647) — replace `extend: tv(theme)` -> `extend: theme` across all 162 occurrences in src/runtime/{components,components/prose,components/content,vue/overrides/*} (tv's extend takes a raw theme object; inner tv() wrapper redundant). Outer tv({...})(...) unchanged so tv stays imported. Direct 1:1 mechanical (1 line/file, 162 files, +162/-162; upstream 163, delta = diverging component set). appConfig.b24ui?.<name> spread pre-existing/untouched. Behaviour-preserving, no snapshot churn"
+      "summary": "chore(deps): update dependency reka-ui to v2.10.1 (#6652) — exact-pin bump reka-ui 2.10.0->2.10.1 in root package.json (only manifest pinning it; playgrounds/docs get it transitively) + lockfile regen under CI gate (reka-ui entry + vaul-vue transitive, 8/+8-; integrity sha512-drcOQ4r... matches upstream byte-for-byte). Direct 1:1, no snapshot churn"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -189,7 +189,7 @@
     "motion-v": "^2.3.0",
     "ohash": "^2.0.11",
     "pathe": "^2.0.3",
-    "reka-ui": "2.10.0",
+    "reka-ui": "2.10.1",
     "scule": "^1.3.0",
     "tailwind-merge": "^3.6.0",
     "tailwind-variants": "^3.2.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -185,8 +185,8 @@ importers:
         specifier: ^2.0.3
         version: 2.0.3
       reka-ui:
-        specifier: 2.10.0
-        version: 2.10.0(vue@3.5.38(typescript@6.0.3))
+        specifier: 2.10.1
+        version: 2.10.1(vue@3.5.38(typescript@6.0.3))
       scule:
         specifier: ^1.3.0
         version: 1.3.0
@@ -225,7 +225,7 @@ importers:
         version: 1.4.1(typescript@6.0.3)
       vaul-vue:
         specifier: 0.4.1
-        version: 0.4.1(reka-ui@2.10.0(vue@3.5.38(typescript@6.0.3)))(vue@3.5.38(typescript@6.0.3))
+        version: 0.4.1(reka-ui@2.10.1(vue@3.5.38(typescript@6.0.3)))(vue@3.5.38(typescript@6.0.3))
       vue-component-type-helpers:
         specifier: ^3.3.5
         version: 3.3.5
@@ -7161,8 +7161,8 @@ packages:
   rehype-sort-attributes@5.0.1:
     resolution: {integrity: sha512-Bxo+AKUIELcnnAZwJDt5zUDDRpt4uzhfz9d0PVGhcxYWsbFj5Cv35xuWxu5r1LeYNFNhgGqsr9Q2QiIOM/Qctg==}
 
-  reka-ui@2.10.0:
-    resolution: {integrity: sha512-HIUVfSBM/AyGkcUI7aiOxxMc4N+0UD2ZEun8dcrT0H4fveotEoeDdvzyZu97eeEvEa1H9oGHoOpApkfxlgnC7g==}
+  reka-ui@2.10.1:
+    resolution: {integrity: sha512-drcOQ4rQtDYAcGCsyQBqQg8QQ+H3B+zDaMJU0h8KPEPMa7g9BHu3zcOi4OB39XJSWizceFoNO0Z9tctSGLOXqg==}
     peerDependencies:
       vue: '>= 3.4.0'
 
@@ -15927,7 +15927,7 @@ snapshots:
       '@types/hast': 3.0.4
       unist-util-visit: 5.1.0
 
-  reka-ui@2.10.0(vue@3.5.38(typescript@6.0.3)):
+  reka-ui@2.10.1(vue@3.5.38(typescript@6.0.3)):
     dependencies:
       '@floating-ui/dom': 1.7.6
       '@floating-ui/vue': 1.1.11(vue@3.5.38(typescript@6.0.3))
@@ -16958,10 +16958,10 @@ snapshots:
 
   vary@1.1.2: {}
 
-  vaul-vue@0.4.1(reka-ui@2.10.0(vue@3.5.38(typescript@6.0.3)))(vue@3.5.38(typescript@6.0.3)):
+  vaul-vue@0.4.1(reka-ui@2.10.1(vue@3.5.38(typescript@6.0.3)))(vue@3.5.38(typescript@6.0.3)):
     dependencies:
       '@vueuse/core': 10.11.1(vue@3.5.38(typescript@6.0.3))
-      reka-ui: 2.10.0(vue@3.5.38(typescript@6.0.3))
+      reka-ui: 2.10.1(vue@3.5.38(typescript@6.0.3))
       vue: 3.5.38(typescript@6.0.3)
     transitivePeerDependencies:
       - '@vue/composition-api'


### PR DESCRIPTION
## Upstream
[`82cd5b5`](https://github.com/nuxt/ui/commit/82cd5b526cf87517d931439b8ce85ed70c88cc87) — `chore(deps): update dependency reka-ui to v2.10.1 (#6652)`

## Change — direct 1:1
Patch bump of the exact-pinned `reka-ui` dependency: `2.10.0` → `2.10.1` in root `package.json`, plus lockfile churn (reka-ui's entry + the `vaul-vue` transitive that depends on it).

`reka-ui` is pinned only in the **root** manifest (same as upstream — playgrounds/docs get it transitively via `@bitrix24/b24ui-nuxt`), so §2 has no other mirror targets. Lockfile regenerated under the CI gate (pnpm 11.8.0); diff is exactly reka-ui + vaul-vue (+8/−8), and the resolved integrity for `reka-ui@2.10.1` (`sha512-drcOQ4rQtDYAcGCsyQBqQg8QQ…`) matches the upstream patch byte-for-byte.

## Tests
Patch dep bump, no source/markup change → no snapshot churn. Full suite unchanged (225 files, 5143 passed / 6 skipped).

## Verify (CI=true)
`dev:prepare` · `lint` · `typecheck` · `test` · `build` — all green.

## Ledger
- `.sync/log/82cd5b5….md` — port rationale
- `.sync/nuxt-ui.json` — add `82cd5b5` as `port`, advance cursor; reconcile prior `3bf1a92` → PR #228 / `9c2a5afa`. (`82cd5b5` itself stays `pending-merge`, reconciled next port.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JS8ypVfQSFzYVZzkTHhURb)_