### PR TITLE
chore(sync): defer upstream AI SDK v7 migration (dfbbfeb)

### DIFF
--- a/.sync/log/dfbbfeb5a9ab3cbaf9582ba3393cceb1584baa5e.md
+++ b/.sync/log/dfbbfeb5a9ab3cbaf9582ba3393cceb1584baa5e.md
@@ -1,0 +1,52 @@
+# Port: chore(deps): migrate AI SDK to v7 (#6636)
+
+**Upstream:** `dfbbfeb5a9ab3cbaf9582ba3393cceb1584baa5e` (nuxt/ui)
+**Decision:** skip (deferred — tracked for a deliberate AI-SDK-v7 adoption pass)
+
+## Upstream change
+Major AI SDK migration:
+- deps: `ai` `^6`→`^7`, `@ai-sdk/anthropic` `^3`→`^4`, `@ai-sdk/gateway`
+  `^3`→`^4`, `@ai-sdk/mcp` `^1`→`^2`, `@ai-sdk/vue` `^3`→`^4` (root + docs +
+  playground manifests + lockfile); root `package.json` marks `ai` an optional
+  peer (`^6 || ^7`).
+- docs/playground **client**: migrate every chat example + `Chat.vue` +
+  playground chat/sidebar pages from the `new Chat({...})` class (`@ai-sdk/vue`)
+  to the `useChat()` composable (`messages`/`status`/`error` become refs;
+  `sendMessage`/`regenerate`/`stop`; `input`/`handleSubmit` removed).
+- docs/playground **server**: rewrite `ai.post.ts`/`chat.post.ts`/
+  `completion.post.ts` to the v7 streaming API — `system`→`instructions`,
+  `stepCountIs`→`isStepCount`, `.toUIMessageStreamResponse()`→
+  `toUIMessageStream()` + `createUIMessageStreamResponse()`,
+  `.toTextStreamResponse()`→`createTextStreamResponse()`, `onFinish`→`onEnd`,
+  model ids bumped (`claude-sonnet-4.6`→`claude-sonnet-5`).
+- docs prose (chat/editor/migration guide) + the `skills/nuxt-ui` chat layout
+  reference updated to match. **No `src/runtime` component change** upstream.
+
+## b24ui decision — skip / defer
+This is a **major**-version dependency migration, not a mechanical port, and it
+touches b24ui surfaces upstream does not:
+
+- **b24ui runtime uses `ai`.** `src/runtime/components/{ChatMessages,ChatMessage,
+  ChatPromptSubmit}.vue` and `src/runtime/utils/ai.ts` import from `ai`. Upstream
+  changed no `src/runtime` file (its runtime was already v7-safe), but b24ui
+  adopting `ai@7` requires verifying b24ui's runtime still typechecks against the
+  v7 type surface (`UIMessage`, `ChatStatus`, etc.) — which the upstream diff
+  gives no guidance on.
+- **b24ui-only `bx-assistant` module.** `docs/modules/bx-assistant/`
+  (`AssistantPanel.vue`, `runtime/server/api/search.ts`,
+  `runtime/composables/useAssistant.ts`) is a b24ui fork addition that uses
+  `@ai-sdk/vue` + `streamText` with **no upstream counterpart** — it would need a
+  hand-authored, independently-tested migration to the v7 API.
+- b24ui keeps its own curated `ai`/`@ai-sdk` pins across root/docs/demo/nuxt (see
+  the cd52459 §2 port); a v7 jump must be mirrored and lockfile-regenerated with
+  the runtime + custom module verified end-to-end.
+
+Deferring is consistent with prior maintainer deferrals of non-mechanical,
+b24ui-divergent work (#220 InputRating, #194 Calendar). b24ui stays on `ai@6`
+for now; the v7 adoption should be a deliberate, separately-tested pass that
+migrates the runtime types **and** the `bx-assistant` module, not a diff replay.
+(Also noted: verbatim upstream `.patch` fetch is currently egress-blocked, so a
+faithful large-file replay isn't cleanly available this session.)
+
+No `src`/manifest change — bookkeeping only; ledger `decision: skip`, cursor
+advances. Tracked for a future AI-SDK-v7 migration task.

--- a/.sync/nuxt-ui.json
+++ b/.sync/nuxt-ui.json
@@ -2,7 +2,7 @@
   "upstream": "nuxt/ui",
   "branch": "v4",
   "sync_enabled": false,
-  "cursor": "08bdab4fd97d0a42e5fb1cda08dc32510b855837",
+  "cursor": "dfbbfeb5a9ab3cbaf9582ba3393cceb1584baa5e",
   "_cursor_note": "cursor = last upstream commit ported into b24ui (oldest-first, manual cadence). sync_enabled stays false until Phase 2 (porter workflow #67 + CLAUDE_CODE_OAUTH_TOKEN) is wired and trusted. `processed` is maintained per port from now on (backfilled #68-#72 on 2026-06-09).",
   "stats": {
     "queue_depth": 0,
@@ -839,10 +839,16 @@
       "summary": "feat(Table): add getScrollElement virtualize option (#6657) — Table.vue: new getScrollElement?:()=>Element|null in virtualize option (removed from Omit); isExternalScroll computed + externalScroll tv variant (alongside b24ui's extra virtualize variant); getScrollElement resolver + scrollMargin computed wired into useVirtualizer (scrollMargin getter + getScrollElement); virtualPaddingTop -=scrollMargin, virtualPaddingBottom +=scrollMargin. theme/table.ts +externalScroll:{true:{root:'overflow-visible'}} (after sticky). ScrollArea refactor: move isExternalScroll above tv + externalScroll variant; offset simplified to start-virtualizerProps.scrollMargin (defaults 0); drop inline overflow:visible root style (now theme variant). theme/scroll-area.ts +externalScroll variant. Component 1:1 (b24ui matched pre-change). +Table renderEach case; 4 snapshots (Table +2 new case overflow-visible; ScrollArea 2 updated inline-style->overflow-visible class). Docs adapted: table.md section (badge New) + NEW TableExternalScrollExample (b24ui payments table: overflow-auto container + sticky title scrollMargin via useElementSize + B24Table virtualize getScrollElement/scrollMargin, :b24ui; TableColumn from @bitrix24/b24ui-nuxt, resolveComponent B24Badge, air status colors like TableVirtualizeExample); ScrollArea example extended with horizontal orientation (orientation prop, axis-aware itemSize/scrollMargin, Start/Top button ArrowToTheLeft/Top) + scroll-area.md orientation options block (find-toolbar stays dropped from #a84de85). useElementSize imported from @vueuse/core. Tests 5147 passed (+2)"
     },
     "08bdab4fd97d0a42e5fb1cda08dc32510b855837": {
-      "pr": null,
-      "b24ui_sha": "pending-merge",
+      "pr": 237,
+      "b24ui_sha": "e92f0a24",
       "decision": "no-op",
       "summary": "chore(github): update reproduire workflow version — NO-OP: re-pins Hebilicious/reproduire @v1 -> @4b686ae...#v0.0.9 in .github/workflows/reproduire.yml (partial revert of df099a5's un-pin). b24ui has no reproduire.yml (only ci/deploy/npm-publish workflows); same N/A basis as df099a5 (#232). Bookkeeping only"
+    },
+    "dfbbfeb5a9ab3cbaf9582ba3393cceb1584baa5e": {
+      "pr": null,
+      "b24ui_sha": "pending-merge",
+      "decision": "skip",
+      "summary": "chore(deps): migrate AI SDK to v7 (#6636) — SKIPPED/DEFERRED (maintainer call): major dep migration ai ^6->^7, @ai-sdk/anthropic ^3->^4, @ai-sdk/gateway ^3->^4, @ai-sdk/mcp ^1->^2, @ai-sdk/vue ^3->^4 + docs/playground client (new Chat()->useChat()) + server routes (system->instructions, stepCountIs->isStepCount, toUIMessageStreamResponse->toUIMessageStream+createUIMessageStreamResponse, toTextStreamResponse->createTextStreamResponse, onFinish->onEnd, model ids). Upstream touched NO src/runtime, but b24ui runtime imports ai (ChatMessages/ChatMessage/ChatPromptSubmit + utils/ai.ts) AND has a b24ui-only bx-assistant module (AssistantPanel/search.ts/useAssistant.ts) using @ai-sdk/vue+streamText with no upstream reference -> not a mechanical replay; needs a deliberate v7 adoption pass verifying runtime types + hand-migrating bx-assistant + lockfile regen + end-to-end test. Also verbatim .patch fetch egress-blocked this session. b24ui stays on ai@6. Consistent with prior deferrals #220/#194. Bookkeeping only, cursor advances; tracked for future AI-SDK-v7 task"
     }
   }
 }


