### PR TITLE
feat(Drawer): add close and closeIcon props

### DIFF
--- a/.sync/log/53e88a468824c0a9b5f9d2bd08a4113b6922afe7.md
+++ b/.sync/log/53e88a468824c0a9b5f9d2bd08a4113b6922afe7.md
@@ -1,0 +1,47 @@
+# Port: feat(Drawer): add `close` and `closeIcon` props (#6669)
+
+**Upstream:** `53e88a468824c0a9b5f9d2bd08a4113b6922afe7` (nuxt/ui)
+**Decision:** port
+
+## Upstream change
+Adds a built-in close button to `Drawer` (mirroring `Modal`): new `close`
+(`boolean | Omit<ButtonProps, LinkPropsKeys>`) and `closeIcon` props, plus
+`actions` and `close` slots. The header is restructured into a `wrapper` (title
++ description) and an `actions` container (`ms-auto`) holding the close button;
+theme gains `wrapper`/`actions`/`close` slots + header flex classes; the
+`drawer.close` i18n message is added to every locale.
+
+## b24ui port — adapted from b24ui's own Modal
+b24ui already ships this exact pattern on `Modal`, so the port mirrors b24ui's
+Modal rather than replaying upstream's icon/color choices:
+
+- **`Drawer.vue`**: added `close`/`closeIcon` props (`closeIcon?: IconComponent`
+  — b24ui has no `Icon.vue`, so `IconComponent` from `../types/icons`, not
+  upstream's `IconProps['name']`), `actions`/`close` slots, imports
+  (`DrawerClose`, `useLocale`, `icons` from `../dictionary/icons`, `B24Button`,
+  `ButtonProps`/`LinkPropsKeys`), `const { t } = useLocale()`. Header
+  restructured into `wrapper` + `actions` (with `DrawerClose` → `B24Button`
+  using b24ui air styling `size="md" color="air-tertiary-no-accent"` +
+  `:aria-label="t('drawer.close')"`, exactly like Modal). b24ui's separate
+  `VisuallyHidden` a11y title/description block is untouched, so wrapping the
+  display title/description in the conditional `wrapper` is a11y-safe.
+- **`theme/drawer.ts`**: `header: 'flex items-center gap-1.5 min-h-8'`, new
+  `wrapper: 'min-w-0 flex-1'`, `actions: 'flex items-center gap-1.5 shrink-0 ms-auto'`,
+  `close: ''` (upstream's generic classes; no air tokens needed).
+- **i18n**: added `drawer: { close: string }` to `types/locale.ts` and a
+  `drawer.close` entry to **all 20** b24ui locales, each set to that locale's
+  existing `modal.close` value (same word — `Close`/`Schließen`/`閉じる`/`Закрыть`
+  …), so no new translations were invented and b24ui's curated locale set is
+  preserved (§2).
+
+## Tests
+Added `renderEach` cases `with close` / `with closeIcon` (Cross30Icon) /
+`with actions slot` / `with close slot` (mirroring Modal.spec). Snapshots:
+**8 written** (4 cases × nuxt/vue) + **30 updated** — the existing
+title/description cases now nest under `data-slot="wrapper"` (the header
+restructure). Suite 5155 passed (+8). The `with close` snapshot renders the
+`actions` container + `B24Button` with `aria-label="Close"`.
+
+## Verify (CI=true)
+`dev:prepare` · `lint` · `typecheck` (all 20 locales satisfy the new
+`drawer.close` type) · `test` · `build` — all green.

--- a/.sync/nuxt-ui.json
+++ b/.sync/nuxt-ui.json
@@ -2,7 +2,7 @@
   "upstream": "nuxt/ui",
   "branch": "v4",
   "sync_enabled": false,
-  "cursor": "efd44e2c1a5924faa962c52b7ea9c71cd440e7c9",
+  "cursor": "53e88a468824c0a9b5f9d2bd08a4113b6922afe7",
   "_cursor_note": "cursor = last upstream commit ported into b24ui (oldest-first, manual cadence). sync_enabled stays false until Phase 2 (porter workflow #67 + CLAUDE_CODE_OAUTH_TOKEN) is wired and trusted. `processed` is maintained per port from now on (backfilled #68-#72 on 2026-06-09).",
   "stats": {
     "queue_depth": 0,
@@ -857,10 +857,16 @@
       "summary": "fix(Button): allow inline event handlers with non-void return types (#6668) — narrow handler types `=> void | Promise<void>` -> `=> void` on onClick/onSubmit (TS void-bivalence widens accepted return types so inline template handlers returning non-void no longer error). b24ui files: Button(onClick), Form(onSubmit), LinkBase(onClick), PageCard, PageFeature, User, vue/overrides/inertia/LinkBase — all single+Array/()=> union variants. BlogPost/ChangelogVersion absent (N/A). +b24ui extension: Badge.onCloseClick (b24ui-only clickable-close prop, same pattern/fix). 8 files +8/-8. Type-only, no snapshot churn"
     },
     "efd44e2c1a5924faa962c52b7ea9c71cd440e7c9": {
+      "pr": 240,
+      "b24ui_sha": "eba22f76",
+      "decision": "port",
+      "summary": "chore(deps): update all non-major dependencies (#6671) — §2 per-dep mirror (nuxt<->demo parity): tailwindcss ^4.3.1->^4.3.2 (root/docs/demo/nuxt/repl/vue), @tailwindcss/postcss+vite ^4.3.1->^4.3.2 (root), @tanstack/vue-virtual 3.13.30->3.13.31 (root), unplugin 3.2.0->3.3.0 (root + pnpm-workspace catalog), vue-component-type-helpers 3.3.5->3.3.6 (root), vue-tsc 3.3.5->3.3.6 (root/demo/nuxt/vue), valibot 1.4.1->1.4.2 (docs), vue-component-meta 3.3.5->3.3.6 (docs). Left untouched: root tailwindcss ^4.0.0 + valibot ^1.0.0 peers. Skipped: @iconify-json/* (no @nuxt/icon in b24ui), @regle/core+rules (b24ui pins ^1.28.0 != upstream ^1.28.1), prettier (b24ui ^3.8.4 != ^3.9.1). Lockfile regen corepack pnpm 11.9.0, lockfileVersion 9.0, +419/-155 (no major churn). No snapshot churn"
+    },
+    "53e88a468824c0a9b5f9d2bd08a4113b6922afe7": {
       "pr": null,
       "b24ui_sha": "pending-merge",
       "decision": "port",
-      "summary": "chore(deps): update all non-major dependencies (#6671) — §2 per-dep mirror (nuxt<->demo parity): tailwindcss ^4.3.1->^4.3.2 (root/docs/demo/nuxt/repl/vue), @tailwindcss/postcss+vite ^4.3.1->^4.3.2 (root), @tanstack/vue-virtual 3.13.30->3.13.31 (root), unplugin 3.2.0->3.3.0 (root + pnpm-workspace catalog), vue-component-type-helpers 3.3.5->3.3.6 (root), vue-tsc 3.3.5->3.3.6 (root/demo/nuxt/vue), valibot 1.4.1->1.4.2 (docs), vue-component-meta 3.3.5->3.3.6 (docs). Left untouched: root tailwindcss ^4.0.0 + valibot ^1.0.0 peers. Skipped: @iconify-json/* (no @nuxt/icon in b24ui), @regle/core+rules (b24ui pins ^1.28.0 != upstream ^1.28.1), prettier (b24ui ^3.8.4 != ^3.9.1). Lockfile regen corepack pnpm 11.9.0, lockfileVersion 9.0, +419/-155 (no major churn). No snapshot churn"
+      "summary": "feat(Drawer): add close and closeIcon props (#6669) — Drawer.vue: +close (boolean|Omit<ButtonProps,LinkPropsKeys>) + closeIcon (IconComponent, b24ui has no Icon.vue so not IconProps['name']) props, +actions/close slots, header restructured into wrapper(title+desc)+actions(ms-auto, DrawerClose->B24Button size=md color=air-tertiary-no-accent aria-label=t('drawer.close')); imports DrawerClose/useLocale/icons(dictionary)/B24Button. Mirrors b24ui's OWN Modal pattern (not upstream neutral/ghost). theme/drawer.ts: header flex + new wrapper/actions/close slots. i18n: +drawer.close to types/locale.ts + all 20 locales (each = that locale's modal.close value; no invented translations, curated set preserved). +renderEach close/closeIcon/actions-slot/close-slot cases (mirror Modal.spec). Snapshots 8 written + 30 updated (title/desc now under data-slot=wrapper). b24ui VisuallyHidden a11y title untouched so wrapper is a11y-safe. Tests 5155 (+8)"
     }
   }
 }

--- a/src/runtime/components/Drawer.vue
+++ b/src/runtime/components/Drawer.vue
@@ -4,6 +4,9 @@ import type { DrawerRootProps, DrawerRootEmits } from 'vaul-vue'
 import type { DialogContentProps, DialogContentEmits } from 'reka-ui'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/b24ui/drawer'
+import type { ButtonProps } from './Button.vue'
+import type { IconComponent } from '../types/icons'
+import type { LinkPropsKeys } from './Link.vue'
 import type { EmitsToProps } from '../types/utils'
 import type { ComponentConfig } from '../types/tv'
 
@@ -54,6 +57,18 @@ export interface DrawerProps extends Pick<DrawerRootProps, 'activeSnapPoint' | '
    * @defaultValue true
    */
   scrollbarThin?: boolean
+  /**
+   * Display a close button to dismiss the drawer.
+   * `{ size: 'md', color: 'air-tertiary-no-accent' }`{lang="ts-type"}
+   * @defaultValue false
+   */
+  close?: boolean | Omit<ButtonProps, LinkPropsKeys>
+  /**
+   * The icon displayed in the close button.
+   * @defaultValue icons.close
+   * @IconComponent
+   */
+  closeIcon?: IconComponent
   class?: any
   b24ui?: Drawer['slots']
 }
@@ -68,6 +83,8 @@ export interface DrawerSlots {
   header?(props?: {}): VNode[]
   title?(props?: {}): VNode[]
   description?(props?: {}): VNode[]
+  actions?(props?: {}): VNode[]
+  close?(props: { b24ui: Drawer['b24ui'] }): VNode[]
   body?(props?: {}): VNode[]
   footer?(props?: {}): VNode[]
 }
