### PR TITLE
fix(useComponentProps): let app config defaultVariants override withDefaults

### DIFF
--- a/.sync/log/f5e58fb7baae38ca2cedf589af3b625b73e247f3.md
+++ b/.sync/log/f5e58fb7baae38ca2cedf589af3b625b73e247f3.md
@@ -1,0 +1,34 @@
+# Port: fix(useComponentProps): let app config `defaultVariants` override `withDefaults` (#6686)
+
+**Upstream:** `f5e58fb7baae38ca2cedf589af3b625b73e247f3` (nuxt/ui)
+**Decision:** port
+
+## Upstream change
+Reorders the `useComponentProps` proxy priority chain so a global
+`app.config.ui.<name>.defaultVariants` value beats the component's
+`withDefaults` fallback: the `appConfig…defaultVariants[prop]` lookup moves
+**above** the `withDefaults`/`raw` block, and the tail returns `undefined`
+instead of the (now-earlier) app-config lookup. This makes `defaultVariants`
+work uniformly for every variant, including props a component pins in
+`withDefaults` (e.g. `orientation`, kept defined so `:data-orientation` always
+renders).
+
+## b24ui port — direct 1:1
+b24ui's `useComponentProps.ts` proxy matched upstream (`appConfig.b24ui`
+namespace). Applied verbatim: moved the
+`appConfigEntry = … appConfig.b24ui?.[name]` + `defaultVariants[prop]` lookup
+above the `propDef`/`raw` block (early-return when defined), changed the tail to
+`return undefined`, and updated the priority-chain jsdoc
+(`… nearest B24Theme > app.config.b24ui.<name>.defaultVariants > withDefaults`).
+
+## Tests
+Ported the upstream `app.config defaultVariants` describe block, adapted to
+b24ui: `B24FormField` (from `#components`), `appConfig.b24ui.formField`. Asserts
+that `defaultVariants.orientation = 'horizontal'` overrides FormField's
+`withDefaults` `orientation: 'vertical'` — drives `data-orientation="horizontal"`
+and the `place-items-baseline` root class (b24ui's FormField horizontal theme) —
+and that an explicit `orientation` prop still wins. Behaviour-preserving when no
+app-config `defaultVariants` is set → no snapshot churn. Suite 5289 passed (+4).
+
+## Verify (CI=true)
+`dev:prepare` · `lint` · `typecheck` · `test` · `build` — all green.

--- a/.sync/nuxt-ui.json
+++ b/.sync/nuxt-ui.json
@@ -2,7 +2,7 @@
   "upstream": "nuxt/ui",
   "branch": "v4",
   "sync_enabled": false,
-  "cursor": "276302eef23a8ea9a2b144aca80e18b6efa55111",
+  "cursor": "f5e58fb7baae38ca2cedf589af3b625b73e247f3",
   "_cursor_note": "cursor = last upstream commit ported into b24ui (oldest-first, manual cadence). sync_enabled stays false until Phase 2 (porter workflow #67 + CLAUDE_CODE_OAUTH_TOKEN) is wired and trusted. `processed` is maintained per port from now on (backfilled #68-#72 on 2026-06-09).",
   "stats": {
     "queue_depth": 0,
@@ -893,10 +893,16 @@
       "summary": "chore(deps): update tiptap to ^3.27.1 (#6654) — bump all 25 @tiptap/* ^3.26.1->^3.27.1 across root/docs/demo/nuxt/vue + useEditorMenu.ts: +import type Plugin from @tiptap/pm/state + const plugin:Plugin=Suggestion({...}) (SuggestionPluginState not exported). Lockfile regen (tiptap 3.27.3). DEVIATION: @tiptap/y-tiptap@3.0.3 (via extension-collaboration) pins @tiptap/pm@3.26.1 -> 2nd prosemirror-view 1.41.8 -> EditorCompletionExtension.ts decorations DecorationSet vs DecorationSource TS2322 (dup types). Fix: +'@tiptap/pm': ^3.27.1 to pnpm-workspace overrides -> single @tiptap/pm/view. (blanket pnpm dedupe rejected: churned nuxt paths -> unrelated TS2883 in plugins/*). No snapshot churn"
     },
     "276302eef23a8ea9a2b144aca80e18b6efa55111": {
+      "pr": 248,
+      "b24ui_sha": "a54dbfd3",
+      "decision": "port",
+      "summary": "fix(Link): apply rel prop to internal links (#6677) — NuxtLink strips rel from custom slot props so explicit rel on internal links was dropped. Link.vue: externalRel computed -> unified rel computed applied to every branch (noRel->null; rel!==undefined->rel||null; !isInternalLink||(target&&!=_self)->noopener noreferrer; else null); 4 rel: bindings -> rel. vue/overrides/none/Link.vue: +hasTarget computed, linkRel->rel (isExternal||hasTarget), 2 rel:linkRel->rel. vue/overrides/{inertia,vue-router}/Link.vue: +target,rel to reactiveOmit. Direct 1:1 (b24ui matched). +4 renderEach cases (internal to-object+target, internal rel, internal noRel, external rel); 8 snapshots (internal+rel now renders rel=nofollow). Tests 5285 (+8)"
+    },
+    "f5e58fb7baae38ca2cedf589af3b625b73e247f3": {
       "pr": null,
       "b24ui_sha": "pending-merge",
       "decision": "port",
-      "summary": "fix(Link): apply rel prop to internal links (#6677) — NuxtLink strips rel from custom slot props so explicit rel on internal links was dropped. Link.vue: externalRel computed -> unified rel computed applied to every branch (noRel->null; rel!==undefined->rel||null; !isInternalLink||(target&&!=_self)->noopener noreferrer; else null); 4 rel: bindings -> rel. vue/overrides/none/Link.vue: +hasTarget computed, linkRel->rel (isExternal||hasTarget), 2 rel:linkRel->rel. vue/overrides/{inertia,vue-router}/Link.vue: +target,rel to reactiveOmit. Direct 1:1 (b24ui matched). +4 renderEach cases (internal to-object+target, internal rel, internal noRel, external rel); 8 snapshots (internal+rel now renders rel=nofollow). Tests 5285 (+8)"
+      "summary": "fix(useComponentProps): let app config defaultVariants override withDefaults (#6686) — reorder proxy priority: appConfig.b24ui.<name>.defaultVariants[prop] lookup moved ABOVE the withDefaults/raw block (early-return if defined), tail -> return undefined; jsdoc chain -> explicit>B24Theme>appConfig defaultVariants>withDefaults. Makes defaultVariants work for withDefaults-pinned props (e.g. orientation). Direct 1:1 (b24ui matched, appConfig.b24ui). +spec 'app.config defaultVariants' block (B24FormField, appConfig.b24ui.formField, orientation horizontal overrides withDefaults vertical -> data-orientation=horizontal + place-items-baseline; explicit prop still wins). Behaviour-preserving w/o appConfig set, no snapshot churn. Tests 5289 (+4)"
     }
   }
 }

