### PR TITLE
chore(sync): no-op upstream Vue/Vite icon pre-bundling (dcf7cbc)

### DIFF
--- a/.sync/log/dcf7cbc0918dcf55ad4e93929ebe4949dd5ac17c.md
+++ b/.sync/log/dcf7cbc0918dcf55ad4e93929ebe4949dd5ac17c.md
@@ -1,0 +1,33 @@
+# Port: feat(unplugin): pre-bundle used icons into the Vue/Vite build (#6635)
+
+**Upstream:** `dcf7cbc0918dcf55ad4e93929ebe4949dd5ac17c` (nuxt/ui)
+**Decision:** no-op
+
+## Upstream change
+The Vue/Vite build-time counterpart of `8d46034` (which did the Nuxt/@nuxt/icon
+client bundle). Adds build-time icon bundling for Vue/Vite: a new
+`IconsPlugin` (`src/plugins/icons.ts`) that emits a `virtual:nuxt-ui-icons`
+module, a `runtime/vue/plugins/icons.ts` that `addIcon()`s them via
+`@iconify/vue`, `src/runtime/types/icons.d.ts`, and extends `src/utils/icons.ts`.
+`src/unplugin.ts` gains an `icon.clientBundle` option (typed from `@nuxt/icon`'s
+`ModuleOptions`) and registers `IconsPlugin`; `src/plugins/plugins.ts` unshifts
+the new `runtime/vue/plugins/icons` plugin. All of it delegates to `@nuxt/icon`
++ `@iconify/vue` + installed `@iconify-json/*` collections.
+
+## b24ui decision — no-op
+The whole commit is `@nuxt/icon`/iconify icon-bundling, which b24ui does not use
+(icons are `@bitrix24/b24icons-vue` **components**):
+- **No `@nuxt/icon` / `@iconify/vue` / `@iconify-json` deps** in b24ui.
+- b24ui has **none** of the new/icon files (`src/plugins/icons.ts`,
+  `src/utils/icons.ts`, `src/runtime/vue/plugins/icons.ts`,
+  `src/runtime/types/icons.d.ts`).
+- b24ui **does** have `src/unplugin.ts` and `src/plugins/plugins.ts`, but the
+  upstream edits there are pure icon-plugin wiring with no b24ui counterpart:
+  b24ui's `unplugin.ts` has no `@nuxt/icon` import, no `icon?` /
+  `RuntimeOptions` / `clientBundle` option and no `IconsPlugin`; its
+  `plugins.ts` registers `router`/`head` (+ `color-mode`) plugins but no icon
+  plugin.
+
+Nothing to wire or add. Same basis as the earlier `@nuxt/icon` no-ops
+(#69 `d50c121c`, #219 `ba35034b`, and the sibling #8d46034). No `src`/manifest
+change — bookkeeping only.

--- a/.sync/nuxt-ui.json
+++ b/.sync/nuxt-ui.json
@@ -2,7 +2,7 @@
   "upstream": "nuxt/ui",
   "branch": "v4",
   "sync_enabled": false,
-  "cursor": "c3b2996f181d68b2382db6aef8c429a5f0fc3d88",
+  "cursor": "dcf7cbc0918dcf55ad4e93929ebe4949dd5ac17c",
   "_cursor_note": "cursor = last upstream commit ported into b24ui (oldest-first, manual cadence). sync_enabled stays false until Phase 2 (porter workflow #67 + CLAUDE_CODE_OAUTH_TOKEN) is wired and trusted. `processed` is maintained per port from now on (backfilled #68-#72 on 2026-06-09).",
   "stats": {
     "queue_depth": 0,
@@ -917,10 +917,16 @@
       "summary": "fix(SelectMenu/InputMenu): only re-highlight first item with create-item (#6689) — the watch(()=>props.items) re-highlight also fired on infinite-scroll appends, scrolling viewport to top. Guard `if (!isOpen.value)` -> `if (!isOpen.value || !props.createItem)` + 2-line comment, in both InputMenu.vue & SelectMenu.vue. Direct 1:1 (b24ui matched). 2 files +6/-2. Runtime watch guard, no snapshot churn, no upstream test. Tests 5289 (unchanged)"
     },
     "c3b2996f181d68b2382db6aef8c429a5f0fc3d88": {
-      "pr": null,
-      "b24ui_sha": "pending-merge",
+      "pr": 252,
+      "b24ui_sha": "365b85ad",
       "decision": "port",
       "summary": "fix(FileUpload): add aria-disabled attribute when disabled (#6653) — non-button variant renders role=button div (no native disabled), so disabled dropzone wasn't announced. +:aria-disabled=\"variant==='button' ? undefined : (disabled || undefined)\" on base after :disabled. Direct 1:1 (b24ui matched). 4 snapshots updated (disabled non-button cases now carry aria-disabled=true on data-slot=base). Tests 5289"
+    },
+    "dcf7cbc0918dcf55ad4e93929ebe4949dd5ac17c": {
+      "pr": null,
+      "b24ui_sha": "pending-merge",
+      "decision": "no-op",
+      "summary": "feat(unplugin): pre-bundle used icons into the Vue/Vite build (#6635) — NO-OP: Vue/Vite sibling of 8d46034 (@nuxt/icon client bundle). New IconsPlugin (src/plugins/icons.ts) emitting virtual:nuxt-ui-icons + runtime/vue/plugins/icons.ts (@iconify/vue addIcon) + types/icons.d.ts + utils/icons.ts; unplugin.ts +icon.clientBundle option (from @nuxt/icon ModuleOptions) + registers IconsPlugin; plugins.ts unshifts icons plugin. All @nuxt/icon+@iconify+@iconify-json. b24ui uses @bitrix24/b24icons-vue components: no @nuxt/icon/@iconify deps, none of the icon files, and b24ui's unplugin.ts has no @nuxt/icon import/icon option/IconsPlugin and plugins.ts registers no icon plugin. Nothing to wire. Same basis as #69/#219/#8d46034. Bookkeeping only"
     }
   }
 }


