### PR TITLE
chore(deps): update all non-major dependencies

### DIFF
--- a/.sync/log/1c1d9be442de642ff6edb69900ea0f7bae4408ac.md
+++ b/.sync/log/1c1d9be442de642ff6edb69900ea0f7bae4408ac.md
@@ -1,0 +1,50 @@
+# Port: chore(deps): update all non-major dependencies (#6679)
+
+**Upstream:** `1c1d9be442de642ff6edb69900ea0f7bae4408ac` (nuxt/ui)
+**Decision:** port
+
+## Upstream change
+Renovate non-major batch (mostly AI-SDK-v7 line + iconify): `ai` 7.0.9→7.0.15,
+`@ai-sdk/{anthropic,gateway,mcp,vue}`, `@iconify-json/*`, `@nuxt/icon`
+2.2.5→2.3.1, `@comark/vue` 0.4→0.5, `@nuxt/content` 3.14→3.15, `@nuxtjs/mdc`
+0.22.0→0.22.1, `@regle/*`, `nuxt-og-image`, `shiki` 4.3.0→4.3.1, pnpm
+11.9→11.10, + a new `@shikijs/types` devDep and a `transformerColorHighlight()
+as ShikiTransformer` cast in `docs/app/mdc.config.ts`.
+
+## b24ui port — §2 per-dep reconciled
+Bumped only deps b24ui pins at the same range (nuxt↔demo parity):
+
+| dep | from → to | b24ui manifests |
+|---|---|---|
+| pnpm (`packageManager`) | 11.9.0 → 11.10.0 | root |
+| `@comark/vue` | ^0.4.0 → ^0.5.0 | docs, demo, nuxt |
+| `@nuxt/content` | ^3.14.0 → ^3.15.0 | docs, demo, nuxt |
+| `@nuxtjs/mdc` | ^0.22.0 → ^0.22.1 | docs |
+
+**Skipped (b24ui on the deferred v6 AI line / no iconify / different pins):**
+`ai` + `@ai-sdk/*` (b24ui pins v6 `^6.0.214`/`^3.0.214` — see #dfbbfeb defer),
+`@iconify-json/*` + `@nuxt/icon` (b24ui has none), `shiki` (b24ui `^4.2.0` ≠
+`^4.3.0`), `nuxt-og-image` (`^6.6.0` ≠ `^6.7.0`), `@regle/*` (`^1.28.0` ≠
+`^1.28.2`). Root `@nuxt/content ^3.0.0` peer left untouched.
+
+## The `mdc.config.ts` cast — needed here too
+Even though b24ui does **not** bump its `shiki` pin (`^4.2.0`), lockfile regen
+resolved `shiki` to `4.3.1` (within `^4.2.0`), which pulls `@shikijs/types@4.3.1`
+into `@nuxtjs/mdc`'s config type while `shiki-transformer-color-highlight` still
+returns a `@shikijs/types@3.23.0` `ShikiTransformer` → `vue-tsc` TS2322. So the
+upstream fix applies: added `import type { ShikiTransformer } from '@shikijs/types'`
++ `transformerColorHighlight() as ShikiTransformer` in `docs/app/mdc.config.ts`,
+and the `@shikijs/types: ^4.3.1` devDep to `docs/package.json` so the bare
+`@shikijs/types` import resolves to 4.3.1.
+
+**Lockfile:** regenerated under the CI gate (corepack pnpm 11.10.0),
+`lockfileVersion 9.0`.
+
+## Tests
+Dep bumps + a type cast → no runtime/markup change, no snapshot churn. Full
+suite unchanged (5277 passed / 6 skipped).
+
+## Verify (CI=true, pnpm 11.10.0)
+Real install (`--frozen-lockfile`) → `dev:prepare` · `lint` · `typecheck`
+(mdc.config cast resolves the shiki 4.3.1 type mismatch) · `test` · `build` —
+all green.

--- a/.sync/nuxt-ui.json
+++ b/.sync/nuxt-ui.json
@@ -2,7 +2,7 @@
   "upstream": "nuxt/ui",
   "branch": "v4",
   "sync_enabled": false,
-  "cursor": "5c986dd4051a3b409945a25015888dd3b8d70642",
+  "cursor": "1c1d9be442de642ff6edb69900ea0f7bae4408ac",
   "_cursor_note": "cursor = last upstream commit ported into b24ui (oldest-first, manual cadence). sync_enabled stays false until Phase 2 (porter workflow #67 + CLAUDE_CODE_OAUTH_TOKEN) is wired and trusted. `processed` is maintained per port from now on (backfilled #68-#72 on 2026-06-09).",
   "stats": {
     "queue_depth": 0,
@@ -869,10 +869,16 @@
       "summary": "feat(Drawer): add close and closeIcon props (#6669) — Drawer.vue: +close (boolean|Omit<ButtonProps,LinkPropsKeys>) + closeIcon (IconComponent, b24ui has no Icon.vue so not IconProps['name']) props, +actions/close slots, header restructured into wrapper(title+desc)+actions(ms-auto, DrawerClose->B24Button size=md color=air-tertiary-no-accent aria-label=t('drawer.close')); imports DrawerClose/useLocale/icons(dictionary)/B24Button. Mirrors b24ui's OWN Modal pattern (not upstream neutral/ghost). theme/drawer.ts: header flex + new wrapper/actions/close slots. i18n: +drawer.close to types/locale.ts + all 20 locales (each = that locale's modal.close value; no invented translations, curated set preserved). +renderEach close/closeIcon/actions-slot/close-slot cases (mirror Modal.spec). Snapshots 8 written + 30 updated (title/desc now under data-slot=wrapper). b24ui VisuallyHidden a11y title untouched so wrapper is a11y-safe. Tests 5155 (+8)"
     },
     "5c986dd4051a3b409945a25015888dd3b8d70642": {
+      "pr": 244,
+      "b24ui_sha": "fffec684",
+      "decision": "port",
+      "summary": "fix(ChatMessages): re-evaluate streaming indicator on each render (#6673) — ChatMessages.vue: showIndicator computed -> plain function + v-if=showIndicator() (computed cached first streaming render with empty assistant msg and never recomputed under @ai-sdk/vue shallowRef+triggerRef in-place mutation; per-render fn fixes stuck indicator). Direct 1:1 (b24ui matched). computed import still used elsewhere. NOT entangled with deferred ai v7 (Vue-reactivity fix, holds for v6/v7). +spec case 'hides streaming indicator once assistant produces parts' verbatim (Parent wrapper re-renders via spacingOffset tick; asserts [data-slot=indicator] appears then gone). No snapshot churn. Tests 5277 (+2)"
+    },
+    "1c1d9be442de642ff6edb69900ea0f7bae4408ac": {
       "pr": null,
       "b24ui_sha": "pending-merge",
       "decision": "port",
-      "summary": "fix(ChatMessages): re-evaluate streaming indicator on each render (#6673) — ChatMessages.vue: showIndicator computed -> plain function + v-if=showIndicator() (computed cached first streaming render with empty assistant msg and never recomputed under @ai-sdk/vue shallowRef+triggerRef in-place mutation; per-render fn fixes stuck indicator). Direct 1:1 (b24ui matched). computed import still used elsewhere. NOT entangled with deferred ai v7 (Vue-reactivity fix, holds for v6/v7). +spec case 'hides streaming indicator once assistant produces parts' verbatim (Parent wrapper re-renders via spacingOffset tick; asserts [data-slot=indicator] appears then gone). No snapshot churn. Tests 5277 (+2)"
+      "summary": "chore(deps): update all non-major dependencies (#6679) — §2 mirror (nuxt<->demo parity): pnpm 11.9.0->11.10.0, @comark/vue ^0.4.0->^0.5.0 (docs/demo/nuxt), @nuxt/content ^3.14.0->^3.15.0 (docs/demo/nuxt; root ^3.0.0 peer untouched), @nuxtjs/mdc ^0.22.0->^0.22.1 (docs). Skipped: ai+@ai-sdk/* (b24ui on deferred v6 line), @iconify-json/*+@nuxt/icon (none in b24ui), shiki (^4.2.0!=^4.3.0), nuxt-og-image (^6.6.0!=^6.7.0), @regle/* (^1.28.0!=^1.28.2). mdc.config.ts: added import type ShikiTransformer from @shikijs/types + transformerColorHighlight() as ShikiTransformer + @shikijs/types ^4.3.1 devDep (docs) — needed because lockfile resolved shiki to 4.3.1 under ^4.2.0 -> @shikijs/types 4.3.1 vs 3.23.0 TS2322. Lockfile regen corepack pnpm 11.10.0, lockfileVersion 9.0. No snapshot churn"
     }
   }
 }