@@ -76,16 +93,19 @@ export interface DrawerSlots {
 <script setup lang="ts">
 import { computed, toRef } from 'vue'
 import { VisuallyHidden } from 'reka-ui'
-import { DrawerRoot, DrawerRootNested, DrawerTrigger, DrawerPortal, DrawerOverlay, DrawerContent, DrawerTitle, DrawerDescription, DrawerHandle } from 'vaul-vue'
+import { DrawerRoot, DrawerRootNested, DrawerTrigger, DrawerPortal, DrawerOverlay, DrawerContent, DrawerTitle, DrawerDescription, DrawerHandle, DrawerClose } from 'vaul-vue'
 import { reactivePick } from '@vueuse/core'
 import { useAppConfig } from '#imports'
 import { useComponentProps } from '../composables/useComponentProps'
 import { useForwardProps } from '../composables/useForwardProps'
 import { useBlurOnOpen } from '../composables/useBlurOnOpen'
+import { useLocale } from '../composables/useLocale'
 import { FieldGroupReset } from '../composables/useFieldGroup'
 import { usePortal } from '../composables/usePortal'
 import { pointerDownOutside } from '../utils/overlay'
 import { tv } from '../utils/tv'
+import icons from '../dictionary/icons'
+import B24Button from './Button.vue'
 
 const _props = withDefaults(defineProps<DrawerProps>(), {
   direction: 'bottom',
@@ -101,6 +121,8 @@ const emits = defineEmits<DrawerEmits>()
 const slots = defineSlots<DrawerSlots>()
 
 const props = useComponentProps('drawer', _props)
+
+const { t } = useLocale()
 
 const appConfig = useAppConfig() as Drawer['AppConfig']
 
@@ -167,21 +189,42 @@ const b24ui = computed(() => tv({ extend: theme, ...(appConfig.b24ui?.drawer || 
 
           <slot name="content">
             <div data-slot="container" :class="b24ui.container({ class: props.b24ui?.container })">
-              <div v-if="!!slots.header || (props.title || !!slots.title) || (props.description || !!slots.description)" data-slot="header" :class="b24ui.header({ class: props.b24ui?.header })">
+              <div v-if="!!slots.header || (props.title || !!slots.title) || (props.description || !!slots.description) || (props.close || !!slots.close) || !!slots.actions" data-slot="header" :class="b24ui.header({ class: props.b24ui?.header })">
                 <slot name="header">
-                  <DrawerTitle v-if="!props.title && !slots.title" />
-                  <DrawerTitle v-else data-slot="title" :class="b24ui.title({ class: props.b24ui?.title })">
-                    <slot name="title">
-                      {{ props.title }}
-                    </slot>
-                  </DrawerTitle>
+                  <div v-if="props.title || !!slots.title || props.description || !!slots.description" data-slot="wrapper" :class="b24ui.wrapper({ class: props.b24ui?.wrapper })">
+                    <DrawerTitle v-if="!props.title && !slots.title" />
+                    <DrawerTitle v-else data-slot="title" :class="b24ui.title({ class: props.b24ui?.title })">
+                      <slot name="title">
+                        {{ props.title }}
+                      </slot>
+                    </DrawerTitle>
 
-                  <DrawerDescription v-if="!props.description && !slots.description" />
-                  <DrawerDescription v-else data-slot="description" :class="b24ui.description({ class: props.b24ui?.description })">
-                    <slot name="description">
-                      {{ props.description }}
-                    </slot>
-                  </DrawerDescription>
+                    <DrawerDescription v-if="!props.description && !slots.description" />
+                    <DrawerDescription v-else data-slot="description" :class="b24ui.description({ class: props.b24ui?.description })">
+                      <slot name="description">
+                        {{ props.description }}
+                      </slot>
+                    </DrawerDescription>
+                  </div>
+
+                  <div v-if="!!slots.actions || props.close || !!slots.close" data-slot="actions" :class="b24ui.actions({ class: props.b24ui?.actions })">
+                    <slot name="actions" />
+
+                    <DrawerClose v-if="props.close || !!slots.close" as-child>
+                      <slot name="close" :b24ui="b24ui">
+                        <B24Button
+                          v-if="props.close"
+                          :icon="props.closeIcon || icons.close"
+                          size="md"
+                          color="air-tertiary-no-accent"
+                          :aria-label="t('drawer.close')"
+                          v-bind="(typeof props.close === 'object' ? props.close : {})"
+                          data-slot="close"
+                          :class="b24ui.close({ class: props.b24ui?.close })"
+                        />
+                      </slot>
+                    </DrawerClose>
+                  </div>
                 </slot>
               </div>
 

--- a/src/runtime/locale/ar.ts
+++ b/src/runtime/locale/ar.ts
@@ -106,6 +106,9 @@ export default defineLocale<Messages>({
     modal: {
       close: 'إغلاق'
     },
+    drawer: {
+      close: 'إغلاق'
+    },
     pricingTable: {
       caption: 'مقارنة خطط الأسعار'
     },

--- a/src/runtime/locale/br.ts
+++ b/src/runtime/locale/br.ts
@@ -105,6 +105,9 @@ export default defineLocale<Messages>({
     modal: {
       close: 'Fechar'
     },
+    drawer: {
+      close: 'Fechar'
+    },
     pricingTable: {
       caption: 'Comparação de planos de preços'
     },

--- a/src/runtime/locale/de.ts
+++ b/src/runtime/locale/de.ts
@@ -105,6 +105,9 @@ export default defineLocale<Messages>({
     modal: {
       close: 'Schließen'
     },
+    drawer: {
+      close: 'Schließen'
+    },
     pricingTable: {
       caption: 'Preisplan-Vergleich'
     },

--- a/src/runtime/locale/en.ts
+++ b/src/runtime/locale/en.ts
@@ -105,6 +105,9 @@ export default defineLocale<Messages>({
     modal: {
       close: 'Close'
     },
+    drawer: {
+      close: 'Close'
+    },
     pricingTable: {
       caption: 'Pricing plans comparison'
     },

--- a/src/runtime/locale/fr.ts
+++ b/src/runtime/locale/fr.ts
@@ -105,6 +105,9 @@ export default defineLocale<Messages>({
     modal: {
       close: 'Fermer'
     },
+    drawer: {
+      close: 'Fermer'
+    },
     pricingTable: {
       caption: 'Comparaison des forfaits'
     },

--- a/src/runtime/locale/id.ts
+++ b/src/runtime/locale/id.ts
@@ -105,6 +105,9 @@ export default defineLocale<Messages>({
     modal: {
       close: 'Tutup'
     },
+    drawer: {
+      close: 'Tutup'
+    },
     pricingTable: {
       caption: 'Perbandingan paket harga'
     },

--- a/src/runtime/locale/in.ts
+++ b/src/runtime/locale/in.ts
@@ -105,6 +105,9 @@ export default defineLocale<Messages>({
     modal: {
       close: 'बंद करें'
     },
+    drawer: {
+      close: 'बंद करें'
+    },
     pricingTable: {
       caption: 'मूल्य योजनाओं की तुलना'
     },

--- a/src/runtime/locale/it.ts
+++ b/src/runtime/locale/it.ts
@@ -105,6 +105,9 @@ export default defineLocale<Messages>({
     modal: {
       close: 'Chiudi'
     },
+    drawer: {
+      close: 'Chiudi'
+    },
     pricingTable: {
       caption: 'Confronto piani tariffari'
     },

--- a/src/runtime/locale/ja.ts
+++ b/src/runtime/locale/ja.ts
@@ -105,6 +105,9 @@ export default defineLocale<Messages>({
     modal: {
       close: '閉じる'
     },
+    drawer: {
+      close: '閉じる'
+    },
     pricingTable: {
       caption: '料金プランの比較'
     },

--- a/src/runtime/locale/kz.ts
+++ b/src/runtime/locale/kz.ts
@@ -105,6 +105,9 @@ export default defineLocale<Messages>({
     modal: {
       close: 'Жабу'
     },
+    drawer: {
+      close: 'Жабу'
+    },
     pricingTable: {
       caption: 'Баға жоспарларын салыстыру'
     },

--- a/src/runtime/locale/la.ts
+++ b/src/runtime/locale/la.ts
@@ -105,6 +105,9 @@ export default defineLocale<Messages>({
     modal: {
       close: 'Cerrar'
     },
+    drawer: {
+      close: 'Cerrar'
+    },
     pricingTable: {
       caption: 'Comparación de planes de precios'
     },

--- a/src/runtime/locale/ms.ts
+++ b/src/runtime/locale/ms.ts
@@ -105,6 +105,9 @@ export default defineLocale<Messages>({
     modal: {
       close: 'Tutup'
     },
+    drawer: {
+      close: 'Tutup'
+    },
     pricingTable: {
       caption: 'Perbandingan pelan harga'
     },

--- a/src/runtime/locale/pl.ts
+++ b/src/runtime/locale/pl.ts
@@ -105,6 +105,9 @@ export default defineLocale<Messages>({
     modal: {
       close: 'Zamknij'
     },
+    drawer: {
+      close: 'Zamknij'
+    },
     pricingTable: {
       caption: 'Porównanie planów cenowych'
     },

--- a/src/runtime/locale/ru.ts
+++ b/src/runtime/locale/ru.ts
@@ -105,6 +105,9 @@ export default defineLocale<Messages>({
     modal: {
       close: 'Закрыть'
     },
+    drawer: {
+      close: 'Закрыть'
+    },
     pricingTable: {
       caption: 'Сравнение тарифов'
     },

--- a/src/runtime/locale/sc.ts
+++ b/src/runtime/locale/sc.ts
@@ -105,6 +105,9 @@ export default defineLocale<Messages>({
     modal: {
       close: '关闭'
     },
+    drawer: {
+      close: '关闭'
+    },
     pricingTable: {
       caption: '价格方案对比'
     },

--- a/src/runtime/locale/tc.ts
+++ b/src/runtime/locale/tc.ts
@@ -105,6 +105,9 @@ export default defineLocale<Messages>({
     modal: {
       close: '關閉'
     },
+    drawer: {
+      close: '關閉'
+    },
     pricingTable: {
       caption: '方案價格比較'
     },

--- a/src/runtime/locale/th.ts
+++ b/src/runtime/locale/th.ts
@@ -105,6 +105,9 @@ export default defineLocale<Messages>({
     modal: {
       close: 'ปิด'
     },
+    drawer: {
+      close: 'ปิด'
+    },
     pricingTable: {
       caption: 'เปรียบเทียบแผนราคา'
     },

--- a/src/runtime/locale/tr.ts
+++ b/src/runtime/locale/tr.ts
@@ -105,6 +105,9 @@ export default defineLocale<Messages>({
     modal: {
       close: 'Kapat'
     },
+    drawer: {
+      close: 'Kapat'
+    },
     pricingTable: {
       caption: 'Fiyat planları karşılaştırması'
     },

--- a/src/runtime/locale/ua.ts
+++ b/src/runtime/locale/ua.ts
@@ -105,6 +105,9 @@ export default defineLocale<Messages>({
     modal: {
       close: 'Закрити'
     },
+    drawer: {
+      close: 'Закрити'
+    },
     pricingTable: {
       caption: 'Порівняння тарифних планів'
     },

--- a/src/runtime/locale/vn.ts
+++ b/src/runtime/locale/vn.ts
@@ -105,6 +105,9 @@ export default defineLocale<Messages>({
     modal: {
       close: 'Đóng'
     },
+    drawer: {
+      close: 'Đóng'
+    },
     pricingTable: {
       caption: 'So sánh gói giá'
     },

--- a/src/runtime/types/locale.ts
+++ b/src/runtime/types/locale.ts
@@ -108,6 +108,9 @@ export type Messages = {
   modal: {
     close: string
   }
+  drawer: {
+    close: string
+  }
   pricingTable: {
     caption: string
   }

--- a/src/theme/drawer.ts
+++ b/src/theme/drawer.ts
@@ -16,7 +16,8 @@ export default {
     ].join(' '),
     handle: 'shrink-0 !bg-(--ui-color-divider-default) transition-opacity',
     container: 'w-full flex flex-col gap-4 p-4 overflow-y-auto',
-    header: '',
+    header: 'flex items-center gap-1.5 min-h-8',
+    wrapper: 'min-w-0 flex-1',
     title: [
       'font-[family-name:var(--ui-font-family-primary)]',
       'text-label',
@@ -29,8 +30,10 @@ export default {
       'text-description',
       'text-(length:--ui-font-size-sm)'
     ].join(' '),
+    actions: 'flex items-center gap-1.5 shrink-0 ms-auto',
     body: 'flex-1',
-    footer: 'flex flex-col gap-1.5'
+    footer: 'flex flex-col gap-1.5',
+    close: ''
   },
   variants: {
     overlayBlur: {

--- a/test/components/Drawer.spec.ts
+++ b/test/components/Drawer.spec.ts
@@ -4,6 +4,7 @@ import { mountSuspended } from '@nuxt/test-utils/runtime'
 import { renderEach } from '../component-render'
 import Drawer from '../../src/runtime/components/Drawer.vue'
 import theme from '#build/b24ui/drawer'
+import Cross30Icon from '@bitrix24/b24icons-vue/actions/Cross30Icon'
 
 describe('Drawer', () => {
   const directions = Object.keys(theme.variants.direction) as any
@@ -14,6 +15,8 @@ describe('Drawer', () => {
     // Props
     ['with title', { props: { ...props, title: 'Title' } }],
     ['with description', { props: { ...props, title: 'Title', description: 'Description' } }],
+    ['with close', { props: { ...props, title: 'Title', close: true } }],
+    ['with closeIcon', { props: { ...props, title: 'Title', close: true, closeIcon: Cross30Icon } }],
     ...directions.map((direction: string) => [`with direction ${direction}`, { props: { ...props, direction, title: 'Title', description: 'Description' } }]),
     ...directions.map((direction: string) => [`with direction ${direction} inset`, { props: { ...props, direction, inset: true, title: 'Title', description: 'Description' } }]),
     ['without handle', { props: { ...props, handle: false, title: 'Title', description: 'Description' } }],
@@ -26,6 +29,8 @@ describe('Drawer', () => {
     ['with header slot', { props, slots: { header: () => 'Header slot' } }],
     ['with title slot', { props, slots: { title: () => 'Title slot' } }],
     ['with description slot', { props, slots: { description: () => 'Description slot' } }],
+    ['with actions slot', { props: { ...props, title: 'Title' }, slots: { actions: () => 'Actions slot' } }],
+    ['with close slot', { props: { ...props, title: 'Title', close: true }, slots: { close: () => 'Close slot' } }],
     ['with body slot', { props, slots: { body: () => 'Body slot' } }],
     ['with footer slot', { props, slots: { footer: () => 'Footer slot' } }]
   ])

--- a/test/components/__snapshots__/Drawer-vue.spec.ts.snap
+++ b/test/components/__snapshots__/Drawer-vue.spec.ts.snap
@@ -1,5 +1,34 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`Drawer > renders with actions slot correctly 1`] = `
+"<!--v-if-->
+<!--teleport start-->
+
+
+
+<div data-state="open" style="pointer-events: auto;" data-vaul-overlay="" data-vaul-snap-points="false" data-vaul-snap-points-overlay="true" data-slot="overlay" class="fixed inset-0 motion-safe:backdrop-blur-[2px] bg-[#003366]/20"></div>
+<div data-dismissable-layer="" style="pointer-events: auto; --snap-point-height: 0;" tabindex="-1" data-vaul-drawer="" data-vaul-drawer-direction="bottom" data-vaul-delayed-snap-points="false" data-vaul-snap-points="false" data-slot="content" class="fixed base-mode bg-(--ui-color-bg-content-primary) flex focus:outline-none ring ring-(--ui-color-divider-default) mt-24 flex-col h-auto max-h-[96%] inset-x-0 bottom-0 rounded-t-lg" id="" role="dialog" aria-describedby="reka-dialog-description-v-1" aria-labelledby="reka-dialog-title-v-0" data-state="open">
+  <div data-vaul-drawer-visible="true" data-vaul-handle="" aria-hidden="true" data-slot="handle" class="shrink-0 !bg-(--ui-color-divider-default) transition-opacity mt-4 !w-12 !h-1.5 mx-auto"><span data-vaul-handle-hitarea="" aria-hidden="true"></span></div><span aria-hidden="true" style="position: absolute; border: 0px; width: 1px; height: 1px; padding: 0px; margin: -1px; overflow: hidden; clip: rect(0, 0, 0, 0); clip-path: inset(50%); white-space: nowrap; word-wrap: normal; top: -1px; left: -1px;"><!--v-if--><p id="reka-dialog-description-v-1"></p></span>
+  <div data-slot="container" class="w-full flex flex-col gap-4 p-4 overflow-y-auto">
+    <div data-slot="header" class="flex items-center gap-1.5 min-h-8">
+      <div data-slot="wrapper" class="min-w-0 flex-1">
+        <h2 id="reka-dialog-title-v-0" data-slot="title" class="font-[family-name:var(--ui-font-family-primary)] text-label font-(--ui-font-weight-medium) mb-0 text-[calc(var(--ui-font-size-2xl)+2px)]/(--ui-font-size-2xl)">Title</h2>
+        <p id="reka-dialog-description-v-1"></p>
+      </div>
+      <div data-slot="actions" class="flex items-center gap-1.5 shrink-0 ms-auto">Actions slot
+        <!--v-if-->
+      </div>
+    </div>
+    <!--v-if-->
+    <!--v-if-->
+  </div>
+</div>
+
+
+
+<!--teleport end-->"
+`;
+
 exports[`Drawer > renders with b24ui correctly 1`] = `
 "<!--v-if-->
 <!--teleport start-->
@@ -63,6 +92,103 @@ exports[`Drawer > renders with class correctly 1`] = `
 <!--teleport end-->"
 `;
 
+exports[`Drawer > renders with close correctly 1`] = `
+"<!--v-if-->
+<!--teleport start-->
+
+
+
+<div data-state="open" style="pointer-events: auto;" data-vaul-overlay="" data-vaul-snap-points="false" data-vaul-snap-points-overlay="true" data-slot="overlay" class="fixed inset-0 motion-safe:backdrop-blur-[2px] bg-[#003366]/20"></div>
+<div data-dismissable-layer="" style="pointer-events: auto; --snap-point-height: 0;" tabindex="-1" data-vaul-drawer="" data-vaul-drawer-direction="bottom" data-vaul-delayed-snap-points="false" data-vaul-snap-points="false" data-slot="content" class="fixed base-mode bg-(--ui-color-bg-content-primary) flex focus:outline-none ring ring-(--ui-color-divider-default) mt-24 flex-col h-auto max-h-[96%] inset-x-0 bottom-0 rounded-t-lg" id="" role="dialog" aria-describedby="reka-dialog-description-v-1" aria-labelledby="reka-dialog-title-v-0" data-state="open">
+  <div data-vaul-drawer-visible="true" data-vaul-handle="" aria-hidden="true" data-slot="handle" class="shrink-0 !bg-(--ui-color-divider-default) transition-opacity mt-4 !w-12 !h-1.5 mx-auto"><span data-vaul-handle-hitarea="" aria-hidden="true"></span></div><span aria-hidden="true" style="position: absolute; border: 0px; width: 1px; height: 1px; padding: 0px; margin: -1px; overflow: hidden; clip: rect(0, 0, 0, 0); clip-path: inset(50%); white-space: nowrap; word-wrap: normal; top: -1px; left: -1px;"><!--v-if--><p id="reka-dialog-description-v-1"></p></span>
+  <div data-slot="container" class="w-full flex flex-col gap-4 p-4 overflow-y-auto">
+    <div data-slot="header" class="flex items-center gap-1.5 min-h-8">
+      <div data-slot="wrapper" class="min-w-0 flex-1">
+        <h2 id="reka-dialog-title-v-0" data-slot="title" class="font-[family-name:var(--ui-font-family-primary)] text-label font-(--ui-font-weight-medium) mb-0 text-[calc(var(--ui-font-size-2xl)+2px)]/(--ui-font-size-2xl)">Title</h2>
+        <p id="reka-dialog-description-v-1"></p>
+      </div>
+      <div data-slot="actions" class="flex items-center gap-1.5 shrink-0 ms-auto"><button type="button" aria-label="Close" data-slot="base" class="ui-btn font-[family-name:var(--ui-font-family-primary)] select-none cursor-pointer inline-flex items-center relative outline-transparent focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed aria-disabled:cursor-not-allowed disabled:opacity-30 aria-disabled:opacity-30 transition duration-0 ease-linear border-(length:--ui-btn-border-width) text-(--ui-btn-color) bg-(--ui-btn-background) border-(--ui-btn-border-color) hover:text-(--ui-btn-color-hover) hover:bg-(--ui-btn-background-hover) hover:border-(--ui-btn-border-color-hover) focus:text-(--ui-btn-color-hover) focus:bg-(--ui-btn-background-hover) focus:border-(--ui-btn-border-color-hover) active:text-(--ui-btn-color-active) active:bg-(--ui-btn-background-active) active:border-(--ui-btn-border-color-active) disabled:bg-(--ui-btn-background) disabled:border-(--ui-btn-border-color) aria-disabled:bg-(--ui-btn-background) aria-disabled:border-(--ui-btn-border-color) focus-visible:outline-(--ui-btn-background) ring-(--ui-btn-background-hover) focus:outline-none focus-visible:ring-(--ui-btn-background-hover) h-(--ui-btn-height) text-(length:--ui-btn-font-size) leading-(--ui-btn-height) font-(--ui-btn-font-weight) --style-plain-no-accent ui-btn-md rounded-(--ui-btn-radius) normal-case --air w-(--ui-btn-height)">
+          <!--v-if-->
+          <div data-slot="baseLine" class="w-full inline-flex items-center justify-center gap-(--ui-btn-icon-space) h-(--ui-btn-height) ps-[4px] pe-[4px]"><svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" aria-hidden="true" data-slot="icon" class="text-(--ui-btn-color) shrink-0 size-(--ui-btn-icon-size)">
+              <path fill="currentColor" d="M8.46 7.54a.65.65 0 0 0-.92.92L11.08 12l-3.54 3.54a.65.65 0 1 0 .92.92L12 12.918l3.54 3.54a.65.65 0 1 0 .919-.92L12.919 12l3.54-3.54a.65.65 0 0 0-.92-.919L12 11.08z"></path>
+            </svg>
+            <!--v-if-->
+            <!--v-if-->
+          </div>
+        </button></div>
+    </div>
+    <!--v-if-->
+    <!--v-if-->
+  </div>
+</div>
+
+
+
+<!--teleport end-->"
+`;
+
+exports[`Drawer > renders with close slot correctly 1`] = `
+"<!--v-if-->
+<!--teleport start-->
+
+
+
+<div data-state="open" style="pointer-events: auto;" data-vaul-overlay="" data-vaul-snap-points="false" data-vaul-snap-points-overlay="true" data-slot="overlay" class="fixed inset-0 motion-safe:backdrop-blur-[2px] bg-[#003366]/20"></div>
+<div data-dismissable-layer="" style="pointer-events: auto; --snap-point-height: 0;" tabindex="-1" data-vaul-drawer="" data-vaul-drawer-direction="bottom" data-vaul-delayed-snap-points="false" data-vaul-snap-points="false" data-slot="content" class="fixed base-mode bg-(--ui-color-bg-content-primary) flex focus:outline-none ring ring-(--ui-color-divider-default) mt-24 flex-col h-auto max-h-[96%] inset-x-0 bottom-0 rounded-t-lg" id="" role="dialog" aria-describedby="reka-dialog-description-v-1" aria-labelledby="reka-dialog-title-v-0" data-state="open">
+  <div data-vaul-drawer-visible="true" data-vaul-handle="" aria-hidden="true" data-slot="handle" class="shrink-0 !bg-(--ui-color-divider-default) transition-opacity mt-4 !w-12 !h-1.5 mx-auto"><span data-vaul-handle-hitarea="" aria-hidden="true"></span></div><span aria-hidden="true" style="position: absolute; border: 0px; width: 1px; height: 1px; padding: 0px; margin: -1px; overflow: hidden; clip: rect(0, 0, 0, 0); clip-path: inset(50%); white-space: nowrap; word-wrap: normal; top: -1px; left: -1px;"><!--v-if--><p id="reka-dialog-description-v-1"></p></span>
+  <div data-slot="container" class="w-full flex flex-col gap-4 p-4 overflow-y-auto">
+    <div data-slot="header" class="flex items-center gap-1.5 min-h-8">
+      <div data-slot="wrapper" class="min-w-0 flex-1">
+        <h2 id="reka-dialog-title-v-0" data-slot="title" class="font-[family-name:var(--ui-font-family-primary)] text-label font-(--ui-font-weight-medium) mb-0 text-[calc(var(--ui-font-size-2xl)+2px)]/(--ui-font-size-2xl)">Title</h2>
+        <p id="reka-dialog-description-v-1"></p>
+      </div>
+      <div data-slot="actions" class="flex items-center gap-1.5 shrink-0 ms-auto">Close slot</div>
+    </div>
+    <!--v-if-->
+    <!--v-if-->
+  </div>
+</div>
+
+
+
+<!--teleport end-->"
+`;
+
+exports[`Drawer > renders with closeIcon correctly 1`] = `
+"<!--v-if-->
+<!--teleport start-->
+
+
+
+<div data-state="open" style="pointer-events: auto;" data-vaul-overlay="" data-vaul-snap-points="false" data-vaul-snap-points-overlay="true" data-slot="overlay" class="fixed inset-0 motion-safe:backdrop-blur-[2px] bg-[#003366]/20"></div>
+<div data-dismissable-layer="" style="pointer-events: auto; --snap-point-height: 0;" tabindex="-1" data-vaul-drawer="" data-vaul-drawer-direction="bottom" data-vaul-delayed-snap-points="false" data-vaul-snap-points="false" data-slot="content" class="fixed base-mode bg-(--ui-color-bg-content-primary) flex focus:outline-none ring ring-(--ui-color-divider-default) mt-24 flex-col h-auto max-h-[96%] inset-x-0 bottom-0 rounded-t-lg" id="" role="dialog" aria-describedby="reka-dialog-description-v-1" aria-labelledby="reka-dialog-title-v-0" data-state="open">
+  <div data-vaul-drawer-visible="true" data-vaul-handle="" aria-hidden="true" data-slot="handle" class="shrink-0 !bg-(--ui-color-divider-default) transition-opacity mt-4 !w-12 !h-1.5 mx-auto"><span data-vaul-handle-hitarea="" aria-hidden="true"></span></div><span aria-hidden="true" style="position: absolute; border: 0px; width: 1px; height: 1px; padding: 0px; margin: -1px; overflow: hidden; clip: rect(0, 0, 0, 0); clip-path: inset(50%); white-space: nowrap; word-wrap: normal; top: -1px; left: -1px;"><!--v-if--><p id="reka-dialog-description-v-1"></p></span>
+  <div data-slot="container" class="w-full flex flex-col gap-4 p-4 overflow-y-auto">
+    <div data-slot="header" class="flex items-center gap-1.5 min-h-8">
+      <div data-slot="wrapper" class="min-w-0 flex-1">
+        <h2 id="reka-dialog-title-v-0" data-slot="title" class="font-[family-name:var(--ui-font-family-primary)] text-label font-(--ui-font-weight-medium) mb-0 text-[calc(var(--ui-font-size-2xl)+2px)]/(--ui-font-size-2xl)">Title</h2>
+        <p id="reka-dialog-description-v-1"></p>
+      </div>
+      <div data-slot="actions" class="flex items-center gap-1.5 shrink-0 ms-auto"><button type="button" aria-label="Close" data-slot="base" class="ui-btn font-[family-name:var(--ui-font-family-primary)] select-none cursor-pointer inline-flex items-center relative outline-transparent focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed aria-disabled:cursor-not-allowed disabled:opacity-30 aria-disabled:opacity-30 transition duration-0 ease-linear border-(length:--ui-btn-border-width) text-(--ui-btn-color) bg-(--ui-btn-background) border-(--ui-btn-border-color) hover:text-(--ui-btn-color-hover) hover:bg-(--ui-btn-background-hover) hover:border-(--ui-btn-border-color-hover) focus:text-(--ui-btn-color-hover) focus:bg-(--ui-btn-background-hover) focus:border-(--ui-btn-border-color-hover) active:text-(--ui-btn-color-active) active:bg-(--ui-btn-background-active) active:border-(--ui-btn-border-color-active) disabled:bg-(--ui-btn-background) disabled:border-(--ui-btn-border-color) aria-disabled:bg-(--ui-btn-background) aria-disabled:border-(--ui-btn-border-color) focus-visible:outline-(--ui-btn-background) ring-(--ui-btn-background-hover) focus:outline-none focus-visible:ring-(--ui-btn-background-hover) h-(--ui-btn-height) text-(length:--ui-btn-font-size) leading-(--ui-btn-height) font-(--ui-btn-font-weight) --style-plain-no-accent ui-btn-md rounded-(--ui-btn-radius) normal-case --air w-(--ui-btn-height)">
+          <!--v-if-->
+          <div data-slot="baseLine" class="w-full inline-flex items-center justify-center gap-(--ui-btn-icon-space) h-(--ui-btn-height) ps-[4px] pe-[4px]"><svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" aria-hidden="true" data-slot="icon" class="text-(--ui-btn-color) shrink-0 size-(--ui-btn-icon-size)">
+              <path fill="currentColor" fill-rule="evenodd" d="m13.505 12 3.905 3.904-1.505 1.505L12 13.505l-3.905 3.904-1.505-1.505L10.495 12 6.59 8.095 8.095 6.59 12 10.495l3.905-3.905 1.505 1.505z" clip-rule="evenodd"></path>
+            </svg>
+            <!--v-if-->
+            <!--v-if-->
+          </div>
+        </button></div>
+    </div>
+    <!--v-if-->
+    <!--v-if-->
+  </div>
+</div>
+
+
+
+<!--teleport end-->"
+`;
+
 exports[`Drawer > renders with content slot correctly 1`] = `
 "<!--v-if-->
 <!--teleport start-->
@@ -111,9 +237,12 @@ exports[`Drawer > renders with description correctly 1`] = `
   <div data-vaul-drawer-visible="true" data-vaul-handle="" aria-hidden="true" data-slot="handle" class="shrink-0 !bg-(--ui-color-divider-default) transition-opacity mt-4 !w-12 !h-1.5 mx-auto"><span data-vaul-handle-hitarea="" aria-hidden="true"></span></div>
   <!--v-if-->
   <div data-slot="container" class="w-full flex flex-col gap-4 p-4 overflow-y-auto">
-    <div data-slot="header" class="">
-      <h2 id="reka-dialog-title-v-0" data-slot="title" class="font-[family-name:var(--ui-font-family-primary)] text-label font-(--ui-font-weight-medium) mb-0 text-[calc(var(--ui-font-size-2xl)+2px)]/(--ui-font-size-2xl)">Title</h2>
-      <p id="reka-dialog-description-v-1" data-slot="description" class="mt-1 text-description text-(length:--ui-font-size-sm)">Description</p>
+    <div data-slot="header" class="flex items-center gap-1.5 min-h-8">
+      <div data-slot="wrapper" class="min-w-0 flex-1">
+        <h2 id="reka-dialog-title-v-0" data-slot="title" class="font-[family-name:var(--ui-font-family-primary)] text-label font-(--ui-font-weight-medium) mb-0 text-[calc(var(--ui-font-size-2xl)+2px)]/(--ui-font-size-2xl)">Title</h2>
+        <p id="reka-dialog-description-v-1" data-slot="description" class="mt-1 text-description text-(length:--ui-font-size-sm)">Description</p>
+      </div>
+      <!--v-if-->
     </div>
     <!--v-if-->
     <!--v-if-->
@@ -135,9 +264,12 @@ exports[`Drawer > renders with description slot correctly 1`] = `
 <div data-dismissable-layer="" style="pointer-events: auto; --snap-point-height: 0;" tabindex="-1" data-vaul-drawer="" data-vaul-drawer-direction="bottom" data-vaul-delayed-snap-points="false" data-vaul-snap-points="false" data-slot="content" class="fixed base-mode bg-(--ui-color-bg-content-primary) flex focus:outline-none ring ring-(--ui-color-divider-default) mt-24 flex-col h-auto max-h-[96%] inset-x-0 bottom-0 rounded-t-lg" id="" role="dialog" aria-describedby="reka-dialog-description-v-1" aria-labelledby="reka-dialog-title-v-0" data-state="open">
   <div data-vaul-drawer-visible="true" data-vaul-handle="" aria-hidden="true" data-slot="handle" class="shrink-0 !bg-(--ui-color-divider-default) transition-opacity mt-4 !w-12 !h-1.5 mx-auto"><span data-vaul-handle-hitarea="" aria-hidden="true"></span></div><span aria-hidden="true" style="position: absolute; border: 0px; width: 1px; height: 1px; padding: 0px; margin: -1px; overflow: hidden; clip: rect(0, 0, 0, 0); clip-path: inset(50%); white-space: nowrap; word-wrap: normal; top: -1px; left: -1px;"><h2 id="reka-dialog-title-v-0"></h2><!--v-if--></span>
   <div data-slot="container" class="w-full flex flex-col gap-4 p-4 overflow-y-auto">
-    <div data-slot="header" class="">
-      <h2 id="reka-dialog-title-v-0"></h2>
-      <p id="reka-dialog-description-v-1" data-slot="description" class="mt-1 text-description text-(length:--ui-font-size-sm)">Description slot</p>
+    <div data-slot="header" class="flex items-center gap-1.5 min-h-8">
+      <div data-slot="wrapper" class="min-w-0 flex-1">
+        <h2 id="reka-dialog-title-v-0"></h2>
+        <p id="reka-dialog-description-v-1" data-slot="description" class="mt-1 text-description text-(length:--ui-font-size-sm)">Description slot</p>
+      </div>
+      <!--v-if-->
     </div>
     <!--v-if-->
     <!--v-if-->
@@ -160,9 +292,12 @@ exports[`Drawer > renders with direction bottom correctly 1`] = `
   <div data-vaul-drawer-visible="true" data-vaul-handle="" aria-hidden="true" data-slot="handle" class="shrink-0 !bg-(--ui-color-divider-default) transition-opacity mt-4 !w-12 !h-1.5 mx-auto"><span data-vaul-handle-hitarea="" aria-hidden="true"></span></div>
   <!--v-if-->
   <div data-slot="container" class="w-full flex flex-col gap-4 p-4 overflow-y-auto">
-    <div data-slot="header" class="">
-      <h2 id="reka-dialog-title-v-0" data-slot="title" class="font-[family-name:var(--ui-font-family-primary)] text-label font-(--ui-font-weight-medium) mb-0 text-[calc(var(--ui-font-size-2xl)+2px)]/(--ui-font-size-2xl)">Title</h2>
-      <p id="reka-dialog-description-v-1" data-slot="description" class="mt-1 text-description text-(length:--ui-font-size-sm)">Description</p>
+    <div data-slot="header" class="flex items-center gap-1.5 min-h-8">
+      <div data-slot="wrapper" class="min-w-0 flex-1">
+        <h2 id="reka-dialog-title-v-0" data-slot="title" class="font-[family-name:var(--ui-font-family-primary)] text-label font-(--ui-font-weight-medium) mb-0 text-[calc(var(--ui-font-size-2xl)+2px)]/(--ui-font-size-2xl)">Title</h2>
+        <p id="reka-dialog-description-v-1" data-slot="description" class="mt-1 text-description text-(length:--ui-font-size-sm)">Description</p>
+      </div>
+      <!--v-if-->
     </div>
     <!--v-if-->
     <!--v-if-->
@@ -185,9 +320,12 @@ exports[`Drawer > renders with direction bottom inset correctly 1`] = `
   <div data-vaul-drawer-visible="true" data-vaul-handle="" aria-hidden="true" data-slot="handle" class="shrink-0 !bg-(--ui-color-divider-default) transition-opacity mt-4 !w-12 !h-1.5 mx-auto"><span data-vaul-handle-hitarea="" aria-hidden="true"></span></div>
   <!--v-if-->
   <div data-slot="container" class="w-full flex flex-col gap-4 p-4 overflow-y-auto">
-    <div data-slot="header" class="">
-      <h2 id="reka-dialog-title-v-0" data-slot="title" class="font-[family-name:var(--ui-font-family-primary)] text-label font-(--ui-font-weight-medium) mb-0 text-[calc(var(--ui-font-size-2xl)+2px)]/(--ui-font-size-2xl)">Title</h2>
-      <p id="reka-dialog-description-v-1" data-slot="description" class="mt-1 text-description text-(length:--ui-font-size-sm)">Description</p>
+    <div data-slot="header" class="flex items-center gap-1.5 min-h-8">
+      <div data-slot="wrapper" class="min-w-0 flex-1">
+        <h2 id="reka-dialog-title-v-0" data-slot="title" class="font-[family-name:var(--ui-font-family-primary)] text-label font-(--ui-font-weight-medium) mb-0 text-[calc(var(--ui-font-size-2xl)+2px)]/(--ui-font-size-2xl)">Title</h2>
+        <p id="reka-dialog-description-v-1" data-slot="description" class="mt-1 text-description text-(length:--ui-font-size-sm)">Description</p>
+      </div>
+      <!--v-if-->
     </div>
     <!--v-if-->
     <!--v-if-->
@@ -210,9 +348,12 @@ exports[`Drawer > renders with direction left correctly 1`] = `
   <div data-vaul-drawer-visible="true" data-vaul-handle="" aria-hidden="true" data-slot="handle" class="shrink-0 !bg-(--ui-color-divider-default) transition-opacity !mr-4 !h-12 !w-1.5 mt-auto mb-auto"><span data-vaul-handle-hitarea="" aria-hidden="true"></span></div>
   <!--v-if-->
   <div data-slot="container" class="w-full flex flex-col gap-4 p-4 overflow-y-auto">
-    <div data-slot="header" class="">
-      <h2 id="reka-dialog-title-v-0" data-slot="title" class="font-[family-name:var(--ui-font-family-primary)] text-label font-(--ui-font-weight-medium) mb-0 text-[calc(var(--ui-font-size-2xl)+2px)]/(--ui-font-size-2xl)">Title</h2>
-      <p id="reka-dialog-description-v-1" data-slot="description" class="mt-1 text-description text-(length:--ui-font-size-sm)">Description</p>
+    <div data-slot="header" class="flex items-center gap-1.5 min-h-8">
+      <div data-slot="wrapper" class="min-w-0 flex-1">
+        <h2 id="reka-dialog-title-v-0" data-slot="title" class="font-[family-name:var(--ui-font-family-primary)] text-label font-(--ui-font-weight-medium) mb-0 text-[calc(var(--ui-font-size-2xl)+2px)]/(--ui-font-size-2xl)">Title</h2>
+        <p id="reka-dialog-description-v-1" data-slot="description" class="mt-1 text-description text-(length:--ui-font-size-sm)">Description</p>
+      </div>
+      <!--v-if-->
     </div>
     <!--v-if-->
     <!--v-if-->
@@ -235,9 +376,12 @@ exports[`Drawer > renders with direction left inset correctly 1`] = `
   <div data-vaul-drawer-visible="true" data-vaul-handle="" aria-hidden="true" data-slot="handle" class="shrink-0 !bg-(--ui-color-divider-default) transition-opacity !mr-4 !h-12 !w-1.5 mt-auto mb-auto"><span data-vaul-handle-hitarea="" aria-hidden="true"></span></div>
   <!--v-if-->
   <div data-slot="container" class="w-full flex flex-col gap-4 p-4 overflow-y-auto">
-    <div data-slot="header" class="">
-      <h2 id="reka-dialog-title-v-0" data-slot="title" class="font-[family-name:var(--ui-font-family-primary)] text-label font-(--ui-font-weight-medium) mb-0 text-[calc(var(--ui-font-size-2xl)+2px)]/(--ui-font-size-2xl)">Title</h2>
-      <p id="reka-dialog-description-v-1" data-slot="description" class="mt-1 text-description text-(length:--ui-font-size-sm)">Description</p>
+    <div data-slot="header" class="flex items-center gap-1.5 min-h-8">
+      <div data-slot="wrapper" class="min-w-0 flex-1">
+        <h2 id="reka-dialog-title-v-0" data-slot="title" class="font-[family-name:var(--ui-font-family-primary)] text-label font-(--ui-font-weight-medium) mb-0 text-[calc(var(--ui-font-size-2xl)+2px)]/(--ui-font-size-2xl)">Title</h2>
+        <p id="reka-dialog-description-v-1" data-slot="description" class="mt-1 text-description text-(length:--ui-font-size-sm)">Description</p>
+      </div>
+      <!--v-if-->
     </div>
     <!--v-if-->
     <!--v-if-->
@@ -260,9 +404,12 @@ exports[`Drawer > renders with direction right correctly 1`] = `
   <div data-vaul-drawer-visible="true" data-vaul-handle="" aria-hidden="true" data-slot="handle" class="shrink-0 !bg-(--ui-color-divider-default) transition-opacity !ml-4 !h-12 !w-1.5 mt-auto mb-auto"><span data-vaul-handle-hitarea="" aria-hidden="true"></span></div>
   <!--v-if-->
   <div data-slot="container" class="w-full flex flex-col gap-4 p-4 overflow-y-auto">
-    <div data-slot="header" class="">
-      <h2 id="reka-dialog-title-v-0" data-slot="title" class="font-[family-name:var(--ui-font-family-primary)] text-label font-(--ui-font-weight-medium) mb-0 text-[calc(var(--ui-font-size-2xl)+2px)]/(--ui-font-size-2xl)">Title</h2>
-      <p id="reka-dialog-description-v-1" data-slot="description" class="mt-1 text-description text-(length:--ui-font-size-sm)">Description</p>
+    <div data-slot="header" class="flex items-center gap-1.5 min-h-8">
+      <div data-slot="wrapper" class="min-w-0 flex-1">
+        <h2 id="reka-dialog-title-v-0" data-slot="title" class="font-[family-name:var(--ui-font-family-primary)] text-label font-(--ui-font-weight-medium) mb-0 text-[calc(var(--ui-font-size-2xl)+2px)]/(--ui-font-size-2xl)">Title</h2>
+        <p id="reka-dialog-description-v-1" data-slot="description" class="mt-1 text-description text-(length:--ui-font-size-sm)">Description</p>
+      </div>
+      <!--v-if-->
     </div>
     <!--v-if-->
     <!--v-if-->
@@ -285,9 +432,12 @@ exports[`Drawer > renders with direction right inset correctly 1`] = `
   <div data-vaul-drawer-visible="true" data-vaul-handle="" aria-hidden="true" data-slot="handle" class="shrink-0 !bg-(--ui-color-divider-default) transition-opacity !ml-4 !h-12 !w-1.5 mt-auto mb-auto"><span data-vaul-handle-hitarea="" aria-hidden="true"></span></div>
   <!--v-if-->
   <div data-slot="container" class="w-full flex flex-col gap-4 p-4 overflow-y-auto">
-    <div data-slot="header" class="">
-      <h2 id="reka-dialog-title-v-0" data-slot="title" class="font-[family-name:var(--ui-font-family-primary)] text-label font-(--ui-font-weight-medium) mb-0 text-[calc(var(--ui-font-size-2xl)+2px)]/(--ui-font-size-2xl)">Title</h2>
-      <p id="reka-dialog-description-v-1" data-slot="description" class="mt-1 text-description text-(length:--ui-font-size-sm)">Description</p>
+    <div data-slot="header" class="flex items-center gap-1.5 min-h-8">
+      <div data-slot="wrapper" class="min-w-0 flex-1">
+        <h2 id="reka-dialog-title-v-0" data-slot="title" class="font-[family-name:var(--ui-font-family-primary)] text-label font-(--ui-font-weight-medium) mb-0 text-[calc(var(--ui-font-size-2xl)+2px)]/(--ui-font-size-2xl)">Title</h2>
+        <p id="reka-dialog-description-v-1" data-slot="description" class="mt-1 text-description text-(length:--ui-font-size-sm)">Description</p>
+      </div>
+      <!--v-if-->
     </div>
     <!--v-if-->
     <!--v-if-->
@@ -310,9 +460,12 @@ exports[`Drawer > renders with direction top correctly 1`] = `
   <div data-vaul-drawer-visible="true" data-vaul-handle="" aria-hidden="true" data-slot="handle" class="shrink-0 !bg-(--ui-color-divider-default) transition-opacity mb-4 !w-12 !h-1.5 mx-auto"><span data-vaul-handle-hitarea="" aria-hidden="true"></span></div>
   <!--v-if-->
   <div data-slot="container" class="w-full flex flex-col gap-4 p-4 overflow-y-auto">
-    <div data-slot="header" class="">
-      <h2 id="reka-dialog-title-v-0" data-slot="title" class="font-[family-name:var(--ui-font-family-primary)] text-label font-(--ui-font-weight-medium) mb-0 text-[calc(var(--ui-font-size-2xl)+2px)]/(--ui-font-size-2xl)">Title</h2>
-      <p id="reka-dialog-description-v-1" data-slot="description" class="mt-1 text-description text-(length:--ui-font-size-sm)">Description</p>
+    <div data-slot="header" class="flex items-center gap-1.5 min-h-8">
+      <div data-slot="wrapper" class="min-w-0 flex-1">
+        <h2 id="reka-dialog-title-v-0" data-slot="title" class="font-[family-name:var(--ui-font-family-primary)] text-label font-(--ui-font-weight-medium) mb-0 text-[calc(var(--ui-font-size-2xl)+2px)]/(--ui-font-size-2xl)">Title</h2>
+        <p id="reka-dialog-description-v-1" data-slot="description" class="mt-1 text-description text-(length:--ui-font-size-sm)">Description</p>
+      </div>
+      <!--v-if-->
     </div>
     <!--v-if-->
     <!--v-if-->
@@ -335,9 +488,12 @@ exports[`Drawer > renders with direction top inset correctly 1`] = `
   <div data-vaul-drawer-visible="true" data-vaul-handle="" aria-hidden="true" data-slot="handle" class="shrink-0 !bg-(--ui-color-divider-default) transition-opacity mb-4 !w-12 !h-1.5 mx-auto"><span data-vaul-handle-hitarea="" aria-hidden="true"></span></div>
   <!--v-if-->
   <div data-slot="container" class="w-full flex flex-col gap-4 p-4 overflow-y-auto">
-    <div data-slot="header" class="">
-      <h2 id="reka-dialog-title-v-0" data-slot="title" class="font-[family-name:var(--ui-font-family-primary)] text-label font-(--ui-font-weight-medium) mb-0 text-[calc(var(--ui-font-size-2xl)+2px)]/(--ui-font-size-2xl)">Title</h2>
-      <p id="reka-dialog-description-v-1" data-slot="description" class="mt-1 text-description text-(length:--ui-font-size-sm)">Description</p>
+    <div data-slot="header" class="flex items-center gap-1.5 min-h-8">
+      <div data-slot="wrapper" class="min-w-0 flex-1">
+        <h2 id="reka-dialog-title-v-0" data-slot="title" class="font-[family-name:var(--ui-font-family-primary)] text-label font-(--ui-font-weight-medium) mb-0 text-[calc(var(--ui-font-size-2xl)+2px)]/(--ui-font-size-2xl)">Title</h2>
+        <p id="reka-dialog-description-v-1" data-slot="description" class="mt-1 text-description text-(length:--ui-font-size-sm)">Description</p>
+      </div>
+      <!--v-if-->
     </div>
     <!--v-if-->
     <!--v-if-->
@@ -380,7 +536,7 @@ exports[`Drawer > renders with header slot correctly 1`] = `
 <div data-dismissable-layer="" style="pointer-events: auto; --snap-point-height: 0;" tabindex="-1" data-vaul-drawer="" data-vaul-drawer-direction="bottom" data-vaul-delayed-snap-points="false" data-vaul-snap-points="false" data-slot="content" class="fixed base-mode bg-(--ui-color-bg-content-primary) flex focus:outline-none ring ring-(--ui-color-divider-default) mt-24 flex-col h-auto max-h-[96%] inset-x-0 bottom-0 rounded-t-lg" id="" role="dialog" aria-describedby="reka-dialog-description-v-1" aria-labelledby="reka-dialog-title-v-0" data-state="open">
   <div data-vaul-drawer-visible="true" data-vaul-handle="" aria-hidden="true" data-slot="handle" class="shrink-0 !bg-(--ui-color-divider-default) transition-opacity mt-4 !w-12 !h-1.5 mx-auto"><span data-vaul-handle-hitarea="" aria-hidden="true"></span></div><span aria-hidden="true" style="position: absolute; border: 0px; width: 1px; height: 1px; padding: 0px; margin: -1px; overflow: hidden; clip: rect(0, 0, 0, 0); clip-path: inset(50%); white-space: nowrap; word-wrap: normal; top: -1px; left: -1px;"><h2 id="reka-dialog-title-v-0"></h2><p id="reka-dialog-description-v-1"></p></span>
   <div data-slot="container" class="w-full flex flex-col gap-4 p-4 overflow-y-auto">
-    <div data-slot="header" class="">Header slot</div>
+    <div data-slot="header" class="flex items-center gap-1.5 min-h-8">Header slot</div>
     <!--v-if-->
     <!--v-if-->
   </div>
@@ -401,9 +557,12 @@ exports[`Drawer > renders with title correctly 1`] = `
 <div data-dismissable-layer="" style="--snap-point-height: 0; pointer-events: auto;" tabindex="-1" data-vaul-drawer="" data-vaul-drawer-direction="bottom" data-vaul-delayed-snap-points="false" data-vaul-snap-points="false" data-slot="content" class="fixed base-mode bg-(--ui-color-bg-content-primary) flex focus:outline-none ring ring-(--ui-color-divider-default) mt-24 flex-col h-auto max-h-[96%] inset-x-0 bottom-0 rounded-t-lg" id="" role="dialog" aria-describedby="reka-dialog-description-v-1" aria-labelledby="reka-dialog-title-v-0" data-state="open">
   <div data-vaul-drawer-visible="true" data-vaul-handle="" aria-hidden="true" data-slot="handle" class="shrink-0 !bg-(--ui-color-divider-default) transition-opacity mt-4 !w-12 !h-1.5 mx-auto"><span data-vaul-handle-hitarea="" aria-hidden="true"></span></div><span aria-hidden="true" style="position: absolute; border: 0px; width: 1px; height: 1px; padding: 0px; margin: -1px; overflow: hidden; clip: rect(0, 0, 0, 0); clip-path: inset(50%); white-space: nowrap; word-wrap: normal; top: -1px; left: -1px;"><!--v-if--><p id="reka-dialog-description-v-1"></p></span>
   <div data-slot="container" class="w-full flex flex-col gap-4 p-4 overflow-y-auto">
-    <div data-slot="header" class="">
-      <h2 id="reka-dialog-title-v-0" data-slot="title" class="font-[family-name:var(--ui-font-family-primary)] text-label font-(--ui-font-weight-medium) mb-0 text-[calc(var(--ui-font-size-2xl)+2px)]/(--ui-font-size-2xl)">Title</h2>
-      <p id="reka-dialog-description-v-1"></p>
+    <div data-slot="header" class="flex items-center gap-1.5 min-h-8">
+      <div data-slot="wrapper" class="min-w-0 flex-1">
+        <h2 id="reka-dialog-title-v-0" data-slot="title" class="font-[family-name:var(--ui-font-family-primary)] text-label font-(--ui-font-weight-medium) mb-0 text-[calc(var(--ui-font-size-2xl)+2px)]/(--ui-font-size-2xl)">Title</h2>
+        <p id="reka-dialog-description-v-1"></p>
+      </div>
+      <!--v-if-->
     </div>
     <!--v-if-->
     <!--v-if-->
@@ -425,9 +584,12 @@ exports[`Drawer > renders with title slot correctly 1`] = `
 <div data-dismissable-layer="" style="pointer-events: auto; --snap-point-height: 0;" tabindex="-1" data-vaul-drawer="" data-vaul-drawer-direction="bottom" data-vaul-delayed-snap-points="false" data-vaul-snap-points="false" data-slot="content" class="fixed base-mode bg-(--ui-color-bg-content-primary) flex focus:outline-none ring ring-(--ui-color-divider-default) mt-24 flex-col h-auto max-h-[96%] inset-x-0 bottom-0 rounded-t-lg" id="" role="dialog" aria-describedby="reka-dialog-description-v-1" aria-labelledby="reka-dialog-title-v-0" data-state="open">
   <div data-vaul-drawer-visible="true" data-vaul-handle="" aria-hidden="true" data-slot="handle" class="shrink-0 !bg-(--ui-color-divider-default) transition-opacity mt-4 !w-12 !h-1.5 mx-auto"><span data-vaul-handle-hitarea="" aria-hidden="true"></span></div><span aria-hidden="true" style="position: absolute; border: 0px; width: 1px; height: 1px; padding: 0px; margin: -1px; overflow: hidden; clip: rect(0, 0, 0, 0); clip-path: inset(50%); white-space: nowrap; word-wrap: normal; top: -1px; left: -1px;"><!--v-if--><p id="reka-dialog-description-v-1"></p></span>
   <div data-slot="container" class="w-full flex flex-col gap-4 p-4 overflow-y-auto">
-    <div data-slot="header" class="">
-      <h2 id="reka-dialog-title-v-0" data-slot="title" class="font-[family-name:var(--ui-font-family-primary)] text-label font-(--ui-font-weight-medium) mb-0 text-[calc(var(--ui-font-size-2xl)+2px)]/(--ui-font-size-2xl)">Title slot</h2>
-      <p id="reka-dialog-description-v-1"></p>
+    <div data-slot="header" class="flex items-center gap-1.5 min-h-8">
+      <div data-slot="wrapper" class="min-w-0 flex-1">
+        <h2 id="reka-dialog-title-v-0" data-slot="title" class="font-[family-name:var(--ui-font-family-primary)] text-label font-(--ui-font-weight-medium) mb-0 text-[calc(var(--ui-font-size-2xl)+2px)]/(--ui-font-size-2xl)">Title slot</h2>
+        <p id="reka-dialog-description-v-1"></p>
+      </div>
+      <!--v-if-->
     </div>
     <!--v-if-->
     <!--v-if-->
@@ -450,9 +612,12 @@ exports[`Drawer > renders without handle correctly 1`] = `
   <!--v-if-->
   <!--v-if-->
   <div data-slot="container" class="w-full flex flex-col gap-4 p-4 overflow-y-auto">
-    <div data-slot="header" class="">
-      <h2 id="reka-dialog-title-v-0" data-slot="title" class="font-[family-name:var(--ui-font-family-primary)] text-label font-(--ui-font-weight-medium) mb-0 text-[calc(var(--ui-font-size-2xl)+2px)]/(--ui-font-size-2xl)">Title</h2>
-      <p id="reka-dialog-description-v-1" data-slot="description" class="mt-1 text-description text-(length:--ui-font-size-sm)">Description</p>
+    <div data-slot="header" class="flex items-center gap-1.5 min-h-8">
+      <div data-slot="wrapper" class="min-w-0 flex-1">
+        <h2 id="reka-dialog-title-v-0" data-slot="title" class="font-[family-name:var(--ui-font-family-primary)] text-label font-(--ui-font-weight-medium) mb-0 text-[calc(var(--ui-font-size-2xl)+2px)]/(--ui-font-size-2xl)">Title</h2>
+        <p id="reka-dialog-description-v-1" data-slot="description" class="mt-1 text-description text-(length:--ui-font-size-sm)">Description</p>
+      </div>
+      <!--v-if-->
     </div>
     <!--v-if-->
     <!--v-if-->
@@ -475,9 +640,12 @@ exports[`Drawer > renders without overlay correctly 1`] = `
   <div data-vaul-drawer-visible="true" data-vaul-handle="" aria-hidden="true" data-slot="handle" class="shrink-0 !bg-(--ui-color-divider-default) transition-opacity mt-4 !w-12 !h-1.5 mx-auto"><span data-vaul-handle-hitarea="" aria-hidden="true"></span></div>
   <!--v-if-->
   <div data-slot="container" class="w-full flex flex-col gap-4 p-4 overflow-y-auto">
-    <div data-slot="header" class="">
-      <h2 id="reka-dialog-title-v-0" data-slot="title" class="font-[family-name:var(--ui-font-family-primary)] text-label font-(--ui-font-weight-medium) mb-0 text-[calc(var(--ui-font-size-2xl)+2px)]/(--ui-font-size-2xl)">Title</h2>
-      <p id="reka-dialog-description-v-1" data-slot="description" class="mt-1 text-description text-(length:--ui-font-size-sm)">Description</p>
+    <div data-slot="header" class="flex items-center gap-1.5 min-h-8">
+      <div data-slot="wrapper" class="min-w-0 flex-1">
+        <h2 id="reka-dialog-title-v-0" data-slot="title" class="font-[family-name:var(--ui-font-family-primary)] text-label font-(--ui-font-weight-medium) mb-0 text-[calc(var(--ui-font-size-2xl)+2px)]/(--ui-font-size-2xl)">Title</h2>
+        <p id="reka-dialog-description-v-1" data-slot="description" class="mt-1 text-description text-(length:--ui-font-size-sm)">Description</p>
+      </div>
+      <!--v-if-->
     </div>
     <!--v-if-->
     <!--v-if-->

--- a/test/components/__snapshots__/Drawer.spec.ts.snap
+++ b/test/components/__snapshots__/Drawer.spec.ts.snap
@@ -1,5 +1,34 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`Drawer > renders with actions slot correctly 1`] = `
+"<!--v-if-->
+<!--teleport start-->
+
+
+
+<div data-state="open" style="pointer-events: auto;" data-vaul-overlay="" data-vaul-snap-points="false" data-vaul-snap-points-overlay="true" data-slot="overlay" class="fixed inset-0 motion-safe:backdrop-blur-[2px] bg-[#003366]/20"></div>
+<div data-dismissable-layer="" style="pointer-events: auto; --snap-point-height: 0;" tabindex="-1" data-vaul-drawer="" data-vaul-drawer-direction="bottom" data-vaul-delayed-snap-points="false" data-vaul-snap-points="false" data-slot="content" class="fixed base-mode bg-(--ui-color-bg-content-primary) flex focus:outline-none ring ring-(--ui-color-divider-default) mt-24 flex-col h-auto max-h-[96%] inset-x-0 bottom-0 rounded-t-lg" id="" role="dialog" aria-describedby="reka-dialog-description-v-0-0-1" aria-labelledby="reka-dialog-title-v-0-0-0" data-state="open">
+  <div data-vaul-drawer-visible="true" data-vaul-handle="" aria-hidden="true" data-slot="handle" class="shrink-0 !bg-(--ui-color-divider-default) transition-opacity mt-4 !w-12 !h-1.5 mx-auto"><span data-vaul-handle-hitarea="" aria-hidden="true"></span></div><span aria-hidden="true" style="position: absolute; border: 0px; width: 1px; height: 1px; padding: 0px; margin: -1px; overflow: hidden; clip: rect(0, 0, 0, 0); clip-path: inset(50%); white-space: nowrap; word-wrap: normal; top: -1px; left: -1px;"><!--v-if--><p id="reka-dialog-description-v-0-0-1"></p></span>
+  <div data-slot="container" class="w-full flex flex-col gap-4 p-4 overflow-y-auto">
+    <div data-slot="header" class="flex items-center gap-1.5 min-h-8">
+      <div data-slot="wrapper" class="min-w-0 flex-1">
+        <h2 id="reka-dialog-title-v-0-0-0" data-slot="title" class="font-[family-name:var(--ui-font-family-primary)] text-label font-(--ui-font-weight-medium) mb-0 text-[calc(var(--ui-font-size-2xl)+2px)]/(--ui-font-size-2xl)">Title</h2>
+        <p id="reka-dialog-description-v-0-0-1"></p>
+      </div>
+      <div data-slot="actions" class="flex items-center gap-1.5 shrink-0 ms-auto">Actions slot
+        <!--v-if-->
+      </div>
+    </div>
+    <!--v-if-->
+    <!--v-if-->
+  </div>
+</div>
+
+
+
+<!--teleport end-->"
+`;
+
 exports[`Drawer > renders with b24ui correctly 1`] = `
 "<!--v-if-->
 <!--teleport start-->
@@ -63,6 +92,103 @@ exports[`Drawer > renders with class correctly 1`] = `
 <!--teleport end-->"
 `;
 
+exports[`Drawer > renders with close correctly 1`] = `
+"<!--v-if-->
+<!--teleport start-->
+
+
+
+<div data-state="open" style="pointer-events: auto;" data-vaul-overlay="" data-vaul-snap-points="false" data-vaul-snap-points-overlay="true" data-slot="overlay" class="fixed inset-0 motion-safe:backdrop-blur-[2px] bg-[#003366]/20"></div>
+<div data-dismissable-layer="" style="pointer-events: auto; --snap-point-height: 0;" tabindex="-1" data-vaul-drawer="" data-vaul-drawer-direction="bottom" data-vaul-delayed-snap-points="false" data-vaul-snap-points="false" data-slot="content" class="fixed base-mode bg-(--ui-color-bg-content-primary) flex focus:outline-none ring ring-(--ui-color-divider-default) mt-24 flex-col h-auto max-h-[96%] inset-x-0 bottom-0 rounded-t-lg" id="" role="dialog" aria-describedby="reka-dialog-description-v-0-0-1" aria-labelledby="reka-dialog-title-v-0-0-0" data-state="open">
+  <div data-vaul-drawer-visible="true" data-vaul-handle="" aria-hidden="true" data-slot="handle" class="shrink-0 !bg-(--ui-color-divider-default) transition-opacity mt-4 !w-12 !h-1.5 mx-auto"><span data-vaul-handle-hitarea="" aria-hidden="true"></span></div><span aria-hidden="true" style="position: absolute; border: 0px; width: 1px; height: 1px; padding: 0px; margin: -1px; overflow: hidden; clip: rect(0, 0, 0, 0); clip-path: inset(50%); white-space: nowrap; word-wrap: normal; top: -1px; left: -1px;"><!--v-if--><p id="reka-dialog-description-v-0-0-1"></p></span>
+  <div data-slot="container" class="w-full flex flex-col gap-4 p-4 overflow-y-auto">
+    <div data-slot="header" class="flex items-center gap-1.5 min-h-8">
+      <div data-slot="wrapper" class="min-w-0 flex-1">
+        <h2 id="reka-dialog-title-v-0-0-0" data-slot="title" class="font-[family-name:var(--ui-font-family-primary)] text-label font-(--ui-font-weight-medium) mb-0 text-[calc(var(--ui-font-size-2xl)+2px)]/(--ui-font-size-2xl)">Title</h2>
+        <p id="reka-dialog-description-v-0-0-1"></p>
+      </div>
+      <div data-slot="actions" class="flex items-center gap-1.5 shrink-0 ms-auto"><button type="button" aria-label="Close" data-slot="base" class="ui-btn font-[family-name:var(--ui-font-family-primary)] select-none cursor-pointer inline-flex items-center relative outline-transparent focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed aria-disabled:cursor-not-allowed disabled:opacity-30 aria-disabled:opacity-30 transition duration-0 ease-linear border-(length:--ui-btn-border-width) text-(--ui-btn-color) bg-(--ui-btn-background) border-(--ui-btn-border-color) hover:text-(--ui-btn-color-hover) hover:bg-(--ui-btn-background-hover) hover:border-(--ui-btn-border-color-hover) focus:text-(--ui-btn-color-hover) focus:bg-(--ui-btn-background-hover) focus:border-(--ui-btn-border-color-hover) active:text-(--ui-btn-color-active) active:bg-(--ui-btn-background-active) active:border-(--ui-btn-border-color-active) disabled:bg-(--ui-btn-background) disabled:border-(--ui-btn-border-color) aria-disabled:bg-(--ui-btn-background) aria-disabled:border-(--ui-btn-border-color) focus-visible:outline-(--ui-btn-background) ring-(--ui-btn-background-hover) focus:outline-none focus-visible:ring-(--ui-btn-background-hover) h-(--ui-btn-height) text-(length:--ui-btn-font-size) leading-(--ui-btn-height) font-(--ui-btn-font-weight) --style-plain-no-accent ui-btn-md rounded-(--ui-btn-radius) normal-case --air w-(--ui-btn-height)">
+          <!--v-if-->
+          <div data-slot="baseLine" class="w-full inline-flex items-center justify-center gap-(--ui-btn-icon-space) h-(--ui-btn-height) ps-[4px] pe-[4px]"><svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" aria-hidden="true" data-slot="icon" class="text-(--ui-btn-color) shrink-0 size-(--ui-btn-icon-size)">
+              <path fill="currentColor" d="M8.46 7.54a.65.65 0 0 0-.92.92L11.08 12l-3.54 3.54a.65.65 0 1 0 .92.92L12 12.918l3.54 3.54a.65.65 0 1 0 .919-.92L12.919 12l3.54-3.54a.65.65 0 0 0-.92-.919L12 11.08z"></path>
+            </svg>
+            <!--v-if-->
+            <!--v-if-->
+          </div>
+        </button></div>
+    </div>
+    <!--v-if-->
+    <!--v-if-->
+  </div>
+</div>
+
+
+
+<!--teleport end-->"
+`;
+
+exports[`Drawer > renders with close slot correctly 1`] = `
+"<!--v-if-->
+<!--teleport start-->
+
+
+
+<div data-state="open" style="pointer-events: auto;" data-vaul-overlay="" data-vaul-snap-points="false" data-vaul-snap-points-overlay="true" data-slot="overlay" class="fixed inset-0 motion-safe:backdrop-blur-[2px] bg-[#003366]/20"></div>
+<div data-dismissable-layer="" style="pointer-events: auto; --snap-point-height: 0;" tabindex="-1" data-vaul-drawer="" data-vaul-drawer-direction="bottom" data-vaul-delayed-snap-points="false" data-vaul-snap-points="false" data-slot="content" class="fixed base-mode bg-(--ui-color-bg-content-primary) flex focus:outline-none ring ring-(--ui-color-divider-default) mt-24 flex-col h-auto max-h-[96%] inset-x-0 bottom-0 rounded-t-lg" id="" role="dialog" aria-describedby="reka-dialog-description-v-0-0-1" aria-labelledby="reka-dialog-title-v-0-0-0" data-state="open">
+  <div data-vaul-drawer-visible="true" data-vaul-handle="" aria-hidden="true" data-slot="handle" class="shrink-0 !bg-(--ui-color-divider-default) transition-opacity mt-4 !w-12 !h-1.5 mx-auto"><span data-vaul-handle-hitarea="" aria-hidden="true"></span></div><span aria-hidden="true" style="position: absolute; border: 0px; width: 1px; height: 1px; padding: 0px; margin: -1px; overflow: hidden; clip: rect(0, 0, 0, 0); clip-path: inset(50%); white-space: nowrap; word-wrap: normal; top: -1px; left: -1px;"><!--v-if--><p id="reka-dialog-description-v-0-0-1"></p></span>
+  <div data-slot="container" class="w-full flex flex-col gap-4 p-4 overflow-y-auto">
+    <div data-slot="header" class="flex items-center gap-1.5 min-h-8">
+      <div data-slot="wrapper" class="min-w-0 flex-1">
+        <h2 id="reka-dialog-title-v-0-0-0" data-slot="title" class="font-[family-name:var(--ui-font-family-primary)] text-label font-(--ui-font-weight-medium) mb-0 text-[calc(var(--ui-font-size-2xl)+2px)]/(--ui-font-size-2xl)">Title</h2>
+        <p id="reka-dialog-description-v-0-0-1"></p>
+      </div>
+      <div data-slot="actions" class="flex items-center gap-1.5 shrink-0 ms-auto">Close slot</div>
+    </div>
+    <!--v-if-->
+    <!--v-if-->
+  </div>
+</div>
+
+
+
+<!--teleport end-->"
+`;
+
+exports[`Drawer > renders with closeIcon correctly 1`] = `
+"<!--v-if-->
+<!--teleport start-->
+
+
+
+<div data-state="open" style="pointer-events: auto;" data-vaul-overlay="" data-vaul-snap-points="false" data-vaul-snap-points-overlay="true" data-slot="overlay" class="fixed inset-0 motion-safe:backdrop-blur-[2px] bg-[#003366]/20"></div>
+<div data-dismissable-layer="" style="pointer-events: auto; --snap-point-height: 0;" tabindex="-1" data-vaul-drawer="" data-vaul-drawer-direction="bottom" data-vaul-delayed-snap-points="false" data-vaul-snap-points="false" data-slot="content" class="fixed base-mode bg-(--ui-color-bg-content-primary) flex focus:outline-none ring ring-(--ui-color-divider-default) mt-24 flex-col h-auto max-h-[96%] inset-x-0 bottom-0 rounded-t-lg" id="" role="dialog" aria-describedby="reka-dialog-description-v-0-0-1" aria-labelledby="reka-dialog-title-v-0-0-0" data-state="open">
+  <div data-vaul-drawer-visible="true" data-vaul-handle="" aria-hidden="true" data-slot="handle" class="shrink-0 !bg-(--ui-color-divider-default) transition-opacity mt-4 !w-12 !h-1.5 mx-auto"><span data-vaul-handle-hitarea="" aria-hidden="true"></span></div><span aria-hidden="true" style="position: absolute; border: 0px; width: 1px; height: 1px; padding: 0px; margin: -1px; overflow: hidden; clip: rect(0, 0, 0, 0); clip-path: inset(50%); white-space: nowrap; word-wrap: normal; top: -1px; left: -1px;"><!--v-if--><p id="reka-dialog-description-v-0-0-1"></p></span>
+  <div data-slot="container" class="w-full flex flex-col gap-4 p-4 overflow-y-auto">
+    <div data-slot="header" class="flex items-center gap-1.5 min-h-8">
+      <div data-slot="wrapper" class="min-w-0 flex-1">
+        <h2 id="reka-dialog-title-v-0-0-0" data-slot="title" class="font-[family-name:var(--ui-font-family-primary)] text-label font-(--ui-font-weight-medium) mb-0 text-[calc(var(--ui-font-size-2xl)+2px)]/(--ui-font-size-2xl)">Title</h2>
+        <p id="reka-dialog-description-v-0-0-1"></p>
+      </div>
+      <div data-slot="actions" class="flex items-center gap-1.5 shrink-0 ms-auto"><button type="button" aria-label="Close" data-slot="base" class="ui-btn font-[family-name:var(--ui-font-family-primary)] select-none cursor-pointer inline-flex items-center relative outline-transparent focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed aria-disabled:cursor-not-allowed disabled:opacity-30 aria-disabled:opacity-30 transition duration-0 ease-linear border-(length:--ui-btn-border-width) text-(--ui-btn-color) bg-(--ui-btn-background) border-(--ui-btn-border-color) hover:text-(--ui-btn-color-hover) hover:bg-(--ui-btn-background-hover) hover:border-(--ui-btn-border-color-hover) focus:text-(--ui-btn-color-hover) focus:bg-(--ui-btn-background-hover) focus:border-(--ui-btn-border-color-hover) active:text-(--ui-btn-color-active) active:bg-(--ui-btn-background-active) active:border-(--ui-btn-border-color-active) disabled:bg-(--ui-btn-background) disabled:border-(--ui-btn-border-color) aria-disabled:bg-(--ui-btn-background) aria-disabled:border-(--ui-btn-border-color) focus-visible:outline-(--ui-btn-background) ring-(--ui-btn-background-hover) focus:outline-none focus-visible:ring-(--ui-btn-background-hover) h-(--ui-btn-height) text-(length:--ui-btn-font-size) leading-(--ui-btn-height) font-(--ui-btn-font-weight) --style-plain-no-accent ui-btn-md rounded-(--ui-btn-radius) normal-case --air w-(--ui-btn-height)">
+          <!--v-if-->
+          <div data-slot="baseLine" class="w-full inline-flex items-center justify-center gap-(--ui-btn-icon-space) h-(--ui-btn-height) ps-[4px] pe-[4px]"><svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" aria-hidden="true" data-slot="icon" class="text-(--ui-btn-color) shrink-0 size-(--ui-btn-icon-size)">
+              <path fill="currentColor" fill-rule="evenodd" d="m13.505 12 3.905 3.904-1.505 1.505L12 13.505l-3.905 3.904-1.505-1.505L10.495 12 6.59 8.095 8.095 6.59 12 10.495l3.905-3.905 1.505 1.505z" clip-rule="evenodd"></path>
+            </svg>
+            <!--v-if-->
+            <!--v-if-->
+          </div>
+        </button></div>
+    </div>
+    <!--v-if-->
+    <!--v-if-->
+  </div>
+</div>
+
+
+
+<!--teleport end-->"
+`;
+
 exports[`Drawer > renders with content slot correctly 1`] = `
 "<!--v-if-->
 <!--teleport start-->
@@ -111,9 +237,12 @@ exports[`Drawer > renders with description correctly 1`] = `
   <div data-vaul-drawer-visible="true" data-vaul-handle="" aria-hidden="true" data-slot="handle" class="shrink-0 !bg-(--ui-color-divider-default) transition-opacity mt-4 !w-12 !h-1.5 mx-auto"><span data-vaul-handle-hitarea="" aria-hidden="true"></span></div>
   <!--v-if-->
   <div data-slot="container" class="w-full flex flex-col gap-4 p-4 overflow-y-auto">
-    <div data-slot="header" class="">
-      <h2 id="reka-dialog-title-v-0-0-0" data-slot="title" class="font-[family-name:var(--ui-font-family-primary)] text-label font-(--ui-font-weight-medium) mb-0 text-[calc(var(--ui-font-size-2xl)+2px)]/(--ui-font-size-2xl)">Title</h2>
-      <p id="reka-dialog-description-v-0-0-1" data-slot="description" class="mt-1 text-description text-(length:--ui-font-size-sm)">Description</p>
+    <div data-slot="header" class="flex items-center gap-1.5 min-h-8">
+      <div data-slot="wrapper" class="min-w-0 flex-1">
+        <h2 id="reka-dialog-title-v-0-0-0" data-slot="title" class="font-[family-name:var(--ui-font-family-primary)] text-label font-(--ui-font-weight-medium) mb-0 text-[calc(var(--ui-font-size-2xl)+2px)]/(--ui-font-size-2xl)">Title</h2>
+        <p id="reka-dialog-description-v-0-0-1" data-slot="description" class="mt-1 text-description text-(length:--ui-font-size-sm)">Description</p>
+      </div>
+      <!--v-if-->
     </div>
     <!--v-if-->
     <!--v-if-->
@@ -135,9 +264,12 @@ exports[`Drawer > renders with description slot correctly 1`] = `
 <div data-dismissable-layer="" style="pointer-events: auto; --snap-point-height: 0;" tabindex="-1" data-vaul-drawer="" data-vaul-drawer-direction="bottom" data-vaul-delayed-snap-points="false" data-vaul-snap-points="false" data-slot="content" class="fixed base-mode bg-(--ui-color-bg-content-primary) flex focus:outline-none ring ring-(--ui-color-divider-default) mt-24 flex-col h-auto max-h-[96%] inset-x-0 bottom-0 rounded-t-lg" id="" role="dialog" aria-describedby="reka-dialog-description-v-0-0-1" aria-labelledby="reka-dialog-title-v-0-0-0" data-state="open">
   <div data-vaul-drawer-visible="true" data-vaul-handle="" aria-hidden="true" data-slot="handle" class="shrink-0 !bg-(--ui-color-divider-default) transition-opacity mt-4 !w-12 !h-1.5 mx-auto"><span data-vaul-handle-hitarea="" aria-hidden="true"></span></div><span aria-hidden="true" style="position: absolute; border: 0px; width: 1px; height: 1px; padding: 0px; margin: -1px; overflow: hidden; clip: rect(0, 0, 0, 0); clip-path: inset(50%); white-space: nowrap; word-wrap: normal; top: -1px; left: -1px;"><h2 id="reka-dialog-title-v-0-0-0"></h2><!--v-if--></span>
   <div data-slot="container" class="w-full flex flex-col gap-4 p-4 overflow-y-auto">
-    <div data-slot="header" class="">
-      <h2 id="reka-dialog-title-v-0-0-0"></h2>
-      <p id="reka-dialog-description-v-0-0-1" data-slot="description" class="mt-1 text-description text-(length:--ui-font-size-sm)">Description slot</p>
+    <div data-slot="header" class="flex items-center gap-1.5 min-h-8">
+      <div data-slot="wrapper" class="min-w-0 flex-1">
+        <h2 id="reka-dialog-title-v-0-0-0"></h2>
+        <p id="reka-dialog-description-v-0-0-1" data-slot="description" class="mt-1 text-description text-(length:--ui-font-size-sm)">Description slot</p>
+      </div>
+      <!--v-if-->
     </div>
     <!--v-if-->
     <!--v-if-->
@@ -160,9 +292,12 @@ exports[`Drawer > renders with direction bottom correctly 1`] = `
   <div data-vaul-drawer-visible="true" data-vaul-handle="" aria-hidden="true" data-slot="handle" class="shrink-0 !bg-(--ui-color-divider-default) transition-opacity mt-4 !w-12 !h-1.5 mx-auto"><span data-vaul-handle-hitarea="" aria-hidden="true"></span></div>
   <!--v-if-->
   <div data-slot="container" class="w-full flex flex-col gap-4 p-4 overflow-y-auto">
-    <div data-slot="header" class="">
-      <h2 id="reka-dialog-title-v-0-0-0" data-slot="title" class="font-[family-name:var(--ui-font-family-primary)] text-label font-(--ui-font-weight-medium) mb-0 text-[calc(var(--ui-font-size-2xl)+2px)]/(--ui-font-size-2xl)">Title</h2>
-      <p id="reka-dialog-description-v-0-0-1" data-slot="description" class="mt-1 text-description text-(length:--ui-font-size-sm)">Description</p>
+    <div data-slot="header" class="flex items-center gap-1.5 min-h-8">
+      <div data-slot="wrapper" class="min-w-0 flex-1">
+        <h2 id="reka-dialog-title-v-0-0-0" data-slot="title" class="font-[family-name:var(--ui-font-family-primary)] text-label font-(--ui-font-weight-medium) mb-0 text-[calc(var(--ui-font-size-2xl)+2px)]/(--ui-font-size-2xl)">Title</h2>
+        <p id="reka-dialog-description-v-0-0-1" data-slot="description" class="mt-1 text-description text-(length:--ui-font-size-sm)">Description</p>
+      </div>
+      <!--v-if-->
     </div>
     <!--v-if-->
     <!--v-if-->
@@ -185,9 +320,12 @@ exports[`Drawer > renders with direction bottom inset correctly 1`] = `
   <div data-vaul-drawer-visible="true" data-vaul-handle="" aria-hidden="true" data-slot="handle" class="shrink-0 !bg-(--ui-color-divider-default) transition-opacity mt-4 !w-12 !h-1.5 mx-auto"><span data-vaul-handle-hitarea="" aria-hidden="true"></span></div>
   <!--v-if-->
   <div data-slot="container" class="w-full flex flex-col gap-4 p-4 overflow-y-auto">
-    <div data-slot="header" class="">
-      <h2 id="reka-dialog-title-v-0-0-0" data-slot="title" class="font-[family-name:var(--ui-font-family-primary)] text-label font-(--ui-font-weight-medium) mb-0 text-[calc(var(--ui-font-size-2xl)+2px)]/(--ui-font-size-2xl)">Title</h2>
-      <p id="reka-dialog-description-v-0-0-1" data-slot="description" class="mt-1 text-description text-(length:--ui-font-size-sm)">Description</p>
+    <div data-slot="header" class="flex items-center gap-1.5 min-h-8">
+      <div data-slot="wrapper" class="min-w-0 flex-1">
+        <h2 id="reka-dialog-title-v-0-0-0" data-slot="title" class="font-[family-name:var(--ui-font-family-primary)] text-label font-(--ui-font-weight-medium) mb-0 text-[calc(var(--ui-font-size-2xl)+2px)]/(--ui-font-size-2xl)">Title</h2>
+        <p id="reka-dialog-description-v-0-0-1" data-slot="description" class="mt-1 text-description text-(length:--ui-font-size-sm)">Description</p>
+      </div>
+      <!--v-if-->
     </div>
     <!--v-if-->
     <!--v-if-->
@@ -210,9 +348,12 @@ exports[`Drawer > renders with direction left correctly 1`] = `
   <div data-vaul-drawer-visible="true" data-vaul-handle="" aria-hidden="true" data-slot="handle" class="shrink-0 !bg-(--ui-color-divider-default) transition-opacity !mr-4 !h-12 !w-1.5 mt-auto mb-auto"><span data-vaul-handle-hitarea="" aria-hidden="true"></span></div>
   <!--v-if-->
   <div data-slot="container" class="w-full flex flex-col gap-4 p-4 overflow-y-auto">
-    <div data-slot="header" class="">
-      <h2 id="reka-dialog-title-v-0-0-0" data-slot="title" class="font-[family-name:var(--ui-font-family-primary)] text-label font-(--ui-font-weight-medium) mb-0 text-[calc(var(--ui-font-size-2xl)+2px)]/(--ui-font-size-2xl)">Title</h2>
-      <p id="reka-dialog-description-v-0-0-1" data-slot="description" class="mt-1 text-description text-(length:--ui-font-size-sm)">Description</p>
+    <div data-slot="header" class="flex items-center gap-1.5 min-h-8">
+      <div data-slot="wrapper" class="min-w-0 flex-1">
+        <h2 id="reka-dialog-title-v-0-0-0" data-slot="title" class="font-[family-name:var(--ui-font-family-primary)] text-label font-(--ui-font-weight-medium) mb-0 text-[calc(var(--ui-font-size-2xl)+2px)]/(--ui-font-size-2xl)">Title</h2>
+        <p id="reka-dialog-description-v-0-0-1" data-slot="description" class="mt-1 text-description text-(length:--ui-font-size-sm)">Description</p>
+      </div>
+      <!--v-if-->
     </div>
     <!--v-if-->
     <!--v-if-->
@@ -235,9 +376,12 @@ exports[`Drawer > renders with direction left inset correctly 1`] = `
   <div data-vaul-drawer-visible="true" data-vaul-handle="" aria-hidden="true" data-slot="handle" class="shrink-0 !bg-(--ui-color-divider-default) transition-opacity !mr-4 !h-12 !w-1.5 mt-auto mb-auto"><span data-vaul-handle-hitarea="" aria-hidden="true"></span></div>
   <!--v-if-->
   <div data-slot="container" class="w-full flex flex-col gap-4 p-4 overflow-y-auto">
-    <div data-slot="header" class="">
-      <h2 id="reka-dialog-title-v-0-0-0" data-slot="title" class="font-[family-name:var(--ui-font-family-primary)] text-label font-(--ui-font-weight-medium) mb-0 text-[calc(var(--ui-font-size-2xl)+2px)]/(--ui-font-size-2xl)">Title</h2>
-      <p id="reka-dialog-description-v-0-0-1" data-slot="description" class="mt-1 text-description text-(length:--ui-font-size-sm)">Description</p>
+    <div data-slot="header" class="flex items-center gap-1.5 min-h-8">
+      <div data-slot="wrapper" class="min-w-0 flex-1">
+        <h2 id="reka-dialog-title-v-0-0-0" data-slot="title" class="font-[family-name:var(--ui-font-family-primary)] text-label font-(--ui-font-weight-medium) mb-0 text-[calc(var(--ui-font-size-2xl)+2px)]/(--ui-font-size-2xl)">Title</h2>
+        <p id="reka-dialog-description-v-0-0-1" data-slot="description" class="mt-1 text-description text-(length:--ui-font-size-sm)">Description</p>
+      </div>
+      <!--v-if-->
     </div>
     <!--v-if-->
     <!--v-if-->
@@ -260,9 +404,12 @@ exports[`Drawer > renders with direction right correctly 1`] = `
   <div data-vaul-drawer-visible="true" data-vaul-handle="" aria-hidden="true" data-slot="handle" class="shrink-0 !bg-(--ui-color-divider-default) transition-opacity !ml-4 !h-12 !w-1.5 mt-auto mb-auto"><span data-vaul-handle-hitarea="" aria-hidden="true"></span></div>
   <!--v-if-->
   <div data-slot="container" class="w-full flex flex-col gap-4 p-4 overflow-y-auto">
-    <div data-slot="header" class="">
-      <h2 id="reka-dialog-title-v-0-0-0" data-slot="title" class="font-[family-name:var(--ui-font-family-primary)] text-label font-(--ui-font-weight-medium) mb-0 text-[calc(var(--ui-font-size-2xl)+2px)]/(--ui-font-size-2xl)">Title</h2>
-      <p id="reka-dialog-description-v-0-0-1" data-slot="description" class="mt-1 text-description text-(length:--ui-font-size-sm)">Description</p>
+    <div data-slot="header" class="flex items-center gap-1.5 min-h-8">
+      <div data-slot="wrapper" class="min-w-0 flex-1">
+        <h2 id="reka-dialog-title-v-0-0-0" data-slot="title" class="font-[family-name:var(--ui-font-family-primary)] text-label font-(--ui-font-weight-medium) mb-0 text-[calc(var(--ui-font-size-2xl)+2px)]/(--ui-font-size-2xl)">Title</h2>
+        <p id="reka-dialog-description-v-0-0-1" data-slot="description" class="mt-1 text-description text-(length:--ui-font-size-sm)">Description</p>
+      </div>
+      <!--v-if-->
     </div>
     <!--v-if-->
     <!--v-if-->
@@ -285,9 +432,12 @@ exports[`Drawer > renders with direction right inset correctly 1`] = `
   <div data-vaul-drawer-visible="true" data-vaul-handle="" aria-hidden="true" data-slot="handle" class="shrink-0 !bg-(--ui-color-divider-default) transition-opacity !ml-4 !h-12 !w-1.5 mt-auto mb-auto"><span data-vaul-handle-hitarea="" aria-hidden="true"></span></div>
   <!--v-if-->
   <div data-slot="container" class="w-full flex flex-col gap-4 p-4 overflow-y-auto">
-    <div data-slot="header" class="">
-      <h2 id="reka-dialog-title-v-0-0-0" data-slot="title" class="font-[family-name:var(--ui-font-family-primary)] text-label font-(--ui-font-weight-medium) mb-0 text-[calc(var(--ui-font-size-2xl)+2px)]/(--ui-font-size-2xl)">Title</h2>
-      <p id="reka-dialog-description-v-0-0-1" data-slot="description" class="mt-1 text-description text-(length:--ui-font-size-sm)">Description</p>
+    <div data-slot="header" class="flex items-center gap-1.5 min-h-8">
+      <div data-slot="wrapper" class="min-w-0 flex-1">
+        <h2 id="reka-dialog-title-v-0-0-0" data-slot="title" class="font-[family-name:var(--ui-font-family-primary)] text-label font-(--ui-font-weight-medium) mb-0 text-[calc(var(--ui-font-size-2xl)+2px)]/(--ui-font-size-2xl)">Title</h2>
+        <p id="reka-dialog-description-v-0-0-1" data-slot="description" class="mt-1 text-description text-(length:--ui-font-size-sm)">Description</p>
+      </div>
+      <!--v-if-->
     </div>
     <!--v-if-->
     <!--v-if-->
@@ -310,9 +460,12 @@ exports[`Drawer > renders with direction top correctly 1`] = `
   <div data-vaul-drawer-visible="true" data-vaul-handle="" aria-hidden="true" data-slot="handle" class="shrink-0 !bg-(--ui-color-divider-default) transition-opacity mb-4 !w-12 !h-1.5 mx-auto"><span data-vaul-handle-hitarea="" aria-hidden="true"></span></div>
   <!--v-if-->
   <div data-slot="container" class="w-full flex flex-col gap-4 p-4 overflow-y-auto">
-    <div data-slot="header" class="">
-      <h2 id="reka-dialog-title-v-0-0-0" data-slot="title" class="font-[family-name:var(--ui-font-family-primary)] text-label font-(--ui-font-weight-medium) mb-0 text-[calc(var(--ui-font-size-2xl)+2px)]/(--ui-font-size-2xl)">Title</h2>
-      <p id="reka-dialog-description-v-0-0-1" data-slot="description" class="mt-1 text-description text-(length:--ui-font-size-sm)">Description</p>
+    <div data-slot="header" class="flex items-center gap-1.5 min-h-8">
+      <div data-slot="wrapper" class="min-w-0 flex-1">
+        <h2 id="reka-dialog-title-v-0-0-0" data-slot="title" class="font-[family-name:var(--ui-font-family-primary)] text-label font-(--ui-font-weight-medium) mb-0 text-[calc(var(--ui-font-size-2xl)+2px)]/(--ui-font-size-2xl)">Title</h2>
+        <p id="reka-dialog-description-v-0-0-1" data-slot="description" class="mt-1 text-description text-(length:--ui-font-size-sm)">Description</p>
+      </div>
+      <!--v-if-->
     </div>
     <!--v-if-->
     <!--v-if-->
@@ -335,9 +488,12 @@ exports[`Drawer > renders with direction top inset correctly 1`] = `
   <div data-vaul-drawer-visible="true" data-vaul-handle="" aria-hidden="true" data-slot="handle" class="shrink-0 !bg-(--ui-color-divider-default) transition-opacity mb-4 !w-12 !h-1.5 mx-auto"><span data-vaul-handle-hitarea="" aria-hidden="true"></span></div>
   <!--v-if-->
   <div data-slot="container" class="w-full flex flex-col gap-4 p-4 overflow-y-auto">
-    <div data-slot="header" class="">
-      <h2 id="reka-dialog-title-v-0-0-0" data-slot="title" class="font-[family-name:var(--ui-font-family-primary)] text-label font-(--ui-font-weight-medium) mb-0 text-[calc(var(--ui-font-size-2xl)+2px)]/(--ui-font-size-2xl)">Title</h2>
-      <p id="reka-dialog-description-v-0-0-1" data-slot="description" class="mt-1 text-description text-(length:--ui-font-size-sm)">Description</p>
+    <div data-slot="header" class="flex items-center gap-1.5 min-h-8">
+      <div data-slot="wrapper" class="min-w-0 flex-1">
+        <h2 id="reka-dialog-title-v-0-0-0" data-slot="title" class="font-[family-name:var(--ui-font-family-primary)] text-label font-(--ui-font-weight-medium) mb-0 text-[calc(var(--ui-font-size-2xl)+2px)]/(--ui-font-size-2xl)">Title</h2>
+        <p id="reka-dialog-description-v-0-0-1" data-slot="description" class="mt-1 text-description text-(length:--ui-font-size-sm)">Description</p>
+      </div>
+      <!--v-if-->
     </div>
     <!--v-if-->
     <!--v-if-->
@@ -380,7 +536,7 @@ exports[`Drawer > renders with header slot correctly 1`] = `
 <div data-dismissable-layer="" style="pointer-events: auto; --snap-point-height: 0;" tabindex="-1" data-vaul-drawer="" data-vaul-drawer-direction="bottom" data-vaul-delayed-snap-points="false" data-vaul-snap-points="false" data-slot="content" class="fixed base-mode bg-(--ui-color-bg-content-primary) flex focus:outline-none ring ring-(--ui-color-divider-default) mt-24 flex-col h-auto max-h-[96%] inset-x-0 bottom-0 rounded-t-lg" id="" role="dialog" aria-describedby="reka-dialog-description-v-0-0-1" aria-labelledby="reka-dialog-title-v-0-0-0" data-state="open">
   <div data-vaul-drawer-visible="true" data-vaul-handle="" aria-hidden="true" data-slot="handle" class="shrink-0 !bg-(--ui-color-divider-default) transition-opacity mt-4 !w-12 !h-1.5 mx-auto"><span data-vaul-handle-hitarea="" aria-hidden="true"></span></div><span aria-hidden="true" style="position: absolute; border: 0px; width: 1px; height: 1px; padding: 0px; margin: -1px; overflow: hidden; clip: rect(0, 0, 0, 0); clip-path: inset(50%); white-space: nowrap; word-wrap: normal; top: -1px; left: -1px;"><h2 id="reka-dialog-title-v-0-0-0"></h2><p id="reka-dialog-description-v-0-0-1"></p></span>
   <div data-slot="container" class="w-full flex flex-col gap-4 p-4 overflow-y-auto">
-    <div data-slot="header" class="">Header slot</div>
+    <div data-slot="header" class="flex items-center gap-1.5 min-h-8">Header slot</div>
     <!--v-if-->
     <!--v-if-->
   </div>
@@ -401,9 +557,12 @@ exports[`Drawer > renders with title correctly 1`] = `
 <div data-dismissable-layer="" style="--snap-point-height: 0; pointer-events: auto;" tabindex="-1" data-vaul-drawer="" data-vaul-drawer-direction="bottom" data-vaul-delayed-snap-points="false" data-vaul-snap-points="false" data-slot="content" class="fixed base-mode bg-(--ui-color-bg-content-primary) flex focus:outline-none ring ring-(--ui-color-divider-default) mt-24 flex-col h-auto max-h-[96%] inset-x-0 bottom-0 rounded-t-lg" id="" role="dialog" aria-describedby="reka-dialog-description-v-0-0-1" aria-labelledby="reka-dialog-title-v-0-0-0" data-state="open">
   <div data-vaul-drawer-visible="true" data-vaul-handle="" aria-hidden="true" data-slot="handle" class="shrink-0 !bg-(--ui-color-divider-default) transition-opacity mt-4 !w-12 !h-1.5 mx-auto"><span data-vaul-handle-hitarea="" aria-hidden="true"></span></div><span aria-hidden="true" style="position: absolute; border: 0px; width: 1px; height: 1px; padding: 0px; margin: -1px; overflow: hidden; clip: rect(0, 0, 0, 0); clip-path: inset(50%); white-space: nowrap; word-wrap: normal; top: -1px; left: -1px;"><!--v-if--><p id="reka-dialog-description-v-0-0-1"></p></span>
   <div data-slot="container" class="w-full flex flex-col gap-4 p-4 overflow-y-auto">
-    <div data-slot="header" class="">
-      <h2 id="reka-dialog-title-v-0-0-0" data-slot="title" class="font-[family-name:var(--ui-font-family-primary)] text-label font-(--ui-font-weight-medium) mb-0 text-[calc(var(--ui-font-size-2xl)+2px)]/(--ui-font-size-2xl)">Title</h2>
-      <p id="reka-dialog-description-v-0-0-1"></p>
+    <div data-slot="header" class="flex items-center gap-1.5 min-h-8">
+      <div data-slot="wrapper" class="min-w-0 flex-1">
+        <h2 id="reka-dialog-title-v-0-0-0" data-slot="title" class="font-[family-name:var(--ui-font-family-primary)] text-label font-(--ui-font-weight-medium) mb-0 text-[calc(var(--ui-font-size-2xl)+2px)]/(--ui-font-size-2xl)">Title</h2>
+        <p id="reka-dialog-description-v-0-0-1"></p>
+      </div>
+      <!--v-if-->
     </div>
     <!--v-if-->
     <!--v-if-->
@@ -425,9 +584,12 @@ exports[`Drawer > renders with title slot correctly 1`] = `
 <div data-dismissable-layer="" style="pointer-events: auto; --snap-point-height: 0;" tabindex="-1" data-vaul-drawer="" data-vaul-drawer-direction="bottom" data-vaul-delayed-snap-points="false" data-vaul-snap-points="false" data-slot="content" class="fixed base-mode bg-(--ui-color-bg-content-primary) flex focus:outline-none ring ring-(--ui-color-divider-default) mt-24 flex-col h-auto max-h-[96%] inset-x-0 bottom-0 rounded-t-lg" id="" role="dialog" aria-describedby="reka-dialog-description-v-0-0-1" aria-labelledby="reka-dialog-title-v-0-0-0" data-state="open">
   <div data-vaul-drawer-visible="true" data-vaul-handle="" aria-hidden="true" data-slot="handle" class="shrink-0 !bg-(--ui-color-divider-default) transition-opacity mt-4 !w-12 !h-1.5 mx-auto"><span data-vaul-handle-hitarea="" aria-hidden="true"></span></div><span aria-hidden="true" style="position: absolute; border: 0px; width: 1px; height: 1px; padding: 0px; margin: -1px; overflow: hidden; clip: rect(0, 0, 0, 0); clip-path: inset(50%); white-space: nowrap; word-wrap: normal; top: -1px; left: -1px;"><!--v-if--><p id="reka-dialog-description-v-0-0-1"></p></span>
   <div data-slot="container" class="w-full flex flex-col gap-4 p-4 overflow-y-auto">
-    <div data-slot="header" class="">
-      <h2 id="reka-dialog-title-v-0-0-0" data-slot="title" class="font-[family-name:var(--ui-font-family-primary)] text-label font-(--ui-font-weight-medium) mb-0 text-[calc(var(--ui-font-size-2xl)+2px)]/(--ui-font-size-2xl)">Title slot</h2>
-      <p id="reka-dialog-description-v-0-0-1"></p>
+    <div data-slot="header" class="flex items-center gap-1.5 min-h-8">
+      <div data-slot="wrapper" class="min-w-0 flex-1">
+        <h2 id="reka-dialog-title-v-0-0-0" data-slot="title" class="font-[family-name:var(--ui-font-family-primary)] text-label font-(--ui-font-weight-medium) mb-0 text-[calc(var(--ui-font-size-2xl)+2px)]/(--ui-font-size-2xl)">Title slot</h2>
+        <p id="reka-dialog-description-v-0-0-1"></p>
+      </div>
+      <!--v-if-->
     </div>
     <!--v-if-->
     <!--v-if-->
@@ -450,9 +612,12 @@ exports[`Drawer > renders without handle correctly 1`] = `
   <!--v-if-->
   <!--v-if-->
   <div data-slot="container" class="w-full flex flex-col gap-4 p-4 overflow-y-auto">
-    <div data-slot="header" class="">
-      <h2 id="reka-dialog-title-v-0-0-0" data-slot="title" class="font-[family-name:var(--ui-font-family-primary)] text-label font-(--ui-font-weight-medium) mb-0 text-[calc(var(--ui-font-size-2xl)+2px)]/(--ui-font-size-2xl)">Title</h2>
-      <p id="reka-dialog-description-v-0-0-1" data-slot="description" class="mt-1 text-description text-(length:--ui-font-size-sm)">Description</p>
+    <div data-slot="header" class="flex items-center gap-1.5 min-h-8">
+      <div data-slot="wrapper" class="min-w-0 flex-1">
+        <h2 id="reka-dialog-title-v-0-0-0" data-slot="title" class="font-[family-name:var(--ui-font-family-primary)] text-label font-(--ui-font-weight-medium) mb-0 text-[calc(var(--ui-font-size-2xl)+2px)]/(--ui-font-size-2xl)">Title</h2>
+        <p id="reka-dialog-description-v-0-0-1" data-slot="description" class="mt-1 text-description text-(length:--ui-font-size-sm)">Description</p>
+      </div>
+      <!--v-if-->
     </div>
     <!--v-if-->
     <!--v-if-->
@@ -475,9 +640,12 @@ exports[`Drawer > renders without overlay correctly 1`] = `
   <div data-vaul-drawer-visible="true" data-vaul-handle="" aria-hidden="true" data-slot="handle" class="shrink-0 !bg-(--ui-color-divider-default) transition-opacity mt-4 !w-12 !h-1.5 mx-auto"><span data-vaul-handle-hitarea="" aria-hidden="true"></span></div>
   <!--v-if-->
   <div data-slot="container" class="w-full flex flex-col gap-4 p-4 overflow-y-auto">
-    <div data-slot="header" class="">
-      <h2 id="reka-dialog-title-v-0-0-0" data-slot="title" class="font-[family-name:var(--ui-font-family-primary)] text-label font-(--ui-font-weight-medium) mb-0 text-[calc(var(--ui-font-size-2xl)+2px)]/(--ui-font-size-2xl)">Title</h2>
-      <p id="reka-dialog-description-v-0-0-1" data-slot="description" class="mt-1 text-description text-(length:--ui-font-size-sm)">Description</p>
+    <div data-slot="header" class="flex items-center gap-1.5 min-h-8">
+      <div data-slot="wrapper" class="min-w-0 flex-1">
+        <h2 id="reka-dialog-title-v-0-0-0" data-slot="title" class="font-[family-name:var(--ui-font-family-primary)] text-label font-(--ui-font-weight-medium) mb-0 text-[calc(var(--ui-font-size-2xl)+2px)]/(--ui-font-size-2xl)">Title</h2>
+        <p id="reka-dialog-description-v-0-0-1" data-slot="description" class="mt-1 text-description text-(length:--ui-font-size-sm)">Description</p>
+      </div>
+      <!--v-if-->
     </div>
     <!--v-if-->
     <!--v-if-->


### PR DESCRIPTION
## Upstream
[`53e88a4`](https://github.com/nuxt/ui/commit/53e88a468824c0a9b5f9d2bd08a4113b6922afe7) — `feat(Drawer): add close and closeIcon props (#6669)`

Adds a built-in close button to `Drawer`, mirroring `Modal`.

## Change — adapted from b24ui's own Modal
b24ui already ships this pattern on `Modal`, so the port mirrors b24ui's Modal rather than upstream's icon/color choices:
- **`Drawer.vue`**: `close` (`boolean | Omit<ButtonProps, LinkPropsKeys>`) and `closeIcon` (`IconComponent` — b24ui has no `Icon.vue`, so not upstream's `IconProps['name']`) props; `actions`/`close` slots; header restructured into `wrapper` (title + description) and `actions` (`ms-auto`, `DrawerClose` → `B24Button` `size="md" color="air-tertiary-no-accent"` `:aria-label="t('drawer.close')"`). b24ui's separate `VisuallyHidden` a11y title/description block is untouched, so wrapping the display title/description is a11y-safe.
- **`theme/drawer.ts`**: header flex classes + new `wrapper`/`actions`/`close` slots.
- **i18n**: `drawer: { close }` added to `types/locale.ts` and **all 20** locales, each set to that locale's existing `modal.close` value (`Close`/`Schließen`/`閉じる`/`Закрыть`…) — no invented translations, curated set preserved.

## Tests
New `renderEach` cases `with close` / `with closeIcon` (Cross30Icon) / `with actions slot` / `with close slot` (mirror Modal.spec). Snapshots: **8 written** + **30 updated** (existing title/description cases now nest under `data-slot="wrapper"`). Suite **5155** passed (+8).

## Verify (CI=true)
`dev:prepare` · `lint` · `typecheck` (all 20 locales satisfy `drawer.close`) · `test` · `build` — all green.

## Ledger
- `.sync/log/53e88a4….md` — port rationale
- `.sync/nuxt-ui.json` — add `53e88a4` as `port`, advance cursor; reconcile prior `efd44e2` → PR #240 / `eba22f76`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JS8ypVfQSFzYVZzkTHhURb)_