### PR TITLE
chore(sync): defer upstream data-slot root-forwarding convention (c9c5232)

### DIFF
--- a/.sync/log/c9c5232238f483f51b1be30128fa1c548a7b0329.md
+++ b/.sync/log/c9c5232238f483f51b1be30128fa1c548a7b0329.md
@@ -1,0 +1,45 @@
+# Port: fix(components): forward `data-slot` to component root (#6643)
+
+**Upstream:** `c9c5232238f483f51b1be30128fa1c548a7b0329` (nuxt/ui)
+**Decision:** skip (deferred — tracked for a dedicated data-slot-convention pass)
+
+## Upstream change
+Establishes a convention that a **caller-supplied `data-slot` always wins on a
+component's root element** (the component's own value is the fallback). Across
+~40 components the root changes from a literal `data-slot="root"` to
+`:data-slot="($attrs['data-slot'] as string | undefined) ?? 'root'"`; components
+that forward `$attrs` to an inner element strip `data-slot`
+(`v-bind="{ ...$attrs, 'data-slot': undefined }"`) to prevent leakage — **three
+strategies** depending on each component's attribute-inheritance pattern. Adds
+`.github/contributing/component-structure.md` (the guidance) and a new
+`test/components/DataSlot.spec.ts` that mounts **every** component with
+`data-slot="probe"` and asserts it appears exactly once on the outermost
+element. ~165 snapshots updated.
+
+## b24ui decision — skip / defer
+This is a broad structural convention, not a mechanical port, and it is
+disproportionately large and risky for b24ui:
+
+- **Scale + per-component judgment.** b24ui has 122 components (128 files carry a
+  root-ish `data-slot`). Each root needs the *correct* one of the three
+  strategies based on how that component inherits/forwards attrs
+  (`inheritAttrs`, `$attrs` spread, `Primitive`, reka roots) — not a blind
+  find/replace.
+- **The enforcing test raises the bar to 100 % coverage.** `DataSlot.spec.ts`
+  mounts **all** components and fails if any root doesn't honour the probe. That
+  includes b24ui **fork-only** components with **no upstream reference**
+  (`Advice`, `Countdown`, `DescriptionList`, `TableWrapper`, `ModalDialogClose`,
+  the `Sidebar*`/`Navbar*` families, …) — each would need the convention applied
+  and verified by hand.
+- **Degraded patch access.** Verbatim `.patch` fetch is egress-blocked this
+  session (WebFetch only, imprecise for a ~40-file structural diff), which makes
+  a faithful large replay error-prone.
+
+Deferring is consistent with the prior large/divergent deferral (#dfbbfeb AI SDK
+v7). It does **not** block the rest of this sync queue — the later commits are
+independent fixes/features. The data-slot convention should be a deliberate,
+separately-tested pass that applies all three strategies across b24ui's full
+(incl. fork-only) component set and lands the `DataSlot.spec.ts` guard.
+
+No `src`/docs change — bookkeeping only; ledger `decision: skip`, cursor
+advances. Tracked for a future data-slot-convention task.

--- a/.sync/nuxt-ui.json
+++ b/.sync/nuxt-ui.json
@@ -2,7 +2,7 @@
   "upstream": "nuxt/ui",
   "branch": "v4",
   "sync_enabled": false,