--- a/docs/app/mdc.config.ts
+++ b/docs/app/mdc.config.ts
@@ -1,10 +1,11 @@
 import { defineConfig } from '@nuxtjs/mdc/config'
+import type { ShikiTransformer } from '@shikijs/types'
 import { transformerColorHighlight } from 'shiki-transformer-color-highlight'
 
 export default defineConfig({
   shiki: {
     transformers: [
-      transformerColorHighlight()
+      transformerColorHighlight() as ShikiTransformer
     ]
   }
 })

--- a/docs/package.json
+++ b/docs/package.json
@@ -14,12 +14,12 @@
     "@ai-sdk/deepseek": "^2.0.38",
     "@ai-sdk/mcp": "^1.0.52",
     "@ai-sdk/vue": "^3.0.214",
-    "@comark/vue": "^0.4.0",
-    "@nuxt/content": "^3.14.0",
+    "@comark/vue": "^0.5.0",
+    "@nuxt/content": "^3.15.0",
     "@nuxt/image": "^2.0.0",
     "@bitrix24/b24ui-nuxt": "workspace:*",
     "@nuxtjs/mcp-toolkit": "^0.17.2",
-    "@nuxtjs/mdc": "^0.22.0",
+    "@nuxtjs/mdc": "^0.22.1",
     "@octokit/rest": "^22.0.1",
     "@regle/core": "^1.28.0",
     "@regle/rules": "^1.28.0",
@@ -60,6 +60,7 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
+    "@shikijs/types": "^4.3.1",
     "@types/sortablejs": "^1.15.9"
   }
 }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@bitrix24/b24ui-nuxt",
   "description": "Bitrix24 UI-Kit for developing web applications REST API for NUXT & VUE",
   "version": "2.9.0",
-  "packageManager": "pnpm@11.9.0",
+  "packageManager": "pnpm@11.10.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/bitrix24/b24ui.git"

