### PR TITLE
fix(Link): apply rel prop to internal links

### DIFF
--- a/.sync/log/276302eef23a8ea9a2b144aca80e18b6efa55111.md
+++ b/.sync/log/276302eef23a8ea9a2b144aca80e18b6efa55111.md
@@ -1,0 +1,39 @@
+# Port: fix(Link): apply `rel` prop to internal links (#6677)
+
+**Upstream:** `276302eef23a8ea9a2b144aca80e18b6efa55111` (nuxt/ui)
+**Decision:** port
+
+## Upstream change
+`NuxtLink` strips `rel` from its slot props when rendered with `custom`, so an
+explicit `rel` on an **internal** link was dropped. Replaces the
+external-only `externalRel` computed with a unified `rel` computed applied to
+**every** branch: `noRel` → `null`; explicit `rel` → `rel || null`; else
+`noopener noreferrer` for external links or links with a non-`_self` `target`;
+otherwise `null`. The `custom` and default slot bindings + the `LinkBase`
+branches all pass this `rel`. The `none`/`inertia`/`vue-router` LinkBase
+overrides get the same `rel` logic (`none`) or omit `target`/`rel` from the
+forwarded router props (`inertia`/`vue-router`).
+
+## b24ui port — direct 1:1
+b24ui's `Link.vue` and the three override `Link.vue` files matched upstream's
+pre-change structure:
+- **`Link.vue`**: `externalRel` → the unified `rel` computed (verbatim); the 4
+  `rel:` bindings (2 internal slot `(rest…).rel`, 2 external `externalRel`) all
+  → `rel`.
+- **`vue/overrides/none/Link.vue`**: added `hasTarget` computed; `linkRel` → the
+  unified `rel` (using `isExternal.value || hasTarget.value`); both
+  `rel: linkRel` → `rel`.
+- **`vue/overrides/{inertia,vue-router}/Link.vue`**: added `'target', 'rel'` to
+  the `reactiveOmit` so they aren't force-forwarded to the router link.
+
+No b24ui-specific surface changes (only the pre-existing `b24ui`/`B24LinkBase`
+naming, untouched).
+
+## Tests
+Added the 4 upstream `renderEach` cases (`internal to object and target`,
+`internal to and rel`, `internal to and noRel`, `external to and rel`). 8
+snapshots written; the `internal to and rel` case now renders `rel="nofollow"`
+(the fix — previously dropped), `noRel` renders none. Suite 5285 passed (+8).
+
+## Verify (CI=true)
+`dev:prepare` · `lint` · `typecheck` · `test` · `build` — all green.

--- a/.sync/nuxt-ui.json
+++ b/.sync/nuxt-ui.json
@@ -2,7 +2,7 @@
   "upstream": "nuxt/ui",
   "branch": "v4",
   "sync_enabled": false,
