### PR TITLE
chore(sync): no-op upstream reproduire workflow version pin (08bdab4)

### DIFF
--- a/.sync/log/08bdab4fd97d0a42e5fb1cda08dc32510b855837.md
+++ b/.sync/log/08bdab4fd97d0a42e5fb1cda08dc32510b855837.md
@@ -1,0 +1,17 @@
+# Port: chore(github): update reproduire workflow version
+
+**Upstream:** `08bdab4fd97d0a42e5fb1cda08dc32510b855837` (nuxt/ui)
+**Decision:** no-op
+
+## Upstream change
+Single-file change to `.github/workflows/reproduire.yml`: re-pins the
+`Hebilicious/reproduire` action from the floating `@v1` tag back to a commit SHA
+(`@4b686ae9… # v0.0.9`). (Partially reverts the un-pin done in `df099a5`.)
+
+## b24ui decision — no-op
+b24ui has **no `reproduire.yml` workflow** (`.github/workflows/` = `ci.yml`,
+`deploy.yml`, `npm-publish.yml` only). The upstream reproduction-label workflow
+has no b24ui counterpart — same basis as the `df099a5` (#232) port, where the
+`reproduire.yml`/`Hebilicious` hunk was already N/A. Nothing to change.
+
+No file change — bookkeeping only.

--- a/.sync/nuxt-ui.json
+++ b/.sync/nuxt-ui.json
@@ -2,7 +2,7 @@
   "upstream": "nuxt/ui",
   "branch": "v4",
   "sync_enabled": false,
-  "cursor": "7e6d0f767666be718ae32709a029cfe456fb660b",
+  "cursor": "08bdab4fd97d0a42e5fb1cda08dc32510b855837",
   "_cursor_note": "cursor = last upstream commit ported into b24ui (oldest-first, manual cadence). sync_enabled stays false until Phase 2 (porter workflow #67 + CLAUDE_CODE_OAUTH_TOKEN) is wired and trusted. `processed` is maintained per port from now on (backfilled #68-#72 on 2026-06-09).",
   "stats": {
     "queue_depth": 0,
@@ -833,10 +833,16 @@
       "summary": "feat(module): pre-bundle used icons into @nuxt/icon client bundle — NO-OP: whole commit is @nuxt/icon+iconify machinery (new src/utils/icons.ts getClientBundleIcons parsing i-{collection}-{name} -> {collection}:{name}; module.ts icon:clientBundleIcons hook; @nuxt/icon 2.2.4->2.2.5 + pnpm-workspace minimumReleaseAgeExclude; docs about clientBundle/@iconify-json). b24ui has NO @nuxt/icon dep (grep => none; only commented-out in module.ts), renders icons via @bitrix24/b24icons-vue components, no theme/icons.ts, no utils/icons.ts, no icon:clientBundleIcons hook. Docs prose describes @nuxt/icon clientBundle behavior b24ui doesn't implement -> not carried over. Matches prior @nuxt/icon no-ops #69/#219. Bookkeeping only"
     },
     "7e6d0f767666be718ae32709a029cfe456fb660b": {
-      "pr": null,
-      "b24ui_sha": "pending-merge",
+      "pr": 236,
+      "b24ui_sha": "85d5bd31",
       "decision": "port",
       "summary": "feat(Table): add getScrollElement virtualize option (#6657) — Table.vue: new getScrollElement?:()=>Element|null in virtualize option (removed from Omit); isExternalScroll computed + externalScroll tv variant (alongside b24ui's extra virtualize variant); getScrollElement resolver + scrollMargin computed wired into useVirtualizer (scrollMargin getter + getScrollElement); virtualPaddingTop -=scrollMargin, virtualPaddingBottom +=scrollMargin. theme/table.ts +externalScroll:{true:{root:'overflow-visible'}} (after sticky). ScrollArea refactor: move isExternalScroll above tv + externalScroll variant; offset simplified to start-virtualizerProps.scrollMargin (defaults 0); drop inline overflow:visible root style (now theme variant). theme/scroll-area.ts +externalScroll variant. Component 1:1 (b24ui matched pre-change). +Table renderEach case; 4 snapshots (Table +2 new case overflow-visible; ScrollArea 2 updated inline-style->overflow-visible class). Docs adapted: table.md section (badge New) + NEW TableExternalScrollExample (b24ui payments table: overflow-auto container + sticky title scrollMargin via useElementSize + B24Table virtualize getScrollElement/scrollMargin, :b24ui; TableColumn from @bitrix24/b24ui-nuxt, resolveComponent B24Badge, air status colors like TableVirtualizeExample); ScrollArea example extended with horizontal orientation (orientation prop, axis-aware itemSize/scrollMargin, Start/Top button ArrowToTheLeft/Top) + scroll-area.md orientation options block (find-toolbar stays dropped from #a84de85). useElementSize imported from @vueuse/core. Tests 5147 passed (+2)"
+    },
+    "08bdab4fd97d0a42e5fb1cda08dc32510b855837": {
+      "pr": null,
+      "b24ui_sha": "pending-merge",
+      "decision": "no-op",
+      "summary": "chore(github): update reproduire workflow version — NO-OP: re-pins Hebilicious/reproduire @v1 -> @4b686ae...#v0.0.9 in .github/workflows/reproduire.yml (partial revert of df099a5's un-pin). b24ui has no reproduire.yml (only ci/deploy/npm-publish workflows); same N/A basis as df099a5 (#232). Bookkeeping only"
     }
   }
 }


### PR DESCRIPTION
## Upstream
[`08bdab4`](https://github.com/nuxt/ui/commit/08bdab4fd97d0a42e5fb1cda08dc32510b855837) — `chore(github): update reproduire workflow version`

Re-pins the `Hebilicious/reproduire` action from the floating `@v1` tag back to a commit SHA (`@4b686ae… # v0.0.9`) in `.github/workflows/reproduire.yml` — a partial revert of the un-pin in `df099a5`.

## Decision — no-op
b24ui has **no `reproduire.yml` workflow** (`.github/workflows/` = `ci.yml`, `deploy.yml`, `npm-publish.yml` only). Same N/A basis as the `df099a5` port (#232), where the `reproduire.yml`/`Hebilicious` hunk was already skipped. Nothing to change.

Bookkeeping only:
- `.sync/log/08bdab4….md` — rationale
- `.sync/nuxt-ui.json` — reconcile prior `7e6d0f7` → PR #236 / `85d5bd31`, add `08bdab4` as `no-op`, advance cursor (= upstream v4 HEAD)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JS8ypVfQSFzYVZzkTHhURb)_