--- a/playgrounds/demo/package.json
+++ b/playgrounds/demo/package.json
@@ -13,9 +13,9 @@
   "dependencies": {
     "@ai-sdk/deepseek": "^2.0.38",
     "@ai-sdk/vue": "^3.0.214",
-    "@comark/vue": "^0.4.0",
+    "@comark/vue": "^0.5.0",
     "@internationalized/date": "^3.12.2",
-    "@nuxt/content": "^3.14.0",
+    "@nuxt/content": "^3.15.0",
     "@bitrix24/b24ui-nuxt": "workspace:*",
     "@bitrix24/b24icons-nuxt": "^2.0.7",
     "@bitrix24/b24icons-vue": "^2.0.7",

--- a/playgrounds/nuxt/package.json
+++ b/playgrounds/nuxt/package.json
@@ -13,9 +13,9 @@
   "dependencies": {
     "@ai-sdk/deepseek": "^2.0.38",
     "@ai-sdk/vue": "^3.0.214",
-    "@comark/vue": "^0.4.0",
+    "@comark/vue": "^0.5.0",
     "@internationalized/date": "^3.12.2",
-    "@nuxt/content": "^3.14.0",
+    "@nuxt/content": "^3.15.0",
     "@bitrix24/b24ui-nuxt": "workspace:*",
     "@bitrix24/b24icons-nuxt": "^2.0.7",
     "@bitrix24/b24icons-vue": "^2.0.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -327,11 +327,11 @@ importers:
         specifier: workspace:*
         version: link:..
       '@comark/vue':
-        specifier: ^0.4.0
-        version: 0.4.0(shiki@4.2.0)(vue@3.5.39(typescript@6.0.3))
+        specifier: ^0.5.0
+        version: 0.5.0(shiki@4.2.0)(vue@3.5.39(typescript@6.0.3))
       '@nuxt/content':
-        specifier: ^3.14.0
-        version: 3.14.0(better-sqlite3@12.11.1)(esbuild@0.27.7)(magicast@0.5.3)(rollup@4.60.2)(valibot@1.4.2(typescript@6.0.3))(vite@7.3.6(@types/node@25.6.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.1)(yaml@2.9.0))
+        specifier: ^3.15.0
+        version: 3.15.0(better-sqlite3@12.11.1)(esbuild@0.27.7)(magicast@0.5.3)(rollup@4.60.2)(valibot@1.4.2(typescript@6.0.3))(vite@7.3.6(@types/node@25.6.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.1)(yaml@2.9.0))
       '@nuxt/image':
         specifier: ^2.0.0
         version: 2.0.0(db0@0.3.4(better-sqlite3@12.11.1))(esbuild@0.27.7)(ioredis@5.10.1)(magicast@0.5.3)(rollup@4.60.2)(srvx@0.11.15)(vite@7.3.6(@types/node@25.6.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.1)(yaml@2.9.0))
@@ -339,8 +339,8 @@ importers:
         specifier: ^0.17.2
         version: 0.17.2(@vue/compiler-sfc@3.5.38)(esbuild@0.27.7)(h3@1.15.11)(magicast@0.5.3)(rollup@4.60.2)(vite@7.3.6(@types/node@25.6.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.1)(yaml@2.9.0))(vue@3.5.39(typescript@6.0.3))(zod@4.4.3)
       '@nuxtjs/mdc':
-        specifier: ^0.22.0
-        version: 0.22.0(esbuild@0.27.7)(magicast@0.5.3)(rollup@4.60.2)(vite@7.3.6(@types/node@25.6.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.1)(yaml@2.9.0))
+        specifier: ^0.22.1
+        version: 0.22.1(esbuild@0.27.7)(magicast@0.5.3)(rollup@4.60.2)(vite@7.3.6(@types/node@25.6.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.1)(yaml@2.9.0))
       '@octokit/rest':
         specifier: ^22.0.1
         version: 22.0.1
@@ -415,7 +415,7 @@ importers:
         version: 6.5.3(49b0cbb0a87a31078752d4e19c9a745d)
       nuxt-schema-org:
         specifier: ^6.2.1
-        version: 6.2.1(64d64582d0445e2f566e82bda5721a0d)
+        version: 6.2.1(4fb188448e89020cd2bf36684823fce4)
       prettier:
         specifier: ^3.8.4
         version: 3.8.4
@@ -456,6 +456,9 @@ importers:
         specifier: ^4.4.3
         version: 4.4.3
     devDependencies:
+      '@shikijs/types':
+        specifier: ^4.3.1
+        version: 4.3.1
       '@types/sortablejs':
         specifier: ^1.15.9
         version: 1.15.9
@@ -478,14 +481,14 @@ importers:
         specifier: workspace:*
         version: link:../..
       '@comark/vue':
-        specifier: ^0.4.0
-        version: 0.4.0(shiki@4.2.0)(vue@3.5.39(typescript@6.0.3))
+        specifier: ^0.5.0
+        version: 0.5.0(shiki@4.3.1)(vue@3.5.39(typescript@6.0.3))
       '@internationalized/date':
         specifier: ^3.12.2
         version: 3.12.2
       '@nuxt/content':
-        specifier: ^3.14.0
-        version: 3.14.0(better-sqlite3@12.11.1)(esbuild@0.27.7)(magicast@0.5.3)(rollup@4.60.2)(valibot@1.4.2(typescript@6.0.3))(vite@7.3.6(@types/node@25.6.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.1)(yaml@2.9.0))
+        specifier: ^3.15.0
+        version: 3.15.0(better-sqlite3@12.11.1)(esbuild@0.27.7)(magicast@0.5.3)(rollup@4.60.2)(valibot@1.4.2(typescript@6.0.3))(vite@7.3.6(@types/node@25.6.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.1)(yaml@2.9.0))
       '@tiptap/extension-emoji':
         specifier: ^3.26.1
         version: 3.26.1(@tiptap/core@3.26.1(@tiptap/pm@3.26.1))(@tiptap/pm@3.26.1)(@tiptap/suggestion@3.26.1(@tiptap/core@3.26.1(@tiptap/pm@3.26.1))(@tiptap/pm@3.26.1))(emojibase@17.0.0)
@@ -533,14 +536,14 @@ importers:
         specifier: workspace:*
         version: link:../..
       '@comark/vue':
-        specifier: ^0.4.0
-        version: 0.4.0(shiki@4.2.0)(vue@3.5.39(typescript@6.0.3))
+        specifier: ^0.5.0
+        version: 0.5.0(shiki@4.3.1)(vue@3.5.39(typescript@6.0.3))
       '@internationalized/date':
         specifier: ^3.12.2
         version: 3.12.2
       '@nuxt/content':
-        specifier: ^3.14.0
-        version: 3.14.0(better-sqlite3@12.11.1)(esbuild@0.27.7)(magicast@0.5.3)(rollup@4.60.2)(valibot@1.4.2(typescript@6.0.3))(vite@7.3.6(@types/node@25.6.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.1)(yaml@2.9.0))
+        specifier: ^3.15.0
+        version: 3.15.0(better-sqlite3@12.11.1)(esbuild@0.27.7)(magicast@0.5.3)(rollup@4.60.2)(valibot@1.4.2(typescript@6.0.3))(vite@7.3.6(@types/node@25.6.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.1)(yaml@2.9.0))
       '@tiptap/extension-emoji':
         specifier: ^3.26.1
         version: 3.26.1(@tiptap/core@3.26.1(@tiptap/pm@3.26.1))(@tiptap/pm@3.26.1)(@tiptap/suggestion@3.26.1(@tiptap/core@3.26.1(@tiptap/pm@3.26.1))(@tiptap/pm@3.26.1))(emojibase@17.0.0)
@@ -889,8 +892,8 @@ packages:
   '@colordx/core@5.4.3':
     resolution: {integrity: sha512-kIxYSfA5T8HXjav55UaaH/o/cKivF6jCCGIb8eqtcsfI46wsvlSiT8jMDyrl779qLec3c2c2oHBZo4oAhvbjrQ==}
 
-  '@comark/vue@0.4.0':
-    resolution: {integrity: sha512-1o4BBBzVIcxCsPOfWUzcYqdnSSI+bCyldxzlrbATc5U+s40Hm+ls7UppYAHPyOqUQPpMZy2vbvD4ESe+PD5lgg==}
+  '@comark/vue@0.5.0':
+    resolution: {integrity: sha512-+ln42jMTAIGK1AhksoKG6ZFejx2Pt62JJ1Tdf+9xxmtLMGT7ouAAAl72sfbKEZ0CIn8DjKVkX3OBt0Ko49apKg==}
     peerDependencies:
       beautiful-mermaid: ^1.1.3
       katex: ^0.16.45
@@ -1669,6 +1672,30 @@ packages:
       valibot:
         optional: true
 
+  '@nuxt/content@3.15.0':
+    resolution: {integrity: sha512-PeInEK8BRs4G3W+H6yhWjtXQ74eIi5Wl6Isii/mdUyV2otLKGuKtvS5/vjSEPJYlwrUDWDEW99TdBEY1MSaMPQ==}
+    engines: {node: '>= 20.19.0'}
+    peerDependencies:
+      '@electric-sql/pglite': '*'
+      '@libsql/client': '*'
+      '@valibot/to-json-schema': ^1.5.0
+      better-sqlite3: ^12.5.0
+      sqlite3: '*'
+      valibot: ^1.2.0
+    peerDependenciesMeta:
+      '@electric-sql/pglite':
+        optional: true
+      '@libsql/client':
+        optional: true
+      '@valibot/to-json-schema':
+        optional: true
+      better-sqlite3:
+        optional: true
+      sqlite3:
+        optional: true
+      valibot:
+        optional: true
+
   '@nuxt/devalue@2.0.2':
     resolution: {integrity: sha512-GBzP8zOc7CGWyFQS6dv1lQz8VVpz5C2yRszbXufwG/9zhStTIH50EtD87NmWbTMwXDvZLNg8GIpb1UFdH93JCA==}
 
@@ -1886,6 +1913,9 @@ packages:
 
   '@nuxtjs/mdc@0.22.0':
     resolution: {integrity: sha512-4jVc967snO5oOZtVhDnLi2Nu8kSsvGU66bsufKGU/Ixsj5lzA3HdaLMJEkFNs8AXtVXJUbkZ2PhvTttFHo8Kgw==}
+
+  '@nuxtjs/mdc@0.22.1':
+    resolution: {integrity: sha512-+tkGhBNxapWZiadZaf9yTxMtnSshjPY2VVnZsy/YoOu+c1p2S6MQgAHB9QWk+FIPT0epJ/VAtGh6qW1tjyPXOg==}
 
   '@octokit/auth-token@6.0.0':
     resolution: {integrity: sha512-P4YJBPdPSpWTQ1NU4XYdvHvXJJDxM6YwpS0FZHRgP7YFkdVxsWcpWGy/NVqlAA7PcPCnMacXlRm1y2PFZRWL/w==}
@@ -2853,16 +2883,32 @@ packages:
     resolution: {integrity: sha512-Hc87Ab1Ld/vEbZRCbwx344I5v+4RU8CVToUTRkqXL1+TjbuOp9U5Xa0M23V4GEWHxVn+yO5otb+HkQVm3ptWQQ==}
     engines: {node: '>=20'}
 
+  '@shikijs/core@4.3.1':
+    resolution: {integrity: sha512-ANMDxuaPsNMdDC1m4vfvhlDmJweMwkE5XitTwrq2rWHx5jM+dlm4MmHt2PP6t0uejfR77SuhrhJ0zEijIF/uhA==}
+    engines: {node: '>=20'}
+
   '@shikijs/engine-javascript@4.2.0':
     resolution: {integrity: sha512-fjETeq1k5ffyXqRgS6+3hpvqseLalp1kjNfRbXpUgWR8FpZ1CmQfiNHovc5lncYjt/Vg5JK/WJEmLahjwMa0og==}
+    engines: {node: '>=20'}
+
+  '@shikijs/engine-javascript@4.3.1':
+    resolution: {integrity: sha512-JBItcnPuYq7jVJdZo/vMj94r+szT7XEjHFX+mvFDGSEIbVAXAGyHAHzhbWzpGOwYidCZrErJLLgn2PVeiokHnQ==}
     engines: {node: '>=20'}
 
   '@shikijs/engine-oniguruma@4.2.0':
     resolution: {integrity: sha512-hTorK1dffPkpbMUk6Z+828PgRo7d07HbnizoP0hNPFjhxMHctj0Px/qoHeGMYafc6ju+u9iMldN4JbVzNQM++g==}
     engines: {node: '>=20'}
 
+  '@shikijs/engine-oniguruma@4.3.1':
+    resolution: {integrity: sha512-OXyNMzg0pews+msMj4cHeqT4xiYKKvbnn6VbdAXxfoFl3SSx4fJTc8FadECuc5/H9p3BzhNAoAUXKwAu9rWYhg==}
+    engines: {node: '>=20'}
+
   '@shikijs/langs@4.2.0':
     resolution: {integrity: sha512-bwrVRlJ0wUhZxAbVdvBbv2TTC9yLsh4C/IO5Ofz0T8MQntgDvyVnkbjw9vi50r1kx7RCIJdnJnjZAwmAsXFLZQ==}
+    engines: {node: '>=20'}
+
+  '@shikijs/langs@4.3.1':
+    resolution: {integrity: sha512-m0l9nsDqgBHvbZbk7A0/kXz/impK3uB/c6rAn6Gpg/uPtdZRQ+alsN/17MU5thb68XTj/4DxkZAotrM0GGSpDQ==}
     engines: {node: '>=20'}
 
   '@shikijs/primitive@4.0.2':
@@ -2873,12 +2919,24 @@ packages:
     resolution: {integrity: sha512-NOq+DtUkVBJtZMVXL5A0vI0Xk8nvDYaXetFHSJFlOqjDZIVhIPRYFdGkSoElDqNuegikcc3A76SNUa8dTqtAYA==}
     engines: {node: '>=20'}
 
+  '@shikijs/primitive@4.3.1':
+    resolution: {integrity: sha512-CXQRQOYy1leqQ8ceTeJdmXv/bsUY++6QyLpXJ94LZAAYj5X2SKRdc5ipguv4NPyGVKItB2PPwUpRNe0Sjh5S1A==}
+    engines: {node: '>=20'}
+
   '@shikijs/themes@4.2.0':
     resolution: {integrity: sha512-RX8IHYeLv8Cu2W6ruc3RxUqWn0IYCqSrMBzi/uRGAmfyDNOnNO5BF/Px7o97n4XTpmFTo5GbRaazuOWj+2ak2w==}
     engines: {node: '>=20'}
 
+  '@shikijs/themes@4.3.1':
+    resolution: {integrity: sha512-dgpoJ4WqNi2yTmizQHBJ5zcX6j2lE6icN/0yt4l1kkf16jrY/pwPLoTb1ETsWMz0OBLf9ZNvwmxft+cH+N9qSA==}
+    engines: {node: '>=20'}
+
   '@shikijs/transformers@4.0.2':
     resolution: {integrity: sha512-1+L0gf9v+SdDXs08vjaLb3mBFa8U7u37cwcBQIv/HCocLwX69Tt6LpUCjtB+UUTvQxI7BnjZKhN/wMjhHBcJGg==}
+    engines: {node: '>=20'}
+
+  '@shikijs/transformers@4.3.1':
+    resolution: {integrity: sha512-z6ir0bGDgWcF2FduktEfPgIsdOtIlDiLAjFBgBzE42Q9xHbkkIXZtORHzlLVB71iZP9elEcqKg6keajvOUwE2A==}
     engines: {node: '>=20'}
 
   '@shikijs/types@3.23.0':
@@ -2890,6 +2948,10 @@ packages:
 
   '@shikijs/types@4.2.0':
     resolution: {integrity: sha512-VT/MKtlpOhEPZloSH3Pb9WCZEBDoQVMa9jedp5UAwmJOar1DVc9DRODAxmYPW9M93IK4ryuqRejFfmlvlVDemw==}
+    engines: {node: '>=20'}
+
+  '@shikijs/types@4.3.1':
+    resolution: {integrity: sha512-CHFxE0jztBIZRHH6gxXE7DXUCFXjReEGxZ/j0rfSLGKZuwp2xBYycEP14875DSa9KLL/6700oxIq6oO6ef9K2g==}
     engines: {node: '>=20'}
 
   '@shikijs/vscode-textmate@10.0.2':
@@ -4386,8 +4448,8 @@ packages:
   colortranslator@5.0.0:
     resolution: {integrity: sha512-Z3UPUKasUVDFCDYAjP2fmlVRf1jFHJv1izAmPjiOa0OCIw1W7iC8PZ2GsoDa8uZv+mKyWopxxStT9q05+27h7w==}
 
-  comark@0.4.0:
-    resolution: {integrity: sha512-s+wZc9FDgxJDxS3oLhDhthuc8EFggd7oEQaGKEFSw/UbECEwM3qMgW/T3dk6eoNTuy+PNSAyPQtjyKZJfudlbA==}
+  comark@0.5.0:
+    resolution: {integrity: sha512-trD29JFZNVdixntA19BmhE2NuWq+MmXdri0YFN5jUCISbEgLVHqYWBYDVDVgPxnZp2hmaNa1ubHvKee6hkQqMQ==}
     peerDependencies:
       beautiful-mermaid: ^1.1.3
       katex: ^0.16.45
@@ -5748,6 +5810,11 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
+  isomorphic-git@1.38.6:
+    resolution: {integrity: sha512-lCmZ1m2R0LqbZ4QATtLCxhwNBQPNJc74R81dfyF90yLqP8xs2DZLedcnkVuRj6th/L2HYoIvWP5lBpS1ooAagw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
   isomorphic.js@0.2.5:
     resolution: {integrity: sha512-PIeMbHqMt4DnUP3MA/Flc0HElYjMXArsw1qwJZcm9sqR8mq3l8NYizFMty0pWwE/tzIGH3EKK5+jes5mAr85yw==}
 
@@ -6508,6 +6575,11 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
+  nypm@0.6.8:
+    resolution: {integrity: sha512-Q9K4Diu6l5u6xJQogeFSs/zKtyMSgFKFtRQV+tHP4kL7KPm2grpBU0dFIwFaXwNxN0MtfKWc43VpCugAa+LPsw==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
@@ -7108,6 +7180,9 @@ packages:
   property-information@7.1.0:
     resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
 
+  property-information@7.2.0:
+    resolution: {integrity: sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg==}
+
   prosemirror-changeset@2.4.1:
     resolution: {integrity: sha512-96WBLhOaYhJ+kPhLg3uW359Tz6I/MfcrQfL4EGv4SrcqKEMC1gmoGrXHecPE8eOwTVCJ4IwgfzM8fFad25wNfw==}
 
@@ -7311,6 +7386,9 @@ packages:
   remark-mdc@3.11.0:
     resolution: {integrity: sha512-xFrKmGRa+xgsfAZPA2CDaKILSHSOhX2irjJBrrPLxNrxaz2NFI+gXuVjo6Bkbh2vx7fKKTB5S9yyKyIwJh+FsQ==}
 
+  remark-mdc@3.11.1:
+    resolution: {integrity: sha512-bjH7Q1OO1BSXVPmUxYIrGH2dUAZkizNY3i9WJUEcIFLowZAEjLTT7fUAH2vH0Tpkeh+/MrzwFFmeWcZ66QLh7A==}
+
   remark-parse@11.0.0:
     resolution: {integrity: sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==}
 
@@ -7482,6 +7560,10 @@ packages:
 
   shiki@4.2.0:
     resolution: {integrity: sha512-hjNax6o/ylDy9lefQEaSDtzaT3iVNtZ3WmpQnbuQNoG4xvnSKf2kSKbihZVO4JRG1TTMejs7CmNRYlWgAL66pQ==}
+    engines: {node: '>=20'}
+
+  shiki@4.3.1:
+    resolution: {integrity: sha512-oR+qDVi2OjX1tmDpyv+3KviX01KzO6Af+0NNnKnsp9491UEGz2YpxTuJboS/6VhYpTdqzmuJBuiTlrAWWJAssw==}
     engines: {node: '>=20'}
 
   side-channel-list@1.0.1:
@@ -8978,12 +9060,19 @@ snapshots:
 
   '@colordx/core@5.4.3': {}
 
-  '@comark/vue@0.4.0(shiki@4.2.0)(vue@3.5.39(typescript@6.0.3))':
+  '@comark/vue@0.5.0(shiki@4.2.0)(vue@3.5.39(typescript@6.0.3))':
     dependencies:
-      comark: 0.4.0(shiki@4.2.0)
+      comark: 0.5.0(shiki@4.2.0)
       vue: 3.5.39(typescript@6.0.3)
     optionalDependencies:
       shiki: 4.2.0
+
+  '@comark/vue@0.5.0(shiki@4.3.1)(vue@3.5.39(typescript@6.0.3))':
+    dependencies:
+      comark: 0.5.0(shiki@4.3.1)
+      vue: 3.5.39(typescript@6.0.3)
+    optionalDependencies:
+      shiki: 4.3.1
 
   '@dxup/nuxt@0.4.1(esbuild@0.27.7)(magicast@0.5.3)(rollup@4.60.2)(typescript@6.0.3)(vite@7.3.6(@types/node@25.6.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.1)(yaml@2.9.0))':
     dependencies:
@@ -9585,7 +9674,7 @@ snapshots:
       giget: 3.2.0
       jiti: 2.7.0
       listhen: 1.10.0(srvx@0.11.15)
-      nypm: 0.6.6
+      nypm: 0.6.8
       ofetch: 1.5.1
       ohash: 2.0.11
       pathe: 2.0.3
@@ -9676,11 +9765,11 @@ snapshots:
       - vite
       - webpack
 
-  '@nuxt/content@3.14.0(better-sqlite3@12.11.1)(esbuild@0.27.7)(magicast@0.5.3)(rollup@4.60.2)(valibot@1.4.2(typescript@6.0.3))(vite@7.3.6(@types/node@25.6.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.1)(yaml@2.9.0))':
+  '@nuxt/content@3.15.0(better-sqlite3@12.11.1)(esbuild@0.27.7)(magicast@0.5.3)(rollup@4.60.2)(valibot@1.4.2(typescript@6.0.3))(vite@7.3.6(@types/node@25.6.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.1)(yaml@2.9.0))':
     dependencies:
       '@nuxt/kit': 4.4.8(esbuild@0.27.7)(magicast@0.5.3)(rollup@4.60.2)(vite@7.3.6(@types/node@25.6.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.1)(yaml@2.9.0))
-      '@nuxtjs/mdc': 0.22.0(esbuild@0.27.7)(magicast@0.5.3)(rollup@4.60.2)(vite@7.3.6(@types/node@25.6.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.1)(yaml@2.9.0))
-      '@shikijs/langs': 4.2.0
+      '@nuxtjs/mdc': 0.22.1(esbuild@0.27.7)(magicast@0.5.3)(rollup@4.60.2)(vite@7.3.6(@types/node@25.6.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.1)(yaml@2.9.0))
+      '@shikijs/langs': 4.3.1
       '@sqlite.org/sqlite-wasm': 3.50.4-build1
       '@standard-schema/spec': 1.1.0
       '@webcontainer/env': 1.1.1
@@ -9691,8 +9780,9 @@ snapshots:
       defu: 6.1.7
       destr: 2.0.5
       git-url-parse: 16.1.0
+      h3: 1.15.11
       hookable: 5.5.3
-      isomorphic-git: 1.38.4
+      isomorphic-git: 1.38.6
       jiti: 2.7.0
       json-schema-to-typescript-lite: 15.0.0
       mdast-util-to-hast: 13.2.1
@@ -9706,13 +9796,13 @@ snapshots:
       minimark: 0.2.0
       minimatch: 10.2.5
       nuxt-component-meta: 0.17.2(esbuild@0.27.7)(magicast@0.5.3)(rollup@4.60.2)(vite@7.3.6(@types/node@25.6.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.1)(yaml@2.9.0))
-      nypm: 0.6.6
+      nypm: 0.6.8
       ohash: 2.0.11
       pathe: 2.0.3
       pkg-types: 2.3.1
       remark-mdc: 3.11.0
       scule: 1.3.0
-      shiki: 4.2.0
+      shiki: 4.3.1
       slugify: 1.6.9
       socket.io-client: 4.8.3
       std-env: 4.1.0
@@ -10337,7 +10427,7 @@ snapshots:
       - vite
       - webpack
 
-  '@nuxt/ui@4.8.2(9a8c698d34af8083eea182a4c8330ce9)':
+  '@nuxt/ui@4.8.2(41256859cf4d7469470ffe7ddd380ae7)':
     dependencies:
       '@floating-ui/dom': 1.7.6
       '@iconify/vue': 5.0.1(vue@3.5.39(typescript@6.0.3))
@@ -10407,7 +10497,7 @@ snapshots:
       '@inertiajs/vue3': 3.0.3(vue@3.5.39(typescript@6.0.3))
       '@internationalized/date': 3.12.2
       '@internationalized/number': 3.6.7
-      '@nuxt/content': 3.14.0(better-sqlite3@12.11.1)(esbuild@0.27.7)(magicast@0.5.3)(rollup@4.60.2)(valibot@1.4.2(typescript@6.0.3))(vite@7.3.6(@types/node@25.6.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.1)(yaml@2.9.0))
+      '@nuxt/content': 3.15.0(better-sqlite3@12.11.1)(esbuild@0.27.7)(magicast@0.5.3)(rollup@4.60.2)(valibot@1.4.2(typescript@6.0.3))(vite@7.3.6(@types/node@25.6.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.1)(yaml@2.9.0))
       joi: 18.2.3
       superstruct: 2.0.2
       valibot: 1.4.2(typescript@6.0.3)
@@ -10676,6 +10766,65 @@ snapshots:
       remark-stringify: 11.0.0
       scule: 1.3.0
       shiki: 4.2.0
+      ufo: 1.6.4
+      unified: 11.0.5
+      unist-builder: 4.0.0
+      unist-util-visit: 5.1.0
+      unwasm: 0.5.3
+      vfile: 6.0.3
+    transitivePeerDependencies:
+      - '@farmfe/core'
+      - '@rspack/core'
+      - bun-types-no-globals
+      - esbuild
+      - magicast
+      - rolldown
+      - rollup
+      - supports-color
+      - unloader
+      - vite
+      - webpack
+
+  '@nuxtjs/mdc@0.22.1(esbuild@0.27.7)(magicast@0.5.3)(rollup@4.60.2)(vite@7.3.6(@types/node@25.6.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.1)(yaml@2.9.0))':
+    dependencies:
+      '@nuxt/kit': 4.4.8(esbuild@0.27.7)(magicast@0.5.3)(rollup@4.60.2)(vite@7.3.6(@types/node@25.6.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.1)(yaml@2.9.0))
+      '@shikijs/core': 4.3.1
+      '@shikijs/engine-javascript': 4.3.1
+      '@shikijs/langs': 4.3.1
+      '@shikijs/themes': 4.3.1
+      '@shikijs/transformers': 4.3.1
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      '@vue/compiler-core': 3.5.39
+      consola: 3.4.2
+      debug: 4.4.3
+      defu: 6.1.7
+      destr: 2.0.5
+      detab: 3.0.2
+      github-slugger: 2.0.0
+      hast-util-format: 1.1.0
+      hast-util-to-mdast: 10.1.2
+      hast-util-to-string: 3.0.1
+      mdast-util-to-hast: 13.2.1
+      micromark-util-sanitize-uri: 2.0.1
+      parse5: 8.0.1
+      pathe: 2.0.3
+      property-information: 7.2.0
+      rehype-external-links: 3.0.0
+      rehype-minify-whitespace: 6.0.2
+      rehype-raw: 7.0.0
+      rehype-remark: 10.0.1
+      rehype-slug: 6.0.0
+      rehype-sort-attribute-values: 5.0.1
+      rehype-sort-attributes: 5.0.1
+      remark-emoji: 5.0.2
+      remark-gfm: 4.0.1
+      remark-mdc: 3.11.1
+      remark-parse: 11.0.0
+      remark-rehype: 11.1.2
+      remark-stringify: 11.0.0
+      scule: 1.3.0
+      shiki: 4.3.1
       ufo: 1.6.4
       unified: 11.0.5
       unist-builder: 4.0.0
@@ -11337,9 +11486,23 @@ snapshots:
       '@types/hast': 3.0.4
       hast-util-to-html: 9.0.5
 
+  '@shikijs/core@4.3.1':
+    dependencies:
+      '@shikijs/primitive': 4.3.1
+      '@shikijs/types': 4.3.1
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.4
+      hast-util-to-html: 9.0.5
+
   '@shikijs/engine-javascript@4.2.0':
     dependencies:
       '@shikijs/types': 4.2.0
+      '@shikijs/vscode-textmate': 10.0.2
+      oniguruma-to-es: 4.3.6
+
+  '@shikijs/engine-javascript@4.3.1':
+    dependencies:
+      '@shikijs/types': 4.3.1
       '@shikijs/vscode-textmate': 10.0.2
       oniguruma-to-es: 4.3.6
 
@@ -11348,9 +11511,18 @@ snapshots:
       '@shikijs/types': 4.2.0
       '@shikijs/vscode-textmate': 10.0.2
 
+  '@shikijs/engine-oniguruma@4.3.1':
+    dependencies:
+      '@shikijs/types': 4.3.1
+      '@shikijs/vscode-textmate': 10.0.2
+
   '@shikijs/langs@4.2.0':
     dependencies:
       '@shikijs/types': 4.2.0
+
+  '@shikijs/langs@4.3.1':
+    dependencies:
+      '@shikijs/types': 4.3.1
 
   '@shikijs/primitive@4.0.2':
     dependencies:
@@ -11364,14 +11536,29 @@ snapshots:
       '@shikijs/vscode-textmate': 10.0.2
       '@types/hast': 3.0.4
 
+  '@shikijs/primitive@4.3.1':
+    dependencies:
+      '@shikijs/types': 4.3.1
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.4
+
   '@shikijs/themes@4.2.0':
     dependencies:
       '@shikijs/types': 4.2.0
+
+  '@shikijs/themes@4.3.1':
+    dependencies:
+      '@shikijs/types': 4.3.1
 
   '@shikijs/transformers@4.0.2':
     dependencies:
       '@shikijs/core': 4.0.2
       '@shikijs/types': 4.0.2
+
+  '@shikijs/transformers@4.3.1':
+    dependencies:
+      '@shikijs/core': 4.3.1
+      '@shikijs/types': 4.3.1
 
   '@shikijs/types@3.23.0':
     dependencies:
@@ -11384,6 +11571,11 @@ snapshots:
       '@types/hast': 3.0.4
 
   '@shikijs/types@4.2.0':
+    dependencies:
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.4
+
+  '@shikijs/types@4.3.1':
     dependencies:
       '@shikijs/vscode-textmate': 10.0.2
       '@types/hast': 3.0.4
@@ -12889,7 +13081,7 @@ snapshots:
 
   colortranslator@5.0.0: {}
 
-  comark@0.4.0(shiki@4.2.0):
+  comark@0.5.0(shiki@4.2.0):
     dependencies:
       entities: 8.0.0
       htmlparser2: 12.0.0
@@ -12897,6 +13089,15 @@ snapshots:
       markdown-exit: 1.0.0-beta.9
     optionalDependencies:
       shiki: 4.2.0
+
+  comark@0.5.0(shiki@4.3.1):
+    dependencies:
+      entities: 8.0.0
+      htmlparser2: 12.0.0
+      js-yaml: 4.1.1
+      markdown-exit: 1.0.0-beta.9
+    optionalDependencies:
+      shiki: 4.3.1
 
   comma-separated-tokens@2.0.3: {}
 
@@ -14484,6 +14685,20 @@ snapshots:
       sha.js: 2.4.12
       simple-get: 4.0.1
 
+  isomorphic-git@1.38.6:
+    dependencies:
+      async-lock: 1.4.1
+      clean-git-ref: 2.0.1
+      crc-32: 1.2.2
+      diff3: 0.0.3
+      ignore: 5.3.2
+      minimisted: 2.0.1
+      pako: 1.0.11
+      pify: 4.0.1
+      readable-stream: 4.7.0
+      sha.js: 2.4.12
+      simple-get: 4.0.1
+
   isomorphic.js@0.2.5: {}
 
   jackspeak@3.4.3:
@@ -15482,12 +15697,12 @@ snapshots:
       - vue
       - webpack
 
-  nuxt-schema-org@6.2.1(64d64582d0445e2f566e82bda5721a0d):
+  nuxt-schema-org@6.2.1(4fb188448e89020cd2bf36684823fce4):
     dependencies:
       '@nuxt/kit': 4.4.8(esbuild@0.27.7)(magicast@0.5.3)(rollup@4.60.2)(vite@7.3.6(@types/node@25.6.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.1)(yaml@2.9.0))
       defu: 6.1.7
       nuxt-site-config: 4.0.8(@nuxt/schema@4.4.8)(esbuild@0.27.7)(magicast@0.5.3)(nuxt@4.4.8(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.6.0)(@vue/compiler-sfc@3.5.39)(better-sqlite3@12.11.1)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.11.1))(esbuild@0.27.7)(eslint@10.6.0(jiti@2.7.0))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.3)(optionator@0.9.4)(rollup-plugin-visualizer@7.0.1(rollup@4.60.2))(rollup@4.60.2)(srvx@0.11.15)(terser@5.46.1)(typescript@6.0.3)(vite@7.3.6(@types/node@25.6.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.1)(yaml@2.9.0))(vue-tsc@3.3.6(typescript@6.0.3))(yaml@2.9.0))(rollup@4.60.2)(vite@7.3.6(@types/node@25.6.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.1)(yaml@2.9.0))(vue@3.5.39(typescript@6.0.3))(zod@4.4.3)
-      nuxtseo-layer-devtools: 5.3.0(44370a5a46f477944dd2bf4a3117b216)
+      nuxtseo-layer-devtools: 5.3.0(41865dfbd00ddc7a43dbb7d5c51bbcb5)
       nuxtseo-shared: 5.2.6(c2658fad96bd4300c6731eec99e70702)
       pkg-types: 2.3.1
       ufo: 1.6.4
@@ -15872,12 +16087,12 @@ snapshots:
       - xml2js
       - yaml
 
-  nuxtseo-layer-devtools@5.3.0(44370a5a46f477944dd2bf4a3117b216):
+  nuxtseo-layer-devtools@5.3.0(41865dfbd00ddc7a43dbb7d5c51bbcb5):
     dependencies:
       '@iconify-json/carbon': 1.2.23
       '@nuxt/devtools-kit': 4.0.0-alpha.3(esbuild@0.27.7)(magicast@0.5.3)(rollup@4.60.2)(vite@7.3.6(@types/node@25.6.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.1)(yaml@2.9.0))
       '@nuxt/kit': 4.4.8(esbuild@0.27.7)(magicast@0.5.3)(rollup@4.60.2)(vite@7.3.6(@types/node@25.6.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.1)(yaml@2.9.0))
-      '@nuxt/ui': 4.8.2(9a8c698d34af8083eea182a4c8330ce9)
+      '@nuxt/ui': 4.8.2(41256859cf4d7469470ffe7ddd380ae7)
       '@shikijs/langs': 4.2.0
       '@shikijs/themes': 4.2.0
       '@vueuse/core': 14.3.0(vue@3.5.39(typescript@6.0.3))
@@ -15985,6 +16200,12 @@ snapshots:
       - webpack
 
   nypm@0.6.6:
+    dependencies:
+      citty: 0.2.2
+      pathe: 2.0.3
+      tinyexec: 1.2.4
+
+  nypm@0.6.8:
     dependencies:
       citty: 0.2.2
       pathe: 2.0.3
@@ -16672,6 +16893,8 @@ snapshots:
 
   property-information@7.1.0: {}
 
+  property-information@7.2.0: {}
+
   prosemirror-changeset@2.4.1:
     dependencies:
       prosemirror-transform: 1.12.0
@@ -17033,6 +17256,29 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  remark-mdc@3.11.1:
+    dependencies:
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      flat: 6.0.1
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+      micromark: 4.0.2
+      micromark-core-commonmark: 2.0.3
+      micromark-factory-space: 2.0.1
+      micromark-factory-whitespace: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-types: 2.0.2
+      parse-entities: 4.0.2
+      scule: 1.3.0
+      stringify-entities: 4.0.4
+      unified: 11.0.5
+      unist-util-visit: 5.1.0
+      unist-util-visit-parents: 6.0.2
+      yaml: 2.9.0
+    transitivePeerDependencies:
+      - supports-color
+
   remark-parse@11.0.0:
     dependencies:
       '@types/mdast': 4.0.4
@@ -17276,6 +17522,17 @@ snapshots:
       '@shikijs/langs': 4.2.0
       '@shikijs/themes': 4.2.0
       '@shikijs/types': 4.2.0
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.4
+
+  shiki@4.3.1:
+    dependencies:
+      '@shikijs/core': 4.3.1
+      '@shikijs/engine-javascript': 4.3.1
+      '@shikijs/engine-oniguruma': 4.3.1
+      '@shikijs/langs': 4.3.1
+      '@shikijs/themes': 4.3.1
+      '@shikijs/types': 4.3.1
       '@shikijs/vscode-textmate': 10.0.2
       '@types/hast': 3.0.4
 


### PR DESCRIPTION
## Upstream
[`1c1d9be`](https://github.com/nuxt/ui/commit/1c1d9be442de642ff6edb69900ea0f7bae4408ac) — `chore(deps): update all non-major dependencies (#6679)`

## Change — §2 per-dep mirror
Bumped only deps b24ui pins at the same range (nuxt↔demo parity):

| dep | from → to | manifests |
|---|---|---|
| pnpm (`packageManager`) | 11.9.0 → 11.10.0 | root |
| `@comark/vue` | ^0.4.0 → ^0.5.0 | docs, demo, nuxt |
| `@nuxt/content` | ^3.14.0 → ^3.15.0 | docs, demo, nuxt |
| `@nuxtjs/mdc` | ^0.22.0 → ^0.22.1 | docs |

**Skipped:** `ai` + `@ai-sdk/*` (b24ui stays on the deferred v6 line — see #dfbbfeb), `@iconify-json/*` + `@nuxt/icon` (b24ui has none), `shiki` (`^4.2.0` ≠ `^4.3.0`), `nuxt-og-image` (`^6.6.0` ≠ `^6.7.0`), `@regle/*` (`^1.28.0` ≠ `^1.28.2`). Root `@nuxt/content ^3.0.0` peer untouched.

## `mdc.config.ts` cast — applies here too
Even without bumping b24ui's `shiki` pin (`^4.2.0`), lockfile regen resolves `shiki` to **4.3.1** (within `^4.2.0`), pulling `@shikijs/types@4.3.1` into `@nuxtjs/mdc`'s config type while `shiki-transformer-color-highlight` still returns a `@shikijs/types@3.23.0` transformer → `vue-tsc` **TS2322**. So the upstream fix applies: `import type { ShikiTransformer } from '@shikijs/types'` + `transformerColorHighlight() as ShikiTransformer`, plus a `@shikijs/types: ^4.3.1` devDep so the bare import resolves.

**Lockfile:** regenerated under the CI gate (corepack pnpm 11.10.0), `lockfileVersion 9.0`.

## Tests
Dep bumps + a type cast → no snapshot churn. Full suite unchanged (5277 passed / 6 skipped).

## Verify (CI=true, pnpm 11.10.0)
Real install → `dev:prepare` · `lint` · `typecheck` (cast resolves the shiki 4.3.1 mismatch) · `test` · `build` — all green.

## Ledger
- `.sync/log/1c1d9be….md` — port rationale
- `.sync/nuxt-ui.json` — add `1c1d9be` as `port`, advance cursor; reconcile prior `5c986dd` → PR #244 / `fffec684`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JS8ypVfQSFzYVZzkTHhURb)_