-  "cursor": "ad931219f70142bba8aa4e5f48bcfaa3765cb5aa",
+  "cursor": "276302eef23a8ea9a2b144aca80e18b6efa55111",
   "_cursor_note": "cursor = last upstream commit ported into b24ui (oldest-first, manual cadence). sync_enabled stays false until Phase 2 (porter workflow #67 + CLAUDE_CODE_OAUTH_TOKEN) is wired and trusted. `processed` is maintained per port from now on (backfilled #68-#72 on 2026-06-09).",
   "stats": {
     "queue_depth": 0,
@@ -887,10 +887,16 @@
       "summary": "docs: use shiki-transformer-icon-highlight package (#6684) — NO-OP: upstream swaps its local docs/app/utils/shiki-transformer-icon-highlight.ts for the published shiki-transformer-icon-highlight@0.1.0 (+dep, +pnpm-workspace minimumReleaseAgeExclude swap @nuxt/icon@2.2.5 -> the new pkg). b24ui docs use ONLY transformerColorHighlight, not transformerIconHighlight — no such util/import (grep => none, file absent), and no minimumReleaseAgeExclude block (the @nuxt/icon exclude came from skipped 8d46034). Nothing to swap. Bookkeeping only"
     },
     "ad931219f70142bba8aa4e5f48bcfaa3765cb5aa": {
+      "pr": 247,
+      "b24ui_sha": "805ca93f",
+      "decision": "port",
+      "summary": "chore(deps): update tiptap to ^3.27.1 (#6654) — bump all 25 @tiptap/* ^3.26.1->^3.27.1 across root/docs/demo/nuxt/vue + useEditorMenu.ts: +import type Plugin from @tiptap/pm/state + const plugin:Plugin=Suggestion({...}) (SuggestionPluginState not exported). Lockfile regen (tiptap 3.27.3). DEVIATION: @tiptap/y-tiptap@3.0.3 (via extension-collaboration) pins @tiptap/pm@3.26.1 -> 2nd prosemirror-view 1.41.8 -> EditorCompletionExtension.ts decorations DecorationSet vs DecorationSource TS2322 (dup types). Fix: +'@tiptap/pm': ^3.27.1 to pnpm-workspace overrides -> single @tiptap/pm/view. (blanket pnpm dedupe rejected: churned nuxt paths -> unrelated TS2883 in plugins/*). No snapshot churn"
+    },
+    "276302eef23a8ea9a2b144aca80e18b6efa55111": {
       "pr": null,
       "b24ui_sha": "pending-merge",
       "decision": "port",
-      "summary": "chore(deps): update tiptap to ^3.27.1 (#6654) — bump all 25 @tiptap/* ^3.26.1->^3.27.1 across root/docs/demo/nuxt/vue + useEditorMenu.ts: +import type Plugin from @tiptap/pm/state + const plugin:Plugin=Suggestion({...}) (SuggestionPluginState not exported). Lockfile regen (tiptap 3.27.3). DEVIATION: @tiptap/y-tiptap@3.0.3 (via extension-collaboration) pins @tiptap/pm@3.26.1 -> 2nd prosemirror-view 1.41.8 -> EditorCompletionExtension.ts decorations DecorationSet vs DecorationSource TS2322 (dup types). Fix: +'@tiptap/pm': ^3.27.1 to pnpm-workspace overrides -> single @tiptap/pm/view. (blanket pnpm dedupe rejected: churned nuxt paths -> unrelated TS2883 in plugins/*). No snapshot churn"
+      "summary": "fix(Link): apply rel prop to internal links (#6677) — NuxtLink strips rel from custom slot props so explicit rel on internal links was dropped. Link.vue: externalRel computed -> unified rel computed applied to every branch (noRel->null; rel!==undefined->rel||null; !isInternalLink||(target&&!=_self)->noopener noreferrer; else null); 4 rel: bindings -> rel. vue/overrides/none/Link.vue: +hasTarget computed, linkRel->rel (isExternal||hasTarget), 2 rel:linkRel->rel. vue/overrides/{inertia,vue-router}/Link.vue: +target,rel to reactiveOmit. Direct 1:1 (b24ui matched). +4 renderEach cases (internal to-object+target, internal rel, internal noRel, external rel); 8 snapshots (internal+rel now renders rel=nofollow). Tests 5285 (+8)"
     }
   }
 }

--- a/src/runtime/components/Link.vue
+++ b/src/runtime/components/Link.vue
@@ -198,10 +198,25 @@ const isInternalLink = computed(() => {
   return true
 })
 