### PR DESCRIPTION
## Upstream
[`dfbbfeb`](https://github.com/nuxt/ui/commit/dfbbfeb5a9ab3cbaf9582ba3393cceb1584baa5e) — `chore(deps): migrate AI SDK to v7 (#6636)`

A **major** AI SDK migration: `ai` `^6`→`^7`, `@ai-sdk/anthropic` `^3`→`^4`, `@ai-sdk/gateway` `^3`→`^4`, `@ai-sdk/mcp` `^1`→`^2`, `@ai-sdk/vue` `^3`→`^4`; docs/playground clients move from the `new Chat()` class to the `useChat()` composable; server routes move to the v7 streaming API (`system`→`instructions`, `stepCountIs`→`isStepCount`, `.toUIMessageStreamResponse()`→`toUIMessageStream()`+`createUIMessageStreamResponse()`, `onFinish`→`onEnd`). **No `src/runtime` change upstream.**

## Decision — skip / defer
This isn't a mechanical port, and it touches b24ui surfaces upstream doesn't:
- **b24ui runtime imports `ai`** — `src/runtime/components/{ChatMessages,ChatMessage,ChatPromptSubmit}.vue` and `src/runtime/utils/ai.ts`. Upstream changed no runtime file (its runtime was already v7-safe), but b24ui adopting `ai@7` requires verifying its runtime still typechecks against the v7 types — which the diff gives no guidance on.
- **b24ui-only `bx-assistant` module** — `docs/modules/bx-assistant/` (`AssistantPanel.vue`, `runtime/server/api/search.ts`, `runtime/composables/useAssistant.ts`) uses `@ai-sdk/vue`+`streamText` with **no upstream counterpart**; it needs a hand-authored, independently-tested migration.

So b24ui stays on `ai@6` for now; v7 adoption should be a deliberate, separately-tested pass (runtime types + `bx-assistant` + lockfile regen + end-to-end chat/assistant test), not a diff replay. Consistent with prior deferrals (#220 InputRating, #194 Calendar). *(Also: verbatim upstream `.patch` fetch is currently egress-blocked this session, so a faithful large-file replay isn't cleanly available.)*

Bookkeeping only — ledger `decision: skip`, cursor advances; tracked for a future AI-SDK-v7 task.
- `.sync/log/dfbbfeb….md` — rationale
- `.sync/nuxt-ui.json` — reconcile prior `08bdab4` → PR #237 / `e92f0a24`, add `dfbbfeb` as `skip`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JS8ypVfQSFzYVZzkTHhURb)_