### PR TITLE
fix(ChatMessages): re-evaluate streaming indicator on each render

### DIFF
--- a/.sync/log/5c986dd4051a3b409945a25015888dd3b8d70642.md
+++ b/.sync/log/5c986dd4051a3b409945a25015888dd3b8d70642.md
@@ -1,0 +1,34 @@
+# Port: fix(ChatMessages): re-evaluate streaming indicator on each render (#6673)
+
+**Upstream:** `5c986dd4051a3b409945a25015888dd3b8d70642` (nuxt/ui)
+**Decision:** port
+
+## Upstream change
+`ChatMessages.vue`: convert `showIndicator` from a `computed` to a plain
+function called as `showIndicator()` in the template. `@ai-sdk/vue` stores
+messages in a `shallowRef` grown by in-place mutation + `triggerRef`, so neither
+the array nor the message objects change identity — a `computed` caches its
+result on the first `streaming` render (empty assistant message) and never
+recomputes, leaving the typing indicator stuck. A per-render function ties the
+indicator to the same re-render that displays the streamed content.
+
+## b24ui port — direct 1:1
+b24ui's `ChatMessages.vue` matched upstream exactly (same `showIndicator`
+computed, same `v-if="showIndicator"` on the indicator `B24ChatMessage`).
+Applied verbatim: computed → function (with upstream's explanatory comment) +
+`v-if="showIndicator()"`. `computed` stays imported (still used elsewhere in the
+file). **Not** entangled with the deferred AI-SDK-v7 migration (#dfbbfeb) — this
+is a Vue-reactivity/render fix that holds under the existing `@ai-sdk/vue`
+shallowRef+triggerRef model regardless of `ai` v6/v7.
+
+## Tests
+Ported the upstream spec case verbatim (`hides the streaming indicator once the
+assistant message produces parts`) — reproduces the shallowRef+triggerRef model
+via a `Parent` wrapper that re-renders on a `spacingOffset` tick (b24ui's
+`ChatMessages` has that prop), asserting `[data-slot="indicator"]` appears then
+disappears. Added the `defineComponent, h, nextTick, ref, shallowRef,
+triggerRef` vue import. Behavioural fix, no snapshot churn.
+
+## Verify (CI=true)
+`dev:prepare` · `lint` · `typecheck` · `test` (5277 passed, +2) · `build` —
+all green.

--- a/.sync/nuxt-ui.json
+++ b/.sync/nuxt-ui.json
@@ -2,7 +2,7 @@
   "upstream": "nuxt/ui",
   "branch": "v4",
   "sync_enabled": false,
-  "cursor": "53e88a468824c0a9b5f9d2bd08a4113b6922afe7",
+  "cursor": "5c986dd4051a3b409945a25015888dd3b8d70642",
   "_cursor_note": "cursor = last upstream commit ported into b24ui (oldest-first, manual cadence). sync_enabled stays false until Phase 2 (porter workflow #67 + CLAUDE_CODE_OAUTH_TOKEN) is wired and trusted. `processed` is maintained per port from now on (backfilled #68-#72 on 2026-06-09).",
   "stats": {
     "queue_depth": 0,
@@ -863,10 +863,16 @@
       "summary": "chore(deps): update all non-major dependencies (#6671) — §2 per-dep mirror (nuxt<->demo parity): tailwindcss ^4.3.1->^4.3.2 (root/docs/demo/nuxt/repl/vue), @tailwindcss/postcss+vite ^4.3.1->^4.3.2 (root), @tanstack/vue-virtual 3.13.30->3.13.31 (root), unplugin 3.2.0->3.3.0 (root + pnpm-workspace catalog), vue-component-type-helpers 3.3.5->3.3.6 (root), vue-tsc 3.3.5->3.3.6 (root/demo/nuxt/vue), valibot 1.4.1->1.4.2 (docs), vue-component-meta 3.3.5->3.3.6 (docs). Left untouched: root tailwindcss ^4.0.0 + valibot ^1.0.0 peers. Skipped: @iconify-json/* (no @nuxt/icon in b24ui), @regle/core+rules (b24ui pins ^1.28.0 != upstream ^1.28.1), prettier (b24ui ^3.8.4 != ^3.9.1). Lockfile regen corepack pnpm 11.9.0, lockfileVersion 9.0, +419/-155 (no major churn). No snapshot churn"
     },
     "53e88a468824c0a9b5f9d2bd08a4113b6922afe7": {
+      "pr": 243,
+      "b24ui_sha": "7cb7f642",
+      "decision": "port",
+      "summary": "feat(Drawer): add close and closeIcon props (#6669) — Drawer.vue: +close (boolean|Omit<ButtonProps,LinkPropsKeys>) + closeIcon (IconComponent, b24ui has no Icon.vue so not IconProps['name']) props, +actions/close slots, header restructured into wrapper(title+desc)+actions(ms-auto, DrawerClose->B24Button size=md color=air-tertiary-no-accent aria-label=t('drawer.close')); imports DrawerClose/useLocale/icons(dictionary)/B24Button. Mirrors b24ui's OWN Modal pattern (not upstream neutral/ghost). theme/drawer.ts: header flex + new wrapper/actions/close slots. i18n: +drawer.close to types/locale.ts + all 20 locales (each = that locale's modal.close value; no invented translations, curated set preserved). +renderEach close/closeIcon/actions-slot/close-slot cases (mirror Modal.spec). Snapshots 8 written + 30 updated (title/desc now under data-slot=wrapper). b24ui VisuallyHidden a11y title untouched so wrapper is a11y-safe. Tests 5155 (+8)"
+    },
+    "5c986dd4051a3b409945a25015888dd3b8d70642": {
       "pr": null,
       "b24ui_sha": "pending-merge",
       "decision": "port",
-      "summary": "feat(Drawer): add close and closeIcon props (#6669) — Drawer.vue: +close (boolean|Omit<ButtonProps,LinkPropsKeys>) + closeIcon (IconComponent, b24ui has no Icon.vue so not IconProps['name']) props, +actions/close slots, header restructured into wrapper(title+desc)+actions(ms-auto, DrawerClose->B24Button size=md color=air-tertiary-no-accent aria-label=t('drawer.close')); imports DrawerClose/useLocale/icons(dictionary)/B24Button. Mirrors b24ui's OWN Modal pattern (not upstream neutral/ghost). theme/drawer.ts: header flex + new wrapper/actions/close slots. i18n: +drawer.close to types/locale.ts + all 20 locales (each = that locale's modal.close value; no invented translations, curated set preserved). +renderEach close/closeIcon/actions-slot/close-slot cases (mirror Modal.spec). Snapshots 8 written + 30 updated (title/desc now under data-slot=wrapper). b24ui VisuallyHidden a11y title untouched so wrapper is a11y-safe. Tests 5155 (+8)"
+      "summary": "fix(ChatMessages): re-evaluate streaming indicator on each render (#6673) — ChatMessages.vue: showIndicator computed -> plain function + v-if=showIndicator() (computed cached first streaming render with empty assistant msg and never recomputed under @ai-sdk/vue shallowRef+triggerRef in-place mutation; per-render fn fixes stuck indicator). Direct 1:1 (b24ui matched). computed import still used elsewhere. NOT entangled with deferred ai v7 (Vue-reactivity fix, holds for v6/v7). +spec case 'hides streaming indicator once assistant produces parts' verbatim (Parent wrapper re-renders via spacingOffset tick; asserts [data-slot=indicator] appears then gone). No snapshot churn. Tests 5277 (+2)"
     }
   }
 }