-const externalRel = computed(() => {
-  if (props.noRel) return null
-  if (props.rel) return props.rel
-  return 'noopener noreferrer'
+// NuxtLink strips `rel` from its slot props when rendered with `custom`, so
+// the prop is applied here for every branch instead of read from the slot.
+const rel = computed(() => {
+  // If noRel is explicitly set, return null
+  if (props.noRel) {
+    return null
+  }
+
+  // If rel is explicitly set, use it
+  if (props.rel !== undefined) {
+    return props.rel || null
+  }
+
+  // Default to "noopener noreferrer" for external links or links with target
+  if (!isInternalLink.value || (props.target && props.target !== '_self')) {
+    return 'noopener noreferrer'
+  }
+
+  return null
 })
 
 function isLinkActive({ route: linkRoute, isActive, isExactActive }: any = {}) {
@@ -268,7 +283,7 @@ function resolveLinkClass({ route, isActive, isExactActive }: any = {}) {
           disabled,
           href,
           navigate,
-          rel: (rest as NuxtLinkDefaultSlotProps).rel,
+          rel,
           target: (rest as NuxtLinkDefaultSlotProps).target,
           isExternal: (rest as NuxtLinkDefaultSlotProps).isExternal,
           active: isLinkActive({ route: linkRoute, isActive, isExactActive })
@@ -285,7 +300,7 @@ function resolveLinkClass({ route, isActive, isExactActive }: any = {}) {
         disabled,
         href,
         navigate,
-        rel: (rest as NuxtLinkDefaultSlotProps).rel,
+        rel,
         target: (rest as NuxtLinkDefaultSlotProps).target,
         isExternal: (rest as NuxtLinkDefaultSlotProps).isExternal
       }"
@@ -302,7 +317,7 @@ function resolveLinkClass({ route, isActive, isExactActive }: any = {}) {
         as,
         type,
         disabled,
-        ...(to ? { href: String(to), target: props.target, rel: externalRel, isExternal: true } : {}),
+        ...(to ? { href: String(to), target: props.target, rel, isExternal: true } : {}),
         active: active ?? false
       }"
     />
@@ -314,7 +329,7 @@ function resolveLinkClass({ route, isActive, isExactActive }: any = {}) {
       as,
       type,
       disabled,
-      ...(to ? { href: String(to), target: props.target, rel: externalRel, isExternal: true } : {})
+      ...(to ? { href: String(to), target: props.target, rel, isExternal: true } : {})
     }"
     :class="resolveLinkClass()"
   >

--- a/src/runtime/vue/overrides/inertia/Link.vue
+++ b/src/runtime/vue/overrides/inertia/Link.vue
@@ -96,7 +96,7 @@ const page = usePage()
 
 const appConfig = useAppConfig() as Link['AppConfig']
 
-const routerLinkProps = useForwardProps(reactiveOmit(props, 'as', 'type', 'disabled', 'active', 'exact', 'activeClass', 'inactiveClass', 'to', 'href', 'raw', 'custom', 'class', 'noRel'))
+const routerLinkProps = useForwardProps(reactiveOmit(props, 'as', 'type', 'disabled', 'active', 'exact', 'activeClass', 'inactiveClass', 'to', 'href', 'raw', 'custom', 'class', 'target', 'rel', 'noRel'))
 
 const b24ui = computed(() => tv({
   extend: theme,

--- a/src/runtime/vue/overrides/none/Link.vue
+++ b/src/runtime/vue/overrides/none/Link.vue
@@ -125,6 +125,8 @@ const isExternal = computed(() => {
   return hasProtocol(href.value, { acceptRelative: true })
 })
 
+const hasTarget = computed(() => !!props.target && props.target !== '_self')
+
 const isLinkActive = computed(() => {
   if (props.active !== undefined) {
     return props.active
@@ -148,16 +150,19 @@ const linkClass = computed(() => {
   })
 })
 
-const linkRel = computed(() => {
+const rel = computed(() => {
+  // If noRel is explicitly set, return null
   if (props.noRel) {
     return null
   }
 
-  if (props.rel) {
-    return props.rel
+  // If rel is explicitly set, use it
+  if (props.rel !== undefined) {
+    return props.rel || null
   }
 
-  if (isExternal.value) {
+  // Default to "noopener noreferrer" for external links or links with target
+  if (isExternal.value || hasTarget.value) {
     return 'noopener noreferrer'
   }
 
@@ -187,7 +192,7 @@ const navigate = handleNavigation
         disabled,
         href,
         navigate,
-        rel: linkRel,
+        rel,
         target: target || (isExternal ? '_blank' : undefined),
         isExternal,
         active: isLinkActive
@@ -203,7 +208,7 @@ const navigate = handleNavigation
       disabled,
       href,
       navigate,
-      rel: linkRel,
+      rel,
       target: target || (isExternal ? '_blank' : undefined),
       isExternal
     }"

--- a/src/runtime/vue/overrides/vue-router/Link.vue
+++ b/src/runtime/vue/overrides/vue-router/Link.vue
@@ -91,7 +91,7 @@ const route = useRoute()
 
 const appConfig = useAppConfig() as Link['AppConfig']
 
-const routerLinkProps = useForwardProps(reactiveOmit(props, 'as', 'type', 'disabled', 'active', 'exact', 'exactQuery', 'exactHash', 'activeClass', 'inactiveClass', 'to', 'href', 'raw', 'custom', 'class', 'noRel'))
+const routerLinkProps = useForwardProps(reactiveOmit(props, 'as', 'type', 'disabled', 'active', 'exact', 'exactQuery', 'exactHash', 'activeClass', 'inactiveClass', 'to', 'href', 'raw', 'custom', 'class', 'target', 'rel', 'noRel'))
 
 const b24ui = computed(() => tv({
   extend: theme,

--- a/test/components/Link.spec.ts
+++ b/test/components/Link.spec.ts
@@ -20,6 +20,10 @@ describe('Link', () => {
     ['with external to', { props: { to: 'https://example.com' } }],
     ['with external to and target', { props: { to: 'https://example.com', target: '_blank' } }],
     ['with internal to and target', { props: { to: '/about', target: '_blank' } }],
+    ['with internal to object and target', { props: { to: { path: '/about' }, target: '_blank' } }],
+    ['with internal to and rel', { props: { to: '/about', rel: 'nofollow' } }],
+    ['with internal to and noRel', { props: { to: '/about', rel: 'nofollow', noRel: true } }],
+    ['with external to and rel', { props: { to: 'https://example.com', rel: 'nofollow' } }],
     ['with external prop', { props: { to: '/api/download', external: true } }],
     // Slots
     ['with default slot', { slots: { default: () => 'Default slot' } }]

--- a/test/components/__snapshots__/Link-vue.spec.ts.snap
+++ b/test/components/__snapshots__/Link-vue.spec.ts.snap
@@ -12,13 +12,21 @@ exports[`Link > renders with disabled correctly 1`] = `"<button type="button" di
 
 exports[`Link > renders with external prop correctly 1`] = `"<a href="/api/download" rel="noopener noreferrer" class="cursor-pointer focus-visible:outline-(--ui-color-accent-main-primary) focus-visible:outline-1 focus-visible:rounded-[4px] text-start text-(--ui-color-design-selection-content) underline-offset-2 hover:text-(--ui-color-accent-main-primary-alt-2) hover:underline"></a>"`;
 
+exports[`Link > renders with external to and rel correctly 1`] = `"<a href="https://example.com" rel="nofollow" class="cursor-pointer focus-visible:outline-(--ui-color-accent-main-primary) focus-visible:outline-1 focus-visible:rounded-[4px] text-start text-(--ui-color-design-selection-content) underline-offset-2 hover:text-(--ui-color-accent-main-primary-alt-2) hover:underline"></a>"`;
+
 exports[`Link > renders with external to and target correctly 1`] = `"<a href="https://example.com" rel="noopener noreferrer" target="_blank" class="cursor-pointer focus-visible:outline-(--ui-color-accent-main-primary) focus-visible:outline-1 focus-visible:rounded-[4px] text-start text-(--ui-color-design-selection-content) underline-offset-2 hover:text-(--ui-color-accent-main-primary-alt-2) hover:underline"></a>"`;
 
 exports[`Link > renders with external to correctly 1`] = `"<a href="https://example.com" rel="noopener noreferrer" class="cursor-pointer focus-visible:outline-(--ui-color-accent-main-primary) focus-visible:outline-1 focus-visible:rounded-[4px] text-start text-(--ui-color-design-selection-content) underline-offset-2 hover:text-(--ui-color-accent-main-primary-alt-2) hover:underline"></a>"`;
 
 exports[`Link > renders with inactiveClass correctly 1`] = `"<button type="button" class="cursor-pointer focus-visible:outline-(--ui-color-accent-main-primary) focus-visible:outline-1 focus-visible:rounded-[4px] text-start text-(--ui-color-design-selection-content) underline-offset-2 hover:text-(--ui-color-accent-main-primary-alt-2) hover:underline"></button>"`;
 
+exports[`Link > renders with internal to and noRel correctly 1`] = `"<a href="/about" class="cursor-pointer focus-visible:outline-(--ui-color-accent-main-primary) focus-visible:outline-1 focus-visible:rounded-[4px] text-start text-(--ui-color-design-selection-content) underline-offset-2 hover:text-(--ui-color-accent-main-primary-alt-2) hover:underline" isaction="false"></a>"`;
+
+exports[`Link > renders with internal to and rel correctly 1`] = `"<a href="/about" rel="nofollow" class="cursor-pointer focus-visible:outline-(--ui-color-accent-main-primary) focus-visible:outline-1 focus-visible:rounded-[4px] text-start text-(--ui-color-design-selection-content) underline-offset-2 hover:text-(--ui-color-accent-main-primary-alt-2) hover:underline" isaction="false"></a>"`;
+
 exports[`Link > renders with internal to and target correctly 1`] = `"<a href="/about" rel="noopener noreferrer" target="_blank" class="cursor-pointer focus-visible:outline-(--ui-color-accent-main-primary) focus-visible:outline-1 focus-visible:rounded-[4px] text-start text-(--ui-color-design-selection-content) underline-offset-2 hover:text-(--ui-color-accent-main-primary-alt-2) hover:underline" isaction="false"></a>"`;
+
+exports[`Link > renders with internal to object and target correctly 1`] = `"<a href="/about" rel="noopener noreferrer" target="_blank" class="cursor-pointer focus-visible:outline-(--ui-color-accent-main-primary) focus-visible:outline-1 focus-visible:rounded-[4px] text-start text-(--ui-color-design-selection-content) underline-offset-2 hover:text-(--ui-color-accent-main-primary-alt-2) hover:underline" isaction="false"></a>"`;
 
 exports[`Link > renders with raw activeClass correctly 1`] = `"<button type="button" class="text-(--ui-color-accent-main-success)"></button>"`;
 

--- a/test/components/__snapshots__/Link.spec.ts.snap
+++ b/test/components/__snapshots__/Link.spec.ts.snap
@@ -12,13 +12,21 @@ exports[`Link > renders with disabled correctly 1`] = `"<button type="button" di
 
 exports[`Link > renders with external prop correctly 1`] = `"<a href="/api/download" rel="noopener noreferrer" class="cursor-pointer focus-visible:outline-(--ui-color-accent-main-primary) focus-visible:outline-1 focus-visible:rounded-[4px] text-start text-(--ui-color-design-selection-content) underline-offset-2 hover:text-(--ui-color-accent-main-primary-alt-2) hover:underline"></a>"`;
 
+exports[`Link > renders with external to and rel correctly 1`] = `"<a href="https://example.com" rel="nofollow" class="cursor-pointer focus-visible:outline-(--ui-color-accent-main-primary) focus-visible:outline-1 focus-visible:rounded-[4px] text-start text-(--ui-color-design-selection-content) underline-offset-2 hover:text-(--ui-color-accent-main-primary-alt-2) hover:underline"></a>"`;
+
 exports[`Link > renders with external to and target correctly 1`] = `"<a href="https://example.com" rel="noopener noreferrer" target="_blank" class="cursor-pointer focus-visible:outline-(--ui-color-accent-main-primary) focus-visible:outline-1 focus-visible:rounded-[4px] text-start text-(--ui-color-design-selection-content) underline-offset-2 hover:text-(--ui-color-accent-main-primary-alt-2) hover:underline"></a>"`;
 
 exports[`Link > renders with external to correctly 1`] = `"<a href="https://example.com" rel="noopener noreferrer" class="cursor-pointer focus-visible:outline-(--ui-color-accent-main-primary) focus-visible:outline-1 focus-visible:rounded-[4px] text-start text-(--ui-color-design-selection-content) underline-offset-2 hover:text-(--ui-color-accent-main-primary-alt-2) hover:underline"></a>"`;
 
 exports[`Link > renders with inactiveClass correctly 1`] = `"<button type="button" class="cursor-pointer focus-visible:outline-(--ui-color-accent-main-primary) focus-visible:outline-1 focus-visible:rounded-[4px] text-start text-(--ui-color-design-selection-content) underline-offset-2 hover:text-(--ui-color-accent-main-primary-alt-2) hover:underline"></button>"`;
 
+exports[`Link > renders with internal to and noRel correctly 1`] = `"<a href="/about" class="cursor-pointer focus-visible:outline-(--ui-color-accent-main-primary) focus-visible:outline-1 focus-visible:rounded-[4px] text-start text-(--ui-color-design-selection-content) underline-offset-2 hover:text-(--ui-color-accent-main-primary-alt-2) hover:underline"></a>"`;
+
+exports[`Link > renders with internal to and rel correctly 1`] = `"<a href="/about" rel="nofollow" class="cursor-pointer focus-visible:outline-(--ui-color-accent-main-primary) focus-visible:outline-1 focus-visible:rounded-[4px] text-start text-(--ui-color-design-selection-content) underline-offset-2 hover:text-(--ui-color-accent-main-primary-alt-2) hover:underline"></a>"`;
+
 exports[`Link > renders with internal to and target correctly 1`] = `"<a href="/about" rel="noopener noreferrer" target="_blank" class="cursor-pointer focus-visible:outline-(--ui-color-accent-main-primary) focus-visible:outline-1 focus-visible:rounded-[4px] text-start text-(--ui-color-design-selection-content) underline-offset-2 hover:text-(--ui-color-accent-main-primary-alt-2) hover:underline"></a>"`;
+
+exports[`Link > renders with internal to object and target correctly 1`] = `"<a href="/about" rel="noopener noreferrer" target="_blank" class="cursor-pointer focus-visible:outline-(--ui-color-accent-main-primary) focus-visible:outline-1 focus-visible:rounded-[4px] text-start text-(--ui-color-design-selection-content) underline-offset-2 hover:text-(--ui-color-accent-main-primary-alt-2) hover:underline"></a>"`;
 
 exports[`Link > renders with raw activeClass correctly 1`] = `"<button type="button" class="text-(--ui-color-accent-main-success)"></button>"`;
 


### PR DESCRIPTION
## Upstream
[`276302e`](https://github.com/nuxt/ui/commit/276302eef23a8ea9a2b144aca80e18b6efa55111) — `fix(Link): apply rel prop to internal links (#6677)`

## Change — direct 1:1
`NuxtLink` strips `rel` from its slot props when rendered with `custom`, so an explicit `rel` on an **internal** link was dropped. Replaces the external-only `externalRel` computed with a unified `rel` computed applied to **every** branch:
- `noRel` → `null`
- explicit `rel` → `rel || null`
- else `noopener noreferrer` for external links or links with a non-`_self` `target`
- otherwise `null`

Applied in `Link.vue` (4 `rel:` bindings → `rel`) and the `none` LinkBase override (`+hasTarget`, `linkRel` → unified `rel`); the `inertia`/`vue-router` overrides omit `target`/`rel` from the forwarded router props. b24ui's files matched upstream exactly.

## Tests
Added the 4 upstream `renderEach` cases. 8 snapshots written — `internal to and rel` now renders `rel="nofollow"` (previously dropped), `noRel` renders none. Suite **5285** passed (+8).

## Verify (CI=true)
`dev:prepare` · `lint` · `typecheck` · `test` · `build` — all green.

## Ledger
- `.sync/log/276302e….md` — port rationale
- `.sync/nuxt-ui.json` — add `276302e` as `port`, advance cursor; reconcile prior `ad93121` → PR #247 / `805ca93f`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JS8ypVfQSFzYVZzkTHhURb)_