--- a/src/runtime/composables/useComponentProps.ts
+++ b/src/runtime/composables/useComponentProps.ts
@@ -46,8 +46,8 @@ function propIsDefined(vnode: VNode | null | undefined, prop: string): boolean {
 
 /**
  * Resolve a component's props with the priority chain:
- *   explicit prop > nearest B24Theme > withDefaults
- *     > app.config.b24ui.<name>.defaultVariants
+ *   explicit prop > nearest B24Theme > app.config.b24ui.<name>.defaultVariants
+ *     > withDefaults
  *
  * The returned proxy transparently reads from `props`, falling through to the
  * injected `ThemeContext` and `app.config.b24ui.<name>.defaultVariants` for
@@ -90,6 +90,15 @@ export function useComponentProps<T extends object>(name: string, props: T): T {
       const themeValue = themeEntry?.[prop]
       if (themeValue !== undefined) return themeValue
 
+      // A global `app.config.b24ui.<name>.defaultVariants` value takes priority over
+      // the component's `withDefaults` fallback. This keeps `defaultVariants`
+      // working uniformly for every variant, including props a component pins in
+      // `withDefaults` (e.g. `orientation`, kept defined so `:data-orientation`
+      // always renders a value).
+      const appConfigEntry = name.includes('.') ? get(appConfig.b24ui ?? {}, name) : appConfig.b24ui?.[name]
+      const appConfigValue = appConfigEntry?.defaultVariants?.[prop]
+      if (appConfigValue !== undefined) return appConfigValue
+
       // Only fall back to `raw` when `withDefaults` set an explicit default for
       // this prop. Otherwise Vue's runtime would auto-cast unset Boolean props
       // to `false` (and other typed props to their normalized fallback), which
@@ -100,8 +109,7 @@ export function useComponentProps<T extends object>(name: string, props: T): T {
         return raw
       }
 
-      const appConfigEntry = name.includes('.') ? get(appConfig.b24ui ?? {}, name) : appConfig.b24ui?.[name]
-      return appConfigEntry?.defaultVariants?.[prop]
+      return undefined
     },
     // `has`, `ownKeys`, and `getOwnPropertyDescriptor` reflect the underlying
     // `defineProps` schema only — theme defaults are NOT enumerable. As a

--- a/test/composables/useComponentProps.spec.ts
+++ b/test/composables/useComponentProps.spec.ts
@@ -1,4 +1,7 @@
-import { describe, expectTypeOf, test } from 'vitest'
+import { describe, expectTypeOf, it, expect, test, beforeAll, afterAll } from 'vitest'
+import { mountSuspended } from '@nuxt/test-utils/runtime'
+import { useAppConfig } from '#imports'
+import { B24FormField } from '#components'
 import type * as b24ui from '#build/b24ui'
 import type { ThemeDefaults } from '../../src/runtime/types/theme'
 
@@ -36,5 +39,42 @@ describe('ThemeDefaults registry', () => {
 
   test('ThemeDefaults declares no entries beyond the `#build/b24ui` registry', () => {
     expectTypeOf<ExtraInThemeDefaults>().toBeNever()
+  })
+})
+
+// `app.config.b24ui.<name>.defaultVariants` must override a prop the component
+// pins in `withDefaults` (here `orientation`). Regression test for upstream #6683.
+describe('app.config defaultVariants', () => {
+  let appConfig: { b24ui?: Record<string, any> }
+
+  beforeAll(() => {
+    appConfig = useAppConfig() as { b24ui?: Record<string, any> }
+    appConfig.b24ui ??= {}
+    appConfig.b24ui.formField = { defaultVariants: { orientation: 'horizontal' } }
+  })
+
+  afterAll(() => {
+    delete appConfig.b24ui!.formField
+  })
+
+  it('overrides the withDefaults fallback', async () => {
+    const wrapper = await mountSuspended(B24FormField, {
+      props: { label: 'Label' }
+    })
+
+    const root = wrapper.find('[data-slot="root"]')
+    // Drives both the `data-orientation` attribute and the tv class resolution,
+    // even though `orientation` isn't set in the theme's `defaultVariants`.
+    expect(root.attributes('data-orientation')).toBe('horizontal')
+    expect(root.classes()).toContain('place-items-baseline')
+  })
+
+  it('still lets an explicit prop win', async () => {
+    const wrapper = await mountSuspended(B24FormField, {
+      props: { label: 'Label', orientation: 'vertical' }
+    })
+
+    const root = wrapper.find('[data-slot="root"]')
+    expect(root.attributes('data-orientation')).toBe('vertical')
   })
 })


### PR DESCRIPTION
## Upstream
[`f5e58fb`](https://github.com/nuxt/ui/commit/f5e58fb7baae38ca2cedf589af3b625b73e247f3) — `fix(useComponentProps): let app config defaultVariants override withDefaults (#6686)`

## Change — direct 1:1
Reorders the `useComponentProps` proxy priority so a global `app.config.b24ui.<name>.defaultVariants` value beats the component's `withDefaults` fallback: the `defaultVariants[prop]` lookup moves **above** the `withDefaults`/`raw` block (early-return when defined), and the tail returns `undefined`. This makes `defaultVariants` work uniformly for every variant, including props a component pins in `withDefaults` (e.g. `orientation`, kept defined so `:data-orientation` always renders).

b24ui's proxy matched upstream (`appConfig.b24ui` namespace); applied verbatim + updated the priority-chain jsdoc.

## Tests
Ported the upstream `app.config defaultVariants` regression block, adapted to `B24FormField` / `appConfig.b24ui.formField`: asserts `defaultVariants.orientation = 'horizontal'` overrides FormField's `withDefaults` `vertical` (→ `data-orientation="horizontal"` + `place-items-baseline`), and an explicit prop still wins. Behaviour-preserving when no app-config `defaultVariants` is set → no snapshot churn. Suite **5289** passed (+4).

## Verify (CI=true)
`dev:prepare` · `lint` · `typecheck` · `test` · `build` — all green.

## Ledger
- `.sync/log/f5e58fb….md` — port rationale
- `.sync/nuxt-ui.json` — add `f5e58fb` as `port`, advance cursor; reconcile prior `276302e` → PR #248 / `a54dbfd3`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JS8ypVfQSFzYVZzkTHhURb)_