-  "cursor": "f5e58fb7baae38ca2cedf589af3b625b73e247f3",
+  "cursor": "c9c5232238f483f51b1be30128fa1c548a7b0329",
   "_cursor_note": "cursor = last upstream commit ported into b24ui (oldest-first, manual cadence). sync_enabled stays false until Phase 2 (porter workflow #67 + CLAUDE_CODE_OAUTH_TOKEN) is wired and trusted. `processed` is maintained per port from now on (backfilled #68-#72 on 2026-06-09).",
   "stats": {
     "queue_depth": 0,
@@ -899,10 +899,16 @@
       "summary": "fix(Link): apply rel prop to internal links (#6677) — NuxtLink strips rel from custom slot props so explicit rel on internal links was dropped. Link.vue: externalRel computed -> unified rel computed applied to every branch (noRel->null; rel!==undefined->rel||null; !isInternalLink||(target&&!=_self)->noopener noreferrer; else null); 4 rel: bindings -> rel. vue/overrides/none/Link.vue: +hasTarget computed, linkRel->rel (isExternal||hasTarget), 2 rel:linkRel->rel. vue/overrides/{inertia,vue-router}/Link.vue: +target,rel to reactiveOmit. Direct 1:1 (b24ui matched). +4 renderEach cases (internal to-object+target, internal rel, internal noRel, external rel); 8 snapshots (internal+rel now renders rel=nofollow). Tests 5285 (+8)"
     },
     "f5e58fb7baae38ca2cedf589af3b625b73e247f3": {
-      "pr": null,
-      "b24ui_sha": "pending-merge",
+      "pr": 249,
+      "b24ui_sha": "f1c90076",
       "decision": "port",
       "summary": "fix(useComponentProps): let app config defaultVariants override withDefaults (#6686) — reorder proxy priority: appConfig.b24ui.<name>.defaultVariants[prop] lookup moved ABOVE the withDefaults/raw block (early-return if defined), tail -> return undefined; jsdoc chain -> explicit>B24Theme>appConfig defaultVariants>withDefaults. Makes defaultVariants work for withDefaults-pinned props (e.g. orientation). Direct 1:1 (b24ui matched, appConfig.b24ui). +spec 'app.config defaultVariants' block (B24FormField, appConfig.b24ui.formField, orientation horizontal overrides withDefaults vertical -> data-orientation=horizontal + place-items-baseline; explicit prop still wins). Behaviour-preserving w/o appConfig set, no snapshot churn. Tests 5289 (+4)"
+    },
+    "c9c5232238f483f51b1be30128fa1c548a7b0329": {
+      "pr": null,
+      "b24ui_sha": "pending-merge",
+      "decision": "skip",
+      "summary": "fix(components): forward data-slot to component root (#6643) — SKIPPED/DEFERRED (maintainer call): broad convention across ~40 components (root data-slot=root -> :data-slot=($attrs['data-slot'] ?? 'root'); $attrs-forwarders strip data-slot; 3 strategies by attr-inheritance) + .github/contributing/component-structure.md + NEW test/components/DataSlot.spec.ts mounting ALL components (probe appears once on outermost) + ~165 snapshots. Too large/risky for b24ui: 122 components/128 root data-slots each needing the right strategy (not find/replace); the enforcing test requires 100% incl. fork-only comps (Advice/Countdown/DescriptionList/TableWrapper/ModalDialogClose/Sidebar*/Navbar*) with no upstream ref; verbatim .patch egress-blocked (WebFetch imprecise for ~40-file structural diff). Doesn't block later independent commits. Deferred like #dfbbfeb; tracked for a dedicated data-slot-convention pass. Bookkeeping only, cursor advances"
     }
   }
 }


### PR DESCRIPTION
## Upstream
[`c9c5232`](https://github.com/nuxt/ui/commit/c9c5232238f483f51b1be30128fa1c548a7b0329) — `fix(components): forward data-slot to component root (#6643)`

Establishes a convention that a **caller-supplied `data-slot` always wins on a component's root** — across ~40 components (root `data-slot="root"` → `:data-slot="($attrs['data-slot'] as string | undefined) ?? 'root'"`; `$attrs`-forwarders strip `data-slot`; **three strategies** by attr-inheritance), plus `.github/contributing/component-structure.md` and a new `test/components/DataSlot.spec.ts` that mounts **every** component and asserts the probe appears once on the outermost element. ~165 snapshots updated.

## Decision — skip / defer
Disproportionately large and risky for b24ui, not a mechanical port:
- **Scale + judgment:** b24ui has 122 components (128 root-ish `data-slot`s); each needs the *correct* one of the three strategies based on its attr-inheritance — not a find/replace.
- **The enforcing test demands 100 % coverage:** `DataSlot.spec.ts` fails if any root doesn't honour the probe, including b24ui **fork-only** components with **no upstream reference** (`Advice`, `Countdown`, `DescriptionList`, `TableWrapper`, `ModalDialogClose`, `Sidebar*`/`Navbar*`, …).
- **Degraded patch access:** verbatim `.patch` fetch is egress-blocked this session (WebFetch only, imprecise for a ~40-file structural diff).

Consistent with the AI-SDK-v7 deferral (#dfbbfeb). It **does not block** the rest of this sync queue — the later commits are independent. The convention should be a deliberate, separately-tested pass that applies all three strategies across the full component set and lands the `DataSlot.spec.ts` guard.

Bookkeeping only — ledger `decision: skip`, cursor advances; tracked for a future data-slot-convention task.
- `.sync/log/c9c5232….md` — rationale
- `.sync/nuxt-ui.json` — reconcile prior `f5e58fb` → PR #249 / `f1c90076`, add `c9c5232` as `skip`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JS8ypVfQSFzYVZzkTHhURb)_