### PR TITLE
test(ChatPrompt): avoid using fake timers before suspended

### DIFF
--- a/.sync/log/d0581cf88fa13008871484e5f88fdb0f9f744ff7.md
+++ b/.sync/log/d0581cf88fa13008871484e5f88fdb0f9f744ff7.md
@@ -1,0 +1,24 @@
+# Port: test(ChatPrompt): avoid using fake timers before suspended (#6688)
+
+**Upstream:** `d0581cf88fa13008871484e5f88fdb0f9f744ff7` (nuxt/ui)
+**Decision:** port
+
+## Upstream change
+Test-only: in `ChatPrompt.spec.ts`'s `re-enables submit after compositionend
+cooldown` case, move `vi.useFakeTimers()` from **before** `mountSuspended()` to
+**after** it, so the fake timers don't interfere with the async suspension
+lifecycle.
+
+## b24ui port — direct 1:1
+b24ui's `test/components/ChatPrompt.spec.ts` matched upstream exactly. Moved the
+`vi.useFakeTimers()` call to right after the `mountSuspended(ChatPrompt, …)`
+block (dropping the now-empty blank line before the mount). Test-only, no `src`
+change.
+
+## Tests
+`ChatPrompt` suite green (62). Full suite unchanged (5289 passed / 6 skipped).
+No snapshot churn.
+
+## Verify (CI=true)
+`dev:prepare` · `lint` · `test` — green. (`typecheck`/`build` unaffected — no
+`src` change.)

--- a/.sync/nuxt-ui.json
+++ b/.sync/nuxt-ui.json
@@ -2,7 +2,7 @@
   "upstream": "nuxt/ui",
   "branch": "v4",
   "sync_enabled": false,
-  "cursor": "dcf7cbc0918dcf55ad4e93929ebe4949dd5ac17c",
+  "cursor": "d0581cf88fa13008871484e5f88fdb0f9f744ff7",
   "_cursor_note": "cursor = last upstream commit ported into b24ui (oldest-first, manual cadence). sync_enabled stays false until Phase 2 (porter workflow #67 + CLAUDE_CODE_OAUTH_TOKEN) is wired and trusted. `processed` is maintained per port from now on (backfilled #68-#72 on 2026-06-09).",
   "stats": {
     "queue_depth": 0,
@@ -923,10 +923,16 @@
       "summary": "fix(FileUpload): add aria-disabled attribute when disabled (#6653) — non-button variant renders role=button div (no native disabled), so disabled dropzone wasn't announced. +:aria-disabled=\"variant==='button' ? undefined : (disabled || undefined)\" on base after :disabled. Direct 1:1 (b24ui matched). 4 snapshots updated (disabled non-button cases now carry aria-disabled=true on data-slot=base). Tests 5289"
     },
     "dcf7cbc0918dcf55ad4e93929ebe4949dd5ac17c": {
-      "pr": null,
-      "b24ui_sha": "pending-merge",
+      "pr": 253,
+      "b24ui_sha": "b13858d3",
       "decision": "no-op",
       "summary": "feat(unplugin): pre-bundle used icons into the Vue/Vite build (#6635) — NO-OP: Vue/Vite sibling of 8d46034 (@nuxt/icon client bundle). New IconsPlugin (src/plugins/icons.ts) emitting virtual:nuxt-ui-icons + runtime/vue/plugins/icons.ts (@iconify/vue addIcon) + types/icons.d.ts + utils/icons.ts; unplugin.ts +icon.clientBundle option (from @nuxt/icon ModuleOptions) + registers IconsPlugin; plugins.ts unshifts icons plugin. All @nuxt/icon+@iconify+@iconify-json. b24ui uses @bitrix24/b24icons-vue components: no @nuxt/icon/@iconify deps, none of the icon files, and b24ui's unplugin.ts has no @nuxt/icon import/icon option/IconsPlugin and plugins.ts registers no icon plugin. Nothing to wire. Same basis as #69/#219/#8d46034. Bookkeeping only"
+    },
+    "d0581cf88fa13008871484e5f88fdb0f9f744ff7": {
+      "pr": null,
+      "b24ui_sha": "pending-merge",
+      "decision": "port",
+      "summary": "test(ChatPrompt): avoid using fake timers before suspended (#6688) — test-only: move vi.useFakeTimers() from before mountSuspended() to after it in the 're-enables submit after compositionend cooldown' case so fake timers don't interfere with the async suspension lifecycle. Direct 1:1 (b24ui matched). No src change, no snapshot churn. Tests 5289"
     }
   }
 }

--- a/test/components/ChatPrompt.spec.ts
+++ b/test/components/ChatPrompt.spec.ts
@@ -56,12 +56,11 @@ describe('ChatPrompt', () => {
   })
 
   it('re-enables submit after compositionend cooldown', async () => {
-    vi.useFakeTimers()
-
     const wrapper = await mountSuspended(ChatPrompt, {
       props: { modelValue: 'Hello' }
     })
 
+    vi.useFakeTimers()
     const textarea = wrapper.find('textarea')
     await textarea.trigger('compositionend')
     vi.advanceTimersByTime(50)


### PR DESCRIPTION
## Upstream
[`d0581cf`](https://github.com/nuxt/ui/commit/d0581cf88fa13008871484e5f88fdb0f9f744ff7) — `test(ChatPrompt): avoid using fake timers before suspended (#6688)`

## Change — direct 1:1 (test-only)
In `ChatPrompt.spec.ts`'s `re-enables submit after compositionend cooldown` case, move `vi.useFakeTimers()` from **before** `mountSuspended()` to **after** it, so the fake timers don't interfere with the async suspension lifecycle. b24ui matched upstream.

## Tests
`ChatPrompt` suite green (62). Full suite unchanged (5289 passed / 6 skipped). No snapshot churn.

## Verify (CI=true)
`dev:prepare` · `lint` · `test` — green (no `src` change).

## Ledger
- `.sync/log/d0581cf….md` — port rationale
- `.sync/nuxt-ui.json` — add `d0581cf` as `port`, advance cursor; reconcile prior `dcf7cbc` → PR #253 / `b13858d3`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JS8ypVfQSFzYVZzkTHhURb)_