### PR DESCRIPTION
## Upstream
[`dcf7cbc`](https://github.com/nuxt/ui/commit/dcf7cbc0918dcf55ad4e93929ebe4949dd5ac17c) — `feat(unplugin): pre-bundle used icons into the Vue/Vite build (#6635)`

The Vue/Vite build-time counterpart of `8d46034` (@nuxt/icon client bundle): a new `IconsPlugin` emitting `virtual:nuxt-ui-icons`, an `@iconify/vue` runtime plugin, and wiring in `src/unplugin.ts` (`icon.clientBundle` option) + `src/plugins/plugins.ts`. All delegates to `@nuxt/icon` + `@iconify/vue` + `@iconify-json/*`.

## Decision — no-op
b24ui renders icons via `@bitrix24/b24icons-vue` **components**, not iconify:
- No `@nuxt/icon` / `@iconify/vue` / `@iconify-json` deps.
- None of the new icon files (`src/plugins/icons.ts`, `src/utils/icons.ts`, `src/runtime/vue/plugins/icons.ts`, `src/runtime/types/icons.d.ts`).
- b24ui **has** `src/unplugin.ts` and `src/plugins/plugins.ts`, but the upstream edits are pure icon-plugin wiring with no b24ui counterpart: b24ui's `unplugin.ts` has no `@nuxt/icon` import / `icon?` option / `IconsPlugin`, and `plugins.ts` registers no icon plugin.

Nothing to wire. Same basis as the earlier `@nuxt/icon` no-ops (#69, #219, sibling #8d46034). Bookkeeping only:
- `.sync/log/dcf7cbc….md` — rationale
- `.sync/nuxt-ui.json` — reconcile prior `c3b2996` → PR #252 / `365b85ad`, add `dcf7cbc` as `no-op`, advance cursor

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JS8ypVfQSFzYVZzkTHhURb)_