--- a/src/runtime/components/ChatMessages.vue
+++ b/src/runtime/components/ChatMessages.vue
@@ -109,13 +109,20 @@ const props = useComponentProps<ChatMessagesProps<T>>('chatMessages', _props)
 
 const getProxySlots = () => omit(slots, ['default', 'indicator', 'viewport'])
 
-const showIndicator = computed(() => {
+// This is intentionally a function (not a `computed`) so it is re-evaluated on
+// every render. `@ai-sdk/vue` stores messages in a `shallowRef` and grows them
+// via in-place mutation + `triggerRef`, so the array reference and the message
+// objects never change identity. A `computed` would cache its result on the
+// first `streaming` render (when the assistant message is still empty) and never
+// recompute as parts stream in, leaving the indicator stuck. Evaluating during
+// render ties the indicator to the same re-render that displays the streamed content.
+function showIndicator() {
   if (props.status === 'submitted') return true
   if (props.status !== 'streaming') return false
 
   const lastMessage = props.messages?.[props.messages.length - 1]
   return lastMessage?.role === 'assistant' && !lastMessage.parts?.length
-})
+}
 
 const appConfig = useAppConfig() as ChatMessages['AppConfig']
 
@@ -342,7 +349,7 @@ defineExpose({
     </slot>
 
     <B24ChatMessage
-      v-if="showIndicator"
+      v-if="showIndicator()"
       id="indicator"
       role="assistant"
       v-bind="{ ...assistantProps, actions: undefined, parts: [] }"

--- a/test/components/ChatMessages.spec.ts
+++ b/test/components/ChatMessages.spec.ts
@@ -1,5 +1,6 @@
 import type { ChatMessagesSlots } from '../../src/runtime/components/ChatMessages.vue'
 import { describe, it, expect } from 'vitest'
+import { defineComponent, h, nextTick, ref, shallowRef, triggerRef } from 'vue'
 import { axe } from 'vitest-axe'
 import { mountSuspended } from '@nuxt/test-utils/runtime'
 import { renderEach } from '../component-render'
@@ -77,6 +78,43 @@ describe('ChatMessages', () => {
       parts: messages[1]!.parts,
       message: messages[1]
     })
+  })
+
+  it('hides the streaming indicator once the assistant message produces parts', async () => {
+    // Reproduces the `@ai-sdk/vue` reactivity model: messages live in a `shallowRef`
+    // and grow via in-place mutation + `triggerRef`, so neither the array nor the
+    // message objects ever change identity. When the server assigns the assistant
+    // message id, an empty assistant message is flushed before any content, so the
+    // indicator must appear then disappear as soon as parts stream in.
+    const messages = shallowRef<any[]>([
+      { id: 'u1', role: 'user', parts: [{ type: 'text', text: 'hi' }] },
+      { id: 'a1', role: 'assistant', parts: [] }
+    ])
+    // A separate reactive value bound to a prop, used only to force ChatMessages to
+    // re-render on each tick, mimicking how streamed content forces re-renders in a
+    // real app (dynamic slots / non-static prop references).
+    const tick = ref(0)
+
+    const Parent = defineComponent({
+      setup() {
+        return () => h(ChatMessages, { messages: messages.value, status: 'streaming', spacingOffset: tick.value })
+      }
+    })
+
+    const wrapper = await mountSuspended(Parent)
+
+    // Empty assistant message -> indicator visible.
+    expect(wrapper.find('[data-slot="indicator"]').exists()).toBe(true)
+
+    // Stream the first part in place + triggerRef, and force a re-render.
+    messages.value[1]!.parts.push({ type: 'text', text: 'Hello' })
+    triggerRef(messages)
+    tick.value++
+    await nextTick()
+
+    // A cached `computed` would stay stuck on its first `streaming` result here;
+    // the indicator must now be gone.
+    expect(wrapper.find('[data-slot="indicator"]').exists()).toBe(false)
   })
 
   it('forwards `message` to the actions slot', async () => {


### PR DESCRIPTION
## Upstream
[`5c986dd`](https://github.com/nuxt/ui/commit/5c986dd4051a3b409945a25015888dd3b8d70642) — `fix(ChatMessages): re-evaluate streaming indicator on each render (#6673)`

## Change — direct 1:1
Convert `showIndicator` from a `computed` to a plain function called as `showIndicator()`. `@ai-sdk/vue` stores messages in a `shallowRef` grown by in-place mutation + `triggerRef`, so neither the array nor the message objects change identity — a `computed` caches its result on the first `streaming` render (empty assistant message) and never recomputes, leaving the typing indicator stuck. A per-render function ties the indicator to the render that shows the streamed content.

b24ui's `ChatMessages.vue` matched upstream exactly; applied verbatim (`computed` stays imported, still used elsewhere).

**Not** entangled with the deferred AI-SDK-v7 migration — this is a Vue-reactivity/render fix that holds under the existing `@ai-sdk/vue` `shallowRef`+`triggerRef` model regardless of `ai` v6/v7.

## Tests
Ported the upstream spec case verbatim (`hides the streaming indicator once the assistant message produces parts`) — reproduces the `shallowRef`+`triggerRef` model via a `Parent` wrapper re-rendering on a `spacingOffset` tick (b24ui's `ChatMessages` has that prop), asserting `[data-slot="indicator"]` appears then disappears. Behavioural fix, no snapshot churn. Suite **5277** passed (+2).

## Verify (CI=true)
`dev:prepare` · `lint` · `typecheck` · `test` · `build` — all green.

## Ledger
- `.sync/log/5c986dd….md` — port rationale
- `.sync/nuxt-ui.json` — add `5c986dd` as `port`, advance cursor; reconcile prior `53e88a4` → PR #243 / `7cb7f642`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JS8ypVfQSFzYVZzkTHhURb)_