### PR TITLE
feat(ChatTool): add actions prop for tool approval

### DIFF
--- a/.sync/log/1a3a9dc35b6a4e7a3aea57d93532b155de51c0ec.md
+++ b/.sync/log/1a3a9dc35b6a4e7a3aea57d93532b155de51c0ec.md
@@ -1,0 +1,62 @@
+# Port: feat(ChatTool): add `actions` prop for tool approval (#6699)
+
+**Upstream:** `1a3a9dc35b6a4e7a3aea57d93532b155de51c0ec` (nuxt/ui)
+**Decision:** port (partial — component feature only; v7 tool-approval flow deferred)
+
+## Upstream change
+`ChatTool` gains an `actions` prop (`ButtonProps[]`) that renders a row of
+buttons below the trigger, plus an `actions` slot. The block auto-opens once
+when actions first appear (uncontrolled only, respecting an explicit
+`defaultOpen`) so the content is visible while the user decides. Theme gains an
+`actions` slot with `inline`/`card` variants, and the `chevron.leading` /
+`alone.false` leading-icon hover-swap is refactored so `group-hover:opacity-0`
+only applies when the icon overlaps the chevron (`alone: false`). `ai.ts` gains
+`isToolApprovalPending()` and treats `approval-requested` as a paused
+(non-streaming) tool state. The feature exists to drive tool-approval flows.
+
+## b24ui port — component feature ported, v7 flow deferred
+The `actions` prop is a plain list of buttons — it does **not** import from
+`ai`/`@ai-sdk/*`. Ported to b24ui with fork naming (`B24Button`,
+`IconComponent`, `b24ui`, `--leftmenu-group-stroke` for the card border):
+
+- `src/runtime/components/ChatTool.vue` — `actions?: ButtonProps[]` prop, `actions`
+  slot, the auto-open `watch` (verbatim; b24ui already uses `internalOpen` +
+  `props.open === undefined`), and the template actions block.
+- `src/theme/chat-tool.ts` — `actions` slot + `inline`/`card` classes;
+  `chevron.leading` → `''`; moved `group-hover:opacity-0` into
+  `alone.false.leadingIcon`.
+- `src/runtime/utils/ai.ts` — `isToolApprovalPending()` + `isToolStreaming`
+  treating `approval-requested` as paused. These are pure string-state helpers;
+  harmless on b24ui's AI-SDK v6 line (the state simply never occurs).
+- `docs/.../ComponentCode.vue` — trim string slots (benign general docs fix).
+- `docs/.../chat-tool.md` — added the **Actions** section (adapted: b24ui icon
+  cast + `air-secondary` color instead of `neutral`/`soft`).
+- `playgrounds/{nuxt,demo}/.../chat-tool.vue` — added the actions demo (kept
+  nuxt↔demo parity).
+- `test/components/ChatTool.spec.ts` — ported the new render cases + the
+  auto-open / onClick / no-actions unit tests (b24ui colors, `SignIcon`).
+
+### Deferred — tool-approval flow (AI SDK v7)
+Upstream's `docs/content/docs/2.components/chat.md`, `playgrounds/nuxt/app/pages/chat.vue`,
+`playgrounds/nuxt/server/api/chat.post.ts` and the new
+`ChatToolApprovalExample.vue` wire the actions to the **v7** tool-approval API
+(`toolApproval`, `addToolApprovalResponse`,
+`lastAssistantMessageIsCompleteWithApprovalResponses`, `approval-requested`).
+b24ui is on the deferred AI-SDK **v6** line (see `dfbbfeb`), so these are not
+ported — only the version-agnostic component/theme/util feature is.
+
+### Deviation — `src/theme/chat-message.ts` skipped
+Upstream added `body: 'w-full'` to the `naked`+`side:left` compound variant.
+b24ui's chat-message theme has no `naked` variant (its variants are
+`message`/`event`/`system` with their own width handling), so the tweak has no
+applicable target and was not ported.
+
+## Tests
+New ChatTool render cases + 5 unit tests (auto-open ×3, onClick, no-actions).
+40 ChatTool snapshots written/updated: 10 new (actions cases) + existing
+`chevron leading` cases reflecting the benign hover-swap refactor (icon-alone no
+longer fades; icon+chevron fades on hover as before). Suite 5309 passed / 6
+skipped (was 5289).
+
+## Verify (CI=true)
+`dev:prepare` · `lint` · `typecheck` · `test` · `build` — all green.

--- a/.sync/nuxt-ui.json
+++ b/.sync/nuxt-ui.json
@@ -2,7 +2,7 @@
   "upstream": "nuxt/ui",
   "branch": "v4",
   "sync_enabled": false,
-  "cursor": "c256997f33b44324d43b212bae6b2be2de83b42c",
+  "cursor": "1a3a9dc35b6a4e7a3aea57d93532b155de51c0ec",
   "_cursor_note": "cursor = last upstream commit ported into b24ui (oldest-first, manual cadence). sync_enabled stays false until Phase 2 (porter workflow #67 + CLAUDE_CODE_OAUTH_TOKEN) is wired and trusted. `processed` is maintained per port from now on (backfilled #68-#72 on 2026-06-09).",
   "stats": {
     "queue_depth": 0,
@@ -941,10 +941,16 @@
       "summary": "feat(Prompt): add claude action (#6693) — prose/Prompt.vue: +claude action; copy now always shown (default actions->[], +computed actions=[...new Set(['copy',...props.actions])]); +openInClaude (claude://code/new?q=), openIn* condensed to encodeURIComponent one-liners; template v-if props.actions->actions computed + Claude B24Button. Docs prompt.md updated (copy always; example cursor+claude). Adapted (b24ui naming). DEVIATION: upstream icon=i-simple-icons-claude (iconify); b24ui has no @nuxt/icon/Claude b24icon, so added inline ClaudeIcon SVG to dictionary/icons.ts (simple-icons claude path, verbatim) mirroring existing CursorIcon/WindsurfIcon; button color air-secondary-accent-2. 14 ProsePrompt snapshots (benign: claude v-if placeholder + copy always via computed). Tests 5289"
     },
     "c256997f33b44324d43b212bae6b2be2de83b42c": {
+      "pr": 256,
+      "b24ui_sha": "cde06e9c25f547cb3839226b1501e87fc6ab4690",
+      "decision": "port",
+      "summary": "fix(inertia): make useRoute().fullPath reactive across navigations (#6696) — inertia useRoute stub returned fullPath: page.url (captured once, stale across navigations). Change to getter get fullPath() { return page.url }. b24ui: src/runtime/vue/stubs/inertia.ts matched, applied verbatim. Direct 1:1. Runtime stub, no snapshot churn. Tests 5289"
+    },
+    "1a3a9dc35b6a4e7a3aea57d93532b155de51c0ec": {
       "pr": null,
       "b24ui_sha": "pending-merge",
       "decision": "port",
-      "summary": "fix(inertia): make useRoute().fullPath reactive across navigations (#6696) — inertia useRoute stub returned fullPath: page.url (captured once, stale across navigations). Change to getter get fullPath() { return page.url }. b24ui: src/runtime/vue/stubs/inertia.ts matched, applied verbatim. Direct 1:1. Runtime stub, no snapshot churn. Tests 5289"
+      "summary": "feat(ChatTool): add actions prop for tool approval (#6699) — ChatTool gains actions?: ButtonProps[] rendering a button row below the trigger + actions slot, auto-opens once when actions appear (uncontrolled, respects defaultOpen). Theme: actions slot (inline/card), chevron.leading->'' with group-hover:opacity-0 moved into alone.false.leadingIcon. ai.ts: isToolApprovalPending() + isToolStreaming treats approval-requested as paused (pure string helpers, harmless on v6). Ported component/theme/util/docs/playgrounds/tests. DEFERRED the v7 tool-approval flow (chat.md, chat.vue, chat.post.ts, ChatToolApprovalExample.vue — toolApproval/addToolApprovalResponse). Skipped chat-message.ts body:w-full (b24ui has no naked variant). Tests 5309."
     }
   }
 }

--- a/docs/app/components/content/ComponentCode.vue
+++ b/docs/app/components/content/ComponentCode.vue
@@ -599,7 +599,7 @@ const { data: ast } = useAsyncData(codeKey, async () => {
         <component :is="component" v-bind="{ ...componentProps, ...componentEvents }">
           <template v-for="slot in Object.keys(slots || {})" :key="slot" #[slot]>
             <slot :name="slot" mdc-unwrap="p">
-              {{ slots?.[slot] }}
+              {{ typeof slots?.[slot] === 'string' ? slots[slot].trim() : slots?.[slot] }}
             </slot>
           </template>
         </component>

--- a/docs/content/docs/2.components/chat-tool.md
+++ b/docs/content/docs/2.components/chat-tool.md
@@ -261,6 +261,38 @@ slots:
 ---
 ::
 
+### Actions
+
+Use the `actions` prop to display a list of [Button](/docs/components/button/) below the trigger, useful for tools that require a user confirmation before running.
+
+::component-code
+---
+prettier: true
+hide:
+  - class
+ignore:
+  - text
+  - icon
+  - variant
+  - actions
+cast:
+  icon: 'RocketIcon'
+props:
+  actions:
+    - label: 'Approve'
+    - label: 'Deny'
+      color: air-secondary
+  text: 'Run terminal command'
+  variant: card
+  icon: 'RocketIcon'
+  class: 'w-60'
+slots:
+  default: |
+
+    $ pnpm run lint
+---
+::
+
 ## Examples
 
 ::tip{to="/docs/components/chat/"}

--- a/playgrounds/demo/app/pages/components/chat-tool.vue
+++ b/playgrounds/demo/app/pages/components/chat-tool.vue
@@ -1,9 +1,15 @@
 <script setup lang="ts">
+import type { ButtonProps } from '@bitrix24/b24ui-nuxt'
 import SearchIcon from '@bitrix24/b24icons-vue/outline/SearchIcon'
 import AiStarsQuestionIcon from '@bitrix24/b24icons-vue/outline/AiStarsQuestionIcon'
 import AiProcessIcon from '@bitrix24/b24icons-vue/outline/AiProcessIcon'
 import AiInternetSearchIcon from '@bitrix24/b24icons-vue/outline/AiInternetSearchIcon'
 import AiReflectionIcon from '@bitrix24/b24icons-vue/outline/AiReflectionIcon'
+
+const actions: ButtonProps[] = [
+  { label: 'Approve', onClick: () => console.log('approve') },
+  { label: 'Deny', color: 'air-secondary', onClick: () => console.log('deny') }
+]
 </script>
 
 <template>
@@ -61,6 +67,18 @@ import AiReflectionIcon from '@bitrix24/b24icons-vue/outline/AiReflectionIcon'
         class="w-full"
       >
         Found 5 matching components.
+      </B24ChatTool>
+
+      <B24ChatTool
+        text="Run terminal command"
+        suffix="pnpm run lint"
+        :icon="AiProcessIcon"
+        variant="card"
+        chevron="leading"
+        class="w-full"
+        :actions="actions"
+      >
+        <pre class="whitespace-pre-wrap">$ pnpm run lint</pre>
       </B24ChatTool>
     </div>
   </PlaygroundPage>

--- a/playgrounds/nuxt/app/pages/components/chat-tool.vue
+++ b/playgrounds/nuxt/app/pages/components/chat-tool.vue
@@ -1,9 +1,15 @@
 <script setup lang="ts">
+import type { ButtonProps } from '@bitrix24/b24ui-nuxt'
 import SearchIcon from '@bitrix24/b24icons-vue/outline/SearchIcon'
 import AiStarsQuestionIcon from '@bitrix24/b24icons-vue/outline/AiStarsQuestionIcon'
 import AiProcessIcon from '@bitrix24/b24icons-vue/outline/AiProcessIcon'
 import AiInternetSearchIcon from '@bitrix24/b24icons-vue/outline/AiInternetSearchIcon'
 import AiReflectionIcon from '@bitrix24/b24icons-vue/outline/AiReflectionIcon'
+
+const actions: ButtonProps[] = [
+  { label: 'Approve', onClick: () => console.log('approve') },
+  { label: 'Deny', color: 'air-secondary', onClick: () => console.log('deny') }
+]
 </script>
 
 <template>
@@ -61,6 +67,18 @@ import AiReflectionIcon from '@bitrix24/b24icons-vue/outline/AiReflectionIcon'
         class="w-full"
       >
         Found 5 matching components.
+      </B24ChatTool>
+
+      <B24ChatTool
+        text="Run terminal command"
+        suffix="pnpm run lint"
+        :icon="AiProcessIcon"
+        variant="card"
+        chevron="leading"
+        class="w-full"
+        :actions="actions"
+      >
+        <pre class="whitespace-pre-wrap">$ pnpm run lint</pre>
       </B24ChatTool>
     </div>
   </PlaygroundPage>

--- a/src/runtime/components/ChatTool.vue
+++ b/src/runtime/components/ChatTool.vue
@@ -4,6 +4,7 @@ import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/b24ui/chat-tool'
 import type { IconComponent } from '../types/icons'
+import type { ButtonProps } from './Button.vue'
 import type { ChatShimmerProps } from './ChatShimmer.vue'
 import type { ComponentConfig } from '../types/tv'
 
@@ -69,6 +70,11 @@ export interface ChatToolProps extends Pick<CollapsibleRootProps, 'defaultOpen' 
    * Customize the [`ChatShimmer`](https://bitrix24.github.io/b24ui/docs/components/chat-shimmer/) component when streaming.
    */
   shimmer?: Partial<Omit<ChatShimmerProps, 'text'>>
+  /**
+   * Display a list of actions below the trigger, useful for tool approval flows.
+   * `{ size: 'xs' }`{lang="ts-type"}
+   */
+  actions?: ButtonProps[]
   class?: any
   b24ui?: ChatTool['slots']
 }
@@ -79,16 +85,18 @@ export interface ChatToolEmits {
 
 export interface ChatToolSlots {
   default?(props: { open: boolean }): VNode[]
+  actions?(props?: {}): VNode[]
 }
 </script>
 
 <script setup lang="ts">
-import { ref, computed } from 'vue'
+import { ref, computed, watch } from 'vue'
 import { CollapsibleRoot, CollapsibleTrigger, CollapsibleContent } from 'reka-ui'
 import { useAppConfig } from '#imports'
 import { useComponentProps } from '../composables/useComponentProps'
 import { tv } from '../utils/tv'
 import icons from '../dictionary/icons'
+import B24Button from './Button.vue'
 import B24ChatShimmer from './ChatShimmer.vue'
 import LoaderWaitIcon from '@bitrix24/b24icons-vue/animated/LoaderWaitIcon'
 import LoaderClockIcon from '@bitrix24/b24icons-vue/animated/LoaderClockIcon'
@@ -128,6 +136,15 @@ function setOpen(value: boolean) {
 }
 
 const hasContent = computed(() => !!slots.default)
+
+// Auto-open when actions first appear (e.g. a pending tool approval) so the content
+// is visible while the user decides. Uncontrolled only, respects an explicit `defaultOpen`,
+// and fires once so the user can still collapse it.
+watch(() => !!props.actions?.length, (hasActions) => {
+  if (hasActions && hasContent.value && props.open === undefined && props.defaultOpen === undefined) {
+    internalOpen.value = true
+  }
+}, { immediate: true })
 
 const resolvedLoadingIcon = computed(() => {
   if (props.loadingIcon) return props.loadingIcon
@@ -191,5 +208,16 @@ const chevronIconName = computed(() => props.chevronIcon || icons.chevronDown)
         <slot :open="isOpen" />
       </div>
     </CollapsibleContent>
+
+    <div
+      v-if="props.actions?.length || !!slots.actions"
+      data-slot="actions"
+      :data-state="hasContent && isOpen ? 'open' : 'closed'"
+      :class="b24ui.actions({ class: props.b24ui?.actions })"
+    >
+      <slot name="actions">
+        <B24Button v-for="(action, index) in props.actions" :key="index" size="xs" v-bind="action" />
+      </slot>
+    </div>
   </CollapsibleRoot>
 </template>

--- a/src/runtime/utils/ai.ts
+++ b/src/runtime/utils/ai.ts
@@ -22,12 +22,21 @@ export function isPartStreaming(part: { state?: string }): boolean {
 }
 
 /**
- * Checks if a tool part is still streaming (hasn't reached a terminal state).
+ * Checks if a tool part is still streaming (hasn't reached a terminal state
+ * and isn't paused waiting for a user approval).
  *
- * Terminal states are `output-available`, `output-error`, and `output-denied`.
+ * Terminal states are `output-available`, `output-error`, and `output-denied`,
+ * `approval-requested` is a paused state.
  */
 export function isToolStreaming(part: { state: string }): boolean {
-  return !['output-available', 'output-error', 'output-denied'].includes(part.state)
+  return !['approval-requested', 'output-available', 'output-error', 'output-denied'].includes(part.state)
+}
+
+/**
+ * Checks if a tool part is waiting for a user approval response.
+ */
+export function isToolApprovalPending(part: { state: string }): boolean {
+  return part.state === 'approval-requested'
 }
 
 /**

--- a/src/theme/chat-tool.ts
+++ b/src/theme/chat-tool.ts
@@ -29,24 +29,25 @@ export default {
     suffix: 'text-dimmed ms-1',
     trailingIcon: 'size-4 shrink-0 group-data-[state=open]:rotate-180 transition-transform duration-200',
     content: 'motion-safe:data-[state=open]:animate-[collapsible-down_200ms_ease-out] motion-safe:data-[state=closed]:animate-[collapsible-up_200ms_ease-out] overflow-hidden',
-    body: 'text-sm text-dimmed whitespace-pre-wrap'
+    body: 'text-sm text-dimmed whitespace-pre-wrap',
+    actions: 'flex items-center justify-end gap-1.5'
   },
   variants: {
     variant: {
       inline: {
-        body: 'pt-2'
+        body: 'pt-2',
+        actions: 'pt-2'
       },
       card: {
         root: 'light:[--leftmenu-group-stroke:var(--ui-color-base-30)] rounded-md ring ring-(--leftmenu-group-stroke) overflow-hidden',
         trigger: 'px-2 py-1',
         trailingIcon: 'ms-auto',
-        body: 'border-t border-(--leftmenu-group-stroke) p-2 max-h-[200px] overflow-y-auto'
+        body: 'border-t border-(--leftmenu-group-stroke) p-2 max-h-[200px] overflow-y-auto',
+        actions: 'border-t border-(--leftmenu-group-stroke) p-2'
       }
     },
     chevron: {
-      leading: {
-        leadingIcon: 'group-hover:opacity-0'
-      },
+      leading: '',
       trailing: ''
     },
     useWait: {
@@ -62,7 +63,7 @@ export default {
     alone: {
       false: {
         leadingIcon: [
-          'absolute inset-0 group-data-[state=open]:opacity-0',
+          'absolute inset-0 group-hover:opacity-0 group-data-[state=open]:opacity-0',
           'transition-opacity duration-200'
         ].join(' '),
         chevronIcon: [

--- a/test/components/ChatTool.spec.ts
+++ b/test/components/ChatTool.spec.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
 import { axe } from 'vitest-axe'
 import { mountSuspended } from '@nuxt/test-utils/runtime'
 import ChatTool from '../../src/runtime/components/ChatTool.vue'
@@ -24,12 +24,62 @@ describe('ChatTool', () => {
     ['with defaultOpen', { props: { ...props, defaultOpen: true } }],
     ['with chevron leading', { props: { ...props, chevron: 'leading' } }],
     ['with chevron leading and icon', { props: { ...props, chevron: 'leading', icon: SignIcon } }],
+    ['with chevron leading, icon and content', { props: { ...props, chevron: 'leading', icon: SignIcon }, slots: { default: () => 'Tool output content' } }],
     ['with chevronIcon', { props: { ...props, chevronIcon: Cross30Icon } }],
     ['with class', { props: { ...props, class: 'my-5' } }],
     ['with b24ui', { props: { ...props, b24ui: { body: 'text-muted' } } }],
+    ['with actions', { props: { ...props, actions: [{ label: 'Approve' }, { label: 'Deny', color: 'air-secondary' as const }] } }],
+    ['with actions variant card', { props: { ...props, variant: 'card' as const, actions: [{ label: 'Approve' }, { label: 'Deny' }] } }],
+    ['with actions and content', { props: { ...props, actions: [{ label: 'Approve' }, { label: 'Deny' }] }, slots: { default: () => 'Tool output content' } }],
     // Slots
-    ['with default slot', { props, slots: { default: () => 'Tool output content' } }]
+    ['with default slot', { props, slots: { default: () => 'Tool output content' } }],
+    ['with actions slot', { props, slots: { actions: () => 'Custom actions' } }]
   ])
+
+  it('auto-opens when actions and content are present', async () => {
+    const wrapper = await mountSuspended(ChatTool, {
+      props: { ...props, actions: [{ label: 'Approve' }] },
+      slots: { default: () => 'Tool output content' }
+    })
+
+    expect(wrapper.find('[data-slot="root"]').attributes('data-state')).toBe('open')
+  })
+
+  it('does not auto-open when there is no content', async () => {
+    const wrapper = await mountSuspended(ChatTool, {
+      props: { ...props, actions: [{ label: 'Approve' }] }
+    })
+
+    expect(wrapper.find('[data-slot="root"]').attributes('data-state')).toBe('closed')
+  })
+
+  it('does not auto-open when defaultOpen is explicitly set', async () => {
+    const wrapper = await mountSuspended(ChatTool, {
+      props: { ...props, actions: [{ label: 'Approve' }], defaultOpen: false },
+      slots: { default: () => 'Tool output content' }
+    })
+
+    expect(wrapper.find('[data-slot="root"]').attributes('data-state')).toBe('closed')
+  })
+
+  it('calls the action onClick when the action button is clicked', async () => {
+    const onClick = vi.fn()
+    const wrapper = await mountSuspended(ChatTool, {
+      props: { ...props, actions: [{ label: 'Approve', onClick }] }
+    })
+
+    await wrapper.find('[data-slot="actions"] button').trigger('click')
+
+    expect(onClick).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not render the actions without actions', async () => {
+    const wrapper = await mountSuspended(ChatTool, {
+      props
+    })
+
+    expect(wrapper.find('[data-slot="actions"]').exists()).toBe(false)
+  })
 
   it('passes accessibility tests', async () => {
     const wrapper = await mountSuspended(ChatTool, {

--- a/test/components/__snapshots__/ChatTool-vue.spec.ts.snap
+++ b/test/components/__snapshots__/ChatTool-vue.spec.ts.snap
@@ -1,5 +1,90 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`ChatTool > renders with actions and content correctly 1`] = `
+"<div data-state="open" data-slot="root" class=""><button type="button" aria-controls="" aria-expanded="true" data-state="open" data-slot="trigger" class="group w-full min-w-0 flex items-center gap-1.5 text-muted text-sm disabled:cursor-default disabled:hover:text-muted hover:text-default focus-visible:outline-offset-2 focus-visible:outline-primary transition-colors">
+    <!--v-if--><span data-slot="label" class="truncate">Searching components<!--v-if--></span><svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" aria-hidden="true" data-slot="icon" class="size-4 shrink-0 group-data-[state=open]:rotate-180 transition-transform duration-200">
+      <path fill="currentColor" fill-rule="evenodd" d="M5.505 9.505a.7.7 0 0 1 .99 0L12 15.01l5.505-5.505a.7.7 0 0 1 .99.99l-6 6a.7.7 0 0 1-.99 0l-6-6a.7.7 0 0 1 0-.99" clip-rule="evenodd"></path>
+    </svg>
+  </button>
+  <div data-slot="content" class="motion-safe:data-[state=open]:animate-[collapsible-down_200ms_ease-out] motion-safe:data-[state=closed]:animate-[collapsible-up_200ms_ease-out] overflow-hidden" id="reka-collapsible-content-v-0" style="--reka-collapsible-content-height: 0px; --reka-collapsible-content-width: 0px; transition-duration: 0s; animation-name: none;">
+    <div data-slot="body" class="text-sm text-dimmed whitespace-pre-wrap pt-2">Tool output content</div>
+  </div>
+  <div data-slot="actions" data-state="open" class="flex items-center justify-end gap-1.5 pt-2"><button type="button" data-slot="base" class="ui-btn font-[family-name:var(--ui-font-family-primary)] select-none cursor-pointer inline-flex items-center relative outline-transparent focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed aria-disabled:cursor-not-allowed disabled:opacity-30 aria-disabled:opacity-30 transition duration-0 ease-linear border-(length:--ui-btn-border-width) text-(--ui-btn-color) bg-(--ui-btn-background) border-(--ui-btn-border-color) hover:text-(--ui-btn-color-hover) hover:bg-(--ui-btn-background-hover) hover:border-(--ui-btn-border-color-hover) focus:text-(--ui-btn-color-hover) focus:bg-(--ui-btn-background-hover) focus:border-(--ui-btn-border-color-hover) active:text-(--ui-btn-color-active) active:bg-(--ui-btn-background-active) active:border-(--ui-btn-border-color-active) disabled:bg-(--ui-btn-background) disabled:border-(--ui-btn-border-color) aria-disabled:bg-(--ui-btn-background) aria-disabled:border-(--ui-btn-border-color) focus-visible:outline-(--ui-btn-background) ring-(--ui-btn-background-hover) focus:outline-none focus-visible:ring-(--ui-btn-background-hover) h-(--ui-btn-height) text-(length:--ui-btn-font-size) leading-(--ui-btn-height) font-(--ui-btn-font-weight) --style-outline-no-accent ui-btn-xs rounded-(--ui-btn-radius) normal-case --air">
+      <!--v-if-->
+      <div data-slot="baseLine" class="w-full inline-flex items-center justify-center gap-(--ui-btn-icon-space) ps-(--ui-btn-padding-left) pe-(--ui-btn-padding-right) h-(--ui-btn-height)">
+        <!--v-if--><span data-slot="label" class="h-(--ui-btn-height) max-w-full inline-flex flex-row items-center tracking-(--ui-btn-letter-spacing) overflow-visible text-clip"><span data-slot="labelInner" class="truncate inline-block max-w-full mt-(--ui-btn-title-compensation)">Approve</span></span>
+        <!--v-if-->
+      </div>
+    </button><button type="button" data-slot="base" class="ui-btn font-[family-name:var(--ui-font-family-primary)] select-none cursor-pointer inline-flex items-center relative outline-transparent focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed aria-disabled:cursor-not-allowed disabled:opacity-30 aria-disabled:opacity-30 transition duration-0 ease-linear border-(length:--ui-btn-border-width) text-(--ui-btn-color) bg-(--ui-btn-background) border-(--ui-btn-border-color) hover:text-(--ui-btn-color-hover) hover:bg-(--ui-btn-background-hover) hover:border-(--ui-btn-border-color-hover) focus:text-(--ui-btn-color-hover) focus:bg-(--ui-btn-background-hover) focus:border-(--ui-btn-border-color-hover) active:text-(--ui-btn-color-active) active:bg-(--ui-btn-background-active) active:border-(--ui-btn-border-color-active) disabled:bg-(--ui-btn-background) disabled:border-(--ui-btn-border-color) aria-disabled:bg-(--ui-btn-background) aria-disabled:border-(--ui-btn-border-color) focus-visible:outline-(--ui-btn-background) ring-(--ui-btn-background-hover) focus:outline-none focus-visible:ring-(--ui-btn-background-hover) h-(--ui-btn-height) text-(length:--ui-btn-font-size) leading-(--ui-btn-height) font-(--ui-btn-font-weight) --style-outline-no-accent ui-btn-xs rounded-(--ui-btn-radius) normal-case --air">
+      <!--v-if-->
+      <div data-slot="baseLine" class="w-full inline-flex items-center justify-center gap-(--ui-btn-icon-space) ps-(--ui-btn-padding-left) pe-(--ui-btn-padding-right) h-(--ui-btn-height)">
+        <!--v-if--><span data-slot="label" class="h-(--ui-btn-height) max-w-full inline-flex flex-row items-center tracking-(--ui-btn-letter-spacing) overflow-visible text-clip"><span data-slot="labelInner" class="truncate inline-block max-w-full mt-(--ui-btn-title-compensation)">Deny</span></span>
+        <!--v-if-->
+      </div>
+    </button></div>
+</div>"
+`;
+
+exports[`ChatTool > renders with actions correctly 1`] = `
+"<div data-state="closed" data-slot="root" class=""><button type="button" aria-controls="" aria-expanded="false" data-state="closed" disabled="" data-slot="trigger" class="group w-full min-w-0 flex items-center gap-1.5 text-muted text-sm disabled:cursor-default disabled:hover:text-muted hover:text-default focus-visible:outline-offset-2 focus-visible:outline-primary transition-colors">
+    <!--v-if--><span data-slot="label" class="truncate">Searching components<!--v-if--></span>
+    <!--v-if-->
+  </button>
+  <div data-slot="content" class="motion-safe:data-[state=open]:animate-[collapsible-down_200ms_ease-out] motion-safe:data-[state=closed]:animate-[collapsible-up_200ms_ease-out] overflow-hidden" id="reka-collapsible-content-v-0" hidden="" data-state="closed" style="--reka-collapsible-content-height: 0px; --reka-collapsible-content-width: 0px;">
+    <div data-slot="body" class="text-sm text-dimmed whitespace-pre-wrap pt-2"></div>
+  </div>
+  <div data-slot="actions" data-state="closed" class="flex items-center justify-end gap-1.5 pt-2"><button type="button" data-slot="base" class="ui-btn font-[family-name:var(--ui-font-family-primary)] select-none cursor-pointer inline-flex items-center relative outline-transparent focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed aria-disabled:cursor-not-allowed disabled:opacity-30 aria-disabled:opacity-30 transition duration-0 ease-linear border-(length:--ui-btn-border-width) text-(--ui-btn-color) bg-(--ui-btn-background) border-(--ui-btn-border-color) hover:text-(--ui-btn-color-hover) hover:bg-(--ui-btn-background-hover) hover:border-(--ui-btn-border-color-hover) focus:text-(--ui-btn-color-hover) focus:bg-(--ui-btn-background-hover) focus:border-(--ui-btn-border-color-hover) active:text-(--ui-btn-color-active) active:bg-(--ui-btn-background-active) active:border-(--ui-btn-border-color-active) disabled:bg-(--ui-btn-background) disabled:border-(--ui-btn-border-color) aria-disabled:bg-(--ui-btn-background) aria-disabled:border-(--ui-btn-border-color) focus-visible:outline-(--ui-btn-background) ring-(--ui-btn-background-hover) focus:outline-none focus-visible:ring-(--ui-btn-background-hover) h-(--ui-btn-height) text-(length:--ui-btn-font-size) leading-(--ui-btn-height) font-(--ui-btn-font-weight) --style-outline-no-accent ui-btn-xs rounded-(--ui-btn-radius) normal-case --air">
+      <!--v-if-->
+      <div data-slot="baseLine" class="w-full inline-flex items-center justify-center gap-(--ui-btn-icon-space) ps-(--ui-btn-padding-left) pe-(--ui-btn-padding-right) h-(--ui-btn-height)">
+        <!--v-if--><span data-slot="label" class="h-(--ui-btn-height) max-w-full inline-flex flex-row items-center tracking-(--ui-btn-letter-spacing) overflow-visible text-clip"><span data-slot="labelInner" class="truncate inline-block max-w-full mt-(--ui-btn-title-compensation)">Approve</span></span>
+        <!--v-if-->
+      </div>
+    </button><button type="button" data-slot="base" class="ui-btn font-[family-name:var(--ui-font-family-primary)] select-none cursor-pointer inline-flex items-center relative outline-transparent focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed aria-disabled:cursor-not-allowed disabled:opacity-30 aria-disabled:opacity-30 transition duration-0 ease-linear border-(length:--ui-btn-border-width) text-(--ui-btn-color) bg-(--ui-btn-background) border-(--ui-btn-border-color) hover:text-(--ui-btn-color-hover) hover:bg-(--ui-btn-background-hover) hover:border-(--ui-btn-border-color-hover) focus:text-(--ui-btn-color-hover) focus:bg-(--ui-btn-background-hover) focus:border-(--ui-btn-border-color-hover) active:text-(--ui-btn-color-active) active:bg-(--ui-btn-background-active) active:border-(--ui-btn-border-color-active) disabled:bg-(--ui-btn-background) disabled:border-(--ui-btn-border-color) aria-disabled:bg-(--ui-btn-background) aria-disabled:border-(--ui-btn-border-color) focus-visible:outline-(--ui-btn-background) ring-(--ui-btn-background-hover) focus:outline-none focus-visible:ring-(--ui-btn-background-hover) h-(--ui-btn-height) text-(length:--ui-btn-font-size) leading-(--ui-btn-height) font-(--ui-btn-font-weight) --style-tinted ui-btn-xs rounded-(--ui-btn-radius) normal-case --air">
+      <!--v-if-->
+      <div data-slot="baseLine" class="w-full inline-flex items-center justify-center gap-(--ui-btn-icon-space) ps-(--ui-btn-padding-left) pe-(--ui-btn-padding-right) h-(--ui-btn-height)">
+        <!--v-if--><span data-slot="label" class="h-(--ui-btn-height) max-w-full inline-flex flex-row items-center tracking-(--ui-btn-letter-spacing) overflow-visible text-clip"><span data-slot="labelInner" class="truncate inline-block max-w-full mt-(--ui-btn-title-compensation)">Deny</span></span>
+        <!--v-if-->
+      </div>
+    </button></div>
+</div>"
+`;
+
+exports[`ChatTool > renders with actions slot correctly 1`] = `
+"<div data-state="closed" data-slot="root" class=""><button type="button" aria-controls="" aria-expanded="false" data-state="closed" disabled="" data-slot="trigger" class="group w-full min-w-0 flex items-center gap-1.5 text-muted text-sm disabled:cursor-default disabled:hover:text-muted hover:text-default focus-visible:outline-offset-2 focus-visible:outline-primary transition-colors">
+    <!--v-if--><span data-slot="label" class="truncate">Searching components<!--v-if--></span>
+    <!--v-if-->
+  </button>
+  <div data-slot="content" class="motion-safe:data-[state=open]:animate-[collapsible-down_200ms_ease-out] motion-safe:data-[state=closed]:animate-[collapsible-up_200ms_ease-out] overflow-hidden" id="reka-collapsible-content-v-0" hidden="" data-state="closed" style="--reka-collapsible-content-height: 0px; --reka-collapsible-content-width: 0px;">
+    <div data-slot="body" class="text-sm text-dimmed whitespace-pre-wrap pt-2"></div>
+  </div>
+  <div data-slot="actions" data-state="closed" class="flex items-center justify-end gap-1.5 pt-2">Custom actions</div>
+</div>"
+`;
+
+exports[`ChatTool > renders with actions variant card correctly 1`] = `
+"<div data-state="closed" data-slot="root" class="light:[--leftmenu-group-stroke:var(--ui-color-base-30)] rounded-md ring ring-(--leftmenu-group-stroke) overflow-hidden"><button type="button" aria-controls="" aria-expanded="false" data-state="closed" disabled="" data-slot="trigger" class="group w-full min-w-0 flex items-center gap-1.5 text-muted text-sm disabled:cursor-default disabled:hover:text-muted hover:text-default focus-visible:outline-offset-2 focus-visible:outline-primary transition-colors px-2 py-1">
+    <!--v-if--><span data-slot="label" class="truncate">Searching components<!--v-if--></span>
+    <!--v-if-->
+  </button>
+  <div data-slot="content" class="motion-safe:data-[state=open]:animate-[collapsible-down_200ms_ease-out] motion-safe:data-[state=closed]:animate-[collapsible-up_200ms_ease-out] overflow-hidden" id="reka-collapsible-content-v-0" hidden="" data-state="closed" style="--reka-collapsible-content-height: 0px; --reka-collapsible-content-width: 0px;">
+    <div data-slot="body" class="text-sm text-dimmed whitespace-pre-wrap border-t border-(--leftmenu-group-stroke) p-2 max-h-[200px] overflow-y-auto"></div>
+  </div>
+  <div data-slot="actions" data-state="closed" class="flex items-center justify-end gap-1.5 border-t border-(--leftmenu-group-stroke) p-2"><button type="button" data-slot="base" class="ui-btn font-[family-name:var(--ui-font-family-primary)] select-none cursor-pointer inline-flex items-center relative outline-transparent focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed aria-disabled:cursor-not-allowed disabled:opacity-30 aria-disabled:opacity-30 transition duration-0 ease-linear border-(length:--ui-btn-border-width) text-(--ui-btn-color) bg-(--ui-btn-background) border-(--ui-btn-border-color) hover:text-(--ui-btn-color-hover) hover:bg-(--ui-btn-background-hover) hover:border-(--ui-btn-border-color-hover) focus:text-(--ui-btn-color-hover) focus:bg-(--ui-btn-background-hover) focus:border-(--ui-btn-border-color-hover) active:text-(--ui-btn-color-active) active:bg-(--ui-btn-background-active) active:border-(--ui-btn-border-color-active) disabled:bg-(--ui-btn-background) disabled:border-(--ui-btn-border-color) aria-disabled:bg-(--ui-btn-background) aria-disabled:border-(--ui-btn-border-color) focus-visible:outline-(--ui-btn-background) ring-(--ui-btn-background-hover) focus:outline-none focus-visible:ring-(--ui-btn-background-hover) h-(--ui-btn-height) text-(length:--ui-btn-font-size) leading-(--ui-btn-height) font-(--ui-btn-font-weight) --style-outline-no-accent ui-btn-xs rounded-(--ui-btn-radius) normal-case --air">
+      <!--v-if-->
+      <div data-slot="baseLine" class="w-full inline-flex items-center justify-center gap-(--ui-btn-icon-space) ps-(--ui-btn-padding-left) pe-(--ui-btn-padding-right) h-(--ui-btn-height)">
+        <!--v-if--><span data-slot="label" class="h-(--ui-btn-height) max-w-full inline-flex flex-row items-center tracking-(--ui-btn-letter-spacing) overflow-visible text-clip"><span data-slot="labelInner" class="truncate inline-block max-w-full mt-(--ui-btn-title-compensation)">Approve</span></span>
+        <!--v-if-->
+      </div>
+    </button><button type="button" data-slot="base" class="ui-btn font-[family-name:var(--ui-font-family-primary)] select-none cursor-pointer inline-flex items-center relative outline-transparent focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed aria-disabled:cursor-not-allowed disabled:opacity-30 aria-disabled:opacity-30 transition duration-0 ease-linear border-(length:--ui-btn-border-width) text-(--ui-btn-color) bg-(--ui-btn-background) border-(--ui-btn-border-color) hover:text-(--ui-btn-color-hover) hover:bg-(--ui-btn-background-hover) hover:border-(--ui-btn-border-color-hover) focus:text-(--ui-btn-color-hover) focus:bg-(--ui-btn-background-hover) focus:border-(--ui-btn-border-color-hover) active:text-(--ui-btn-color-active) active:bg-(--ui-btn-background-active) active:border-(--ui-btn-border-color-active) disabled:bg-(--ui-btn-background) disabled:border-(--ui-btn-border-color) aria-disabled:bg-(--ui-btn-background) aria-disabled:border-(--ui-btn-border-color) focus-visible:outline-(--ui-btn-background) ring-(--ui-btn-background-hover) focus:outline-none focus-visible:ring-(--ui-btn-background-hover) h-(--ui-btn-height) text-(length:--ui-btn-font-size) leading-(--ui-btn-height) font-(--ui-btn-font-weight) --style-outline-no-accent ui-btn-xs rounded-(--ui-btn-radius) normal-case --air">
+      <!--v-if-->
+      <div data-slot="baseLine" class="w-full inline-flex items-center justify-center gap-(--ui-btn-icon-space) ps-(--ui-btn-padding-left) pe-(--ui-btn-padding-right) h-(--ui-btn-height)">
+        <!--v-if--><span data-slot="label" class="h-(--ui-btn-height) max-w-full inline-flex flex-row items-center tracking-(--ui-btn-letter-spacing) overflow-visible text-clip"><span data-slot="labelInner" class="truncate inline-block max-w-full mt-(--ui-btn-title-compensation)">Deny</span></span>
+        <!--v-if-->
+      </div>
+    </button></div>
+</div>"
+`;
+
 exports[`ChatTool > renders with b24ui correctly 1`] = `
 "<div data-state="closed" data-slot="root" class=""><button type="button" aria-controls="" aria-expanded="false" data-state="closed" disabled="" data-slot="trigger" class="group w-full min-w-0 flex items-center gap-1.5 text-muted text-sm disabled:cursor-default disabled:hover:text-muted hover:text-default focus-visible:outline-offset-2 focus-visible:outline-primary transition-colors">
     <!--v-if--><span data-slot="label" class="truncate">Searching components<!--v-if--></span>
@@ -8,16 +93,18 @@ exports[`ChatTool > renders with b24ui correctly 1`] = `
   <div data-slot="content" class="motion-safe:data-[state=open]:animate-[collapsible-down_200ms_ease-out] motion-safe:data-[state=closed]:animate-[collapsible-up_200ms_ease-out] overflow-hidden" id="reka-collapsible-content-v-0" hidden="" data-state="closed" style="--reka-collapsible-content-height: 0px; --reka-collapsible-content-width: 0px;">
     <div data-slot="body" class="text-sm whitespace-pre-wrap pt-2 text-muted"></div>
   </div>
+  <!--v-if-->
 </div>"
 `;
 
 exports[`ChatTool > renders with chevron leading and icon correctly 1`] = `
-"<div data-state="closed" data-slot="root" class=""><button type="button" aria-controls="" aria-expanded="false" data-state="closed" disabled="" data-slot="trigger" class="group w-full min-w-0 flex items-center gap-1.5 text-muted text-sm disabled:cursor-default disabled:hover:text-muted hover:text-default focus-visible:outline-offset-2 focus-visible:outline-primary transition-colors"><span data-slot="leading" class="relative shrink-0 size-5"><svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" aria-hidden="true" data-slot="icon" class="shrink-0 size-5 group-hover:opacity-0"><path fill="currentColor" fill-rule="evenodd" d="M11.985 3a1.706 1.706 0 0 0-1.699 1.825L6.774 7.304h-1.7a1 1 0 0 0-1 1v9.203a1 1 0 0 0 1 1h13.822a1 1 0 0 0 1-1V8.304a1 1 0 0 0-1-1H17.19l-3.51-2.447q.006-.075.007-.15c0-.94-.763-1.707-1.703-1.707M10.8 5.931a1.694 1.694 0 0 0 2.35.019l1.943 1.354H8.855zm-4.231 4.744a.8.8 0 0 1 .8-.8h7.115a.8.8 0 0 1 .8.8v.137a.8.8 0 0 1-.8.8H7.37a.8.8 0 0 1-.8-.8zm.8 2.845a.8.8 0 0 0-.8.8v.137a.8.8 0 0 0 .8.8H13.1a.8.8 0 0 0 .8-.8v-.138a.8.8 0 0 0-.8-.8z" clip-rule="evenodd"></path></svg><!--v-if--></span><span data-slot="label" class="truncate">Searching components<!--v-if--></span>
+"<div data-state="closed" data-slot="root" class=""><button type="button" aria-controls="" aria-expanded="false" data-state="closed" disabled="" data-slot="trigger" class="group w-full min-w-0 flex items-center gap-1.5 text-muted text-sm disabled:cursor-default disabled:hover:text-muted hover:text-default focus-visible:outline-offset-2 focus-visible:outline-primary transition-colors"><span data-slot="leading" class="relative shrink-0 size-5"><svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" aria-hidden="true" data-slot="icon" class="shrink-0 size-5"><path fill="currentColor" fill-rule="evenodd" d="M11.985 3a1.706 1.706 0 0 0-1.699 1.825L6.774 7.304h-1.7a1 1 0 0 0-1 1v9.203a1 1 0 0 0 1 1h13.822a1 1 0 0 0 1-1V8.304a1 1 0 0 0-1-1H17.19l-3.51-2.447q.006-.075.007-.15c0-.94-.763-1.707-1.703-1.707M10.8 5.931a1.694 1.694 0 0 0 2.35.019l1.943 1.354H8.855zm-4.231 4.744a.8.8 0 0 1 .8-.8h7.115a.8.8 0 0 1 .8.8v.137a.8.8 0 0 1-.8.8H7.37a.8.8 0 0 1-.8-.8zm.8 2.845a.8.8 0 0 0-.8.8v.137a.8.8 0 0 0 .8.8H13.1a.8.8 0 0 0 .8-.8v-.138a.8.8 0 0 0-.8-.8z" clip-rule="evenodd"></path></svg><!--v-if--></span><span data-slot="label" class="truncate">Searching components<!--v-if--></span>
     <!--v-if-->
   </button>
   <div data-slot="content" class="motion-safe:data-[state=open]:animate-[collapsible-down_200ms_ease-out] motion-safe:data-[state=closed]:animate-[collapsible-up_200ms_ease-out] overflow-hidden" id="reka-collapsible-content-v-0" hidden="" data-state="closed" style="--reka-collapsible-content-height: 0px; --reka-collapsible-content-width: 0px;">
     <div data-slot="body" class="text-sm text-dimmed whitespace-pre-wrap pt-2"></div>
   </div>
+  <!--v-if-->
 </div>"
 `;
 
@@ -29,6 +116,18 @@ exports[`ChatTool > renders with chevron leading correctly 1`] = `
   <div data-slot="content" class="motion-safe:data-[state=open]:animate-[collapsible-down_200ms_ease-out] motion-safe:data-[state=closed]:animate-[collapsible-up_200ms_ease-out] overflow-hidden" id="reka-collapsible-content-v-0" hidden="" data-state="closed" style="--reka-collapsible-content-height: 0px; --reka-collapsible-content-width: 0px;">
     <div data-slot="body" class="text-sm text-dimmed whitespace-pre-wrap pt-2"></div>
   </div>
+  <!--v-if-->
+</div>"
+`;
+
+exports[`ChatTool > renders with chevron leading, icon and content correctly 1`] = `
+"<div data-state="closed" data-slot="root" class=""><button type="button" aria-controls="" aria-expanded="false" data-state="closed" data-slot="trigger" class="group w-full min-w-0 flex items-center gap-1.5 text-muted text-sm disabled:cursor-default disabled:hover:text-muted hover:text-default focus-visible:outline-offset-2 focus-visible:outline-primary transition-colors"><span data-slot="leading" class="relative shrink-0 size-5"><svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" aria-hidden="true" data-slot="icon" class="shrink-0 size-5 absolute inset-0 group-hover:opacity-0 group-data-[state=open]:opacity-0 transition-opacity duration-200"><path fill="currentColor" fill-rule="evenodd" d="M11.985 3a1.706 1.706 0 0 0-1.699 1.825L6.774 7.304h-1.7a1 1 0 0 0-1 1v9.203a1 1 0 0 0 1 1h13.822a1 1 0 0 0 1-1V8.304a1 1 0 0 0-1-1H17.19l-3.51-2.447q.006-.075.007-.15c0-.94-.763-1.707-1.703-1.707M10.8 5.931a1.694 1.694 0 0 0 2.35.019l1.943 1.354H8.855zm-4.231 4.744a.8.8 0 0 1 .8-.8h7.115a.8.8 0 0 1 .8.8v.137a.8.8 0 0 1-.8.8H7.37a.8.8 0 0 1-.8-.8zm.8 2.845a.8.8 0 0 0-.8.8v.137a.8.8 0 0 0 .8.8H13.1a.8.8 0 0 0 .8-.8v-.138a.8.8 0 0 0-.8-.8z" clip-rule="evenodd"></path></svg><svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" aria-hidden="true" data-slot="icon" class="shrink-0 group-data-[state=open]:rotate-180 absolute inset-0 opacity-0 group-hover:opacity-100 group-data-[state=open]:opacity-100 transition-[rotate,opacity] duration-200"><path fill="currentColor" fill-rule="evenodd" d="M5.505 9.505a.7.7 0 0 1 .99 0L12 15.01l5.505-5.505a.7.7 0 0 1 .99.99l-6 6a.7.7 0 0 1-.99 0l-6-6a.7.7 0 0 1 0-.99" clip-rule="evenodd"></path></svg></span><span data-slot="label" class="truncate">Searching components<!--v-if--></span>
+    <!--v-if-->
+  </button>
+  <div data-slot="content" class="motion-safe:data-[state=open]:animate-[collapsible-down_200ms_ease-out] motion-safe:data-[state=closed]:animate-[collapsible-up_200ms_ease-out] overflow-hidden" id="reka-collapsible-content-v-0" hidden="" data-state="closed" style="--reka-collapsible-content-height: 0px; --reka-collapsible-content-width: 0px;">
+    <div data-slot="body" class="text-sm text-dimmed whitespace-pre-wrap pt-2">Tool output content</div>
+  </div>
+  <!--v-if-->
 </div>"
 `;
 
@@ -40,6 +139,7 @@ exports[`ChatTool > renders with chevronIcon correctly 1`] = `
   <div data-slot="content" class="motion-safe:data-[state=open]:animate-[collapsible-down_200ms_ease-out] motion-safe:data-[state=closed]:animate-[collapsible-up_200ms_ease-out] overflow-hidden" id="reka-collapsible-content-v-0" hidden="" data-state="closed" style="--reka-collapsible-content-height: 0px; --reka-collapsible-content-width: 0px;">
     <div data-slot="body" class="text-sm text-dimmed whitespace-pre-wrap pt-2"></div>
   </div>
+  <!--v-if-->
 </div>"
 `;
 
@@ -51,6 +151,7 @@ exports[`ChatTool > renders with class correctly 1`] = `
   <div data-slot="content" class="motion-safe:data-[state=open]:animate-[collapsible-down_200ms_ease-out] motion-safe:data-[state=closed]:animate-[collapsible-up_200ms_ease-out] overflow-hidden" id="reka-collapsible-content-v-0" hidden="" data-state="closed" style="--reka-collapsible-content-height: 0px; --reka-collapsible-content-width: 0px;">
     <div data-slot="body" class="text-sm text-dimmed whitespace-pre-wrap pt-2"></div>
   </div>
+  <!--v-if-->
 </div>"
 `;
 
@@ -63,6 +164,7 @@ exports[`ChatTool > renders with default slot correctly 1`] = `
   <div data-slot="content" class="motion-safe:data-[state=open]:animate-[collapsible-down_200ms_ease-out] motion-safe:data-[state=closed]:animate-[collapsible-up_200ms_ease-out] overflow-hidden" id="reka-collapsible-content-v-0" hidden="" data-state="closed" style="--reka-collapsible-content-height: 0px; --reka-collapsible-content-width: 0px;">
     <div data-slot="body" class="text-sm text-dimmed whitespace-pre-wrap pt-2">Tool output content</div>
   </div>
+  <!--v-if-->
 </div>"
 `;
 
@@ -74,6 +176,7 @@ exports[`ChatTool > renders with defaultOpen correctly 1`] = `
   <div data-slot="content" class="motion-safe:data-[state=open]:animate-[collapsible-down_200ms_ease-out] motion-safe:data-[state=closed]:animate-[collapsible-up_200ms_ease-out] overflow-hidden" id="reka-collapsible-content-v-0" style="--reka-collapsible-content-height: 0px; --reka-collapsible-content-width: 0px; transition-duration: 0s; animation-name: none;">
     <div data-slot="body" class="text-sm text-dimmed whitespace-pre-wrap pt-2"></div>
   </div>
+  <!--v-if-->
 </div>"
 `;
 
@@ -84,6 +187,7 @@ exports[`ChatTool > renders with icon correctly 1`] = `
   <div data-slot="content" class="motion-safe:data-[state=open]:animate-[collapsible-down_200ms_ease-out] motion-safe:data-[state=closed]:animate-[collapsible-up_200ms_ease-out] overflow-hidden" id="reka-collapsible-content-v-0" hidden="" data-state="closed" style="--reka-collapsible-content-height: 0px; --reka-collapsible-content-width: 0px;">
     <div data-slot="body" class="text-sm text-dimmed whitespace-pre-wrap pt-2"></div>
   </div>
+  <!--v-if-->
 </div>"
 `;
 
@@ -94,6 +198,7 @@ exports[`ChatTool > renders with loading and loadingIcon correctly 1`] = `
   <div data-slot="content" class="motion-safe:data-[state=open]:animate-[collapsible-down_200ms_ease-out] motion-safe:data-[state=closed]:animate-[collapsible-up_200ms_ease-out] overflow-hidden" id="reka-collapsible-content-v-0" hidden="" data-state="closed" style="--reka-collapsible-content-height: 0px; --reka-collapsible-content-width: 0px;">
     <div data-slot="body" class="text-sm text-dimmed whitespace-pre-wrap pt-2"></div>
   </div>
+  <!--v-if-->
 </div>"
 `;
 
@@ -104,6 +209,7 @@ exports[`ChatTool > renders with loading correctly 1`] = `
   <div data-slot="content" class="motion-safe:data-[state=open]:animate-[collapsible-down_200ms_ease-out] motion-safe:data-[state=closed]:animate-[collapsible-up_200ms_ease-out] overflow-hidden" id="reka-collapsible-content-v-0" hidden="" data-state="closed" style="--reka-collapsible-content-height: 0px; --reka-collapsible-content-width: 0px;">
     <div data-slot="body" class="text-sm text-dimmed whitespace-pre-wrap pt-2"></div>
   </div>
+  <!--v-if-->
 </div>"
 `;
 
@@ -116,6 +222,7 @@ exports[`ChatTool > renders with streaming correctly 1`] = `
   <div data-slot="content" class="motion-safe:data-[state=open]:animate-[collapsible-down_200ms_ease-out] motion-safe:data-[state=closed]:animate-[collapsible-up_200ms_ease-out] overflow-hidden" id="reka-collapsible-content-v-0" hidden="" data-state="closed" style="--reka-collapsible-content-height: 0px; --reka-collapsible-content-width: 0px;">
     <div data-slot="body" class="text-sm text-dimmed whitespace-pre-wrap pt-2"></div>
   </div>
+  <!--v-if-->
 </div>"
 `;
 
@@ -127,6 +234,7 @@ exports[`ChatTool > renders with suffix correctly 1`] = `
   <div data-slot="content" class="motion-safe:data-[state=open]:animate-[collapsible-down_200ms_ease-out] motion-safe:data-[state=closed]:animate-[collapsible-up_200ms_ease-out] overflow-hidden" id="reka-collapsible-content-v-0" hidden="" data-state="closed" style="--reka-collapsible-content-height: 0px; --reka-collapsible-content-width: 0px;">
     <div data-slot="body" class="text-sm text-dimmed whitespace-pre-wrap pt-2"></div>
   </div>
+  <!--v-if-->
 </div>"
 `;
 
@@ -138,6 +246,7 @@ exports[`ChatTool > renders with text correctly 1`] = `
   <div data-slot="content" class="motion-safe:data-[state=open]:animate-[collapsible-down_200ms_ease-out] motion-safe:data-[state=closed]:animate-[collapsible-up_200ms_ease-out] overflow-hidden" id="reka-collapsible-content-v-0" hidden="" data-state="closed" style="--reka-collapsible-content-height: 0px; --reka-collapsible-content-width: 0px;">
     <div data-slot="body" class="text-sm text-dimmed whitespace-pre-wrap pt-2"></div>
   </div>
+  <!--v-if-->
 </div>"
 `;
 
@@ -149,6 +258,7 @@ exports[`ChatTool > renders with variant card correctly 1`] = `
   <div data-slot="content" class="motion-safe:data-[state=open]:animate-[collapsible-down_200ms_ease-out] motion-safe:data-[state=closed]:animate-[collapsible-up_200ms_ease-out] overflow-hidden" id="reka-collapsible-content-v-0" hidden="" data-state="closed" style="--reka-collapsible-content-height: 0px; --reka-collapsible-content-width: 0px;">
     <div data-slot="body" class="text-sm text-dimmed whitespace-pre-wrap border-t border-(--leftmenu-group-stroke) p-2 max-h-[200px] overflow-y-auto"></div>
   </div>
+  <!--v-if-->
 </div>"
 `;
 
@@ -160,5 +270,6 @@ exports[`ChatTool > renders with variant inline correctly 1`] = `
   <div data-slot="content" class="motion-safe:data-[state=open]:animate-[collapsible-down_200ms_ease-out] motion-safe:data-[state=closed]:animate-[collapsible-up_200ms_ease-out] overflow-hidden" id="reka-collapsible-content-v-0" hidden="" data-state="closed" style="--reka-collapsible-content-height: 0px; --reka-collapsible-content-width: 0px;">
     <div data-slot="body" class="text-sm text-dimmed whitespace-pre-wrap pt-2"></div>
   </div>
+  <!--v-if-->
 </div>"
 `;

--- a/test/components/__snapshots__/ChatTool.spec.ts.snap
+++ b/test/components/__snapshots__/ChatTool.spec.ts.snap
@@ -1,5 +1,90 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`ChatTool > renders with actions and content correctly 1`] = `
+"<div data-state="open" data-slot="root" class=""><button type="button" aria-controls="" aria-expanded="true" data-state="open" data-slot="trigger" class="group w-full min-w-0 flex items-center gap-1.5 text-muted text-sm disabled:cursor-default disabled:hover:text-muted hover:text-default focus-visible:outline-offset-2 focus-visible:outline-primary transition-colors">
+    <!--v-if--><span data-slot="label" class="truncate">Searching components<!--v-if--></span><svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" aria-hidden="true" data-slot="icon" class="size-4 shrink-0 group-data-[state=open]:rotate-180 transition-transform duration-200">
+      <path fill="currentColor" fill-rule="evenodd" d="M5.505 9.505a.7.7 0 0 1 .99 0L12 15.01l5.505-5.505a.7.7 0 0 1 .99.99l-6 6a.7.7 0 0 1-.99 0l-6-6a.7.7 0 0 1 0-.99" clip-rule="evenodd"></path>
+    </svg>
+  </button>
+  <div data-slot="content" class="motion-safe:data-[state=open]:animate-[collapsible-down_200ms_ease-out] motion-safe:data-[state=closed]:animate-[collapsible-up_200ms_ease-out] overflow-hidden" id="reka-collapsible-content-v-0-0-0" style="--reka-collapsible-content-height: 0px; --reka-collapsible-content-width: 0px; transition-duration: 0s; animation-name: none;">
+    <div data-slot="body" class="text-sm text-dimmed whitespace-pre-wrap pt-2">Tool output content</div>
+  </div>
+  <div data-slot="actions" data-state="open" class="flex items-center justify-end gap-1.5 pt-2"><button type="button" data-slot="base" class="ui-btn font-[family-name:var(--ui-font-family-primary)] select-none cursor-pointer inline-flex items-center relative outline-transparent focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed aria-disabled:cursor-not-allowed disabled:opacity-30 aria-disabled:opacity-30 transition duration-0 ease-linear border-(length:--ui-btn-border-width) text-(--ui-btn-color) bg-(--ui-btn-background) border-(--ui-btn-border-color) hover:text-(--ui-btn-color-hover) hover:bg-(--ui-btn-background-hover) hover:border-(--ui-btn-border-color-hover) focus:text-(--ui-btn-color-hover) focus:bg-(--ui-btn-background-hover) focus:border-(--ui-btn-border-color-hover) active:text-(--ui-btn-color-active) active:bg-(--ui-btn-background-active) active:border-(--ui-btn-border-color-active) disabled:bg-(--ui-btn-background) disabled:border-(--ui-btn-border-color) aria-disabled:bg-(--ui-btn-background) aria-disabled:border-(--ui-btn-border-color) focus-visible:outline-(--ui-btn-background) ring-(--ui-btn-background-hover) focus:outline-none focus-visible:ring-(--ui-btn-background-hover) h-(--ui-btn-height) text-(length:--ui-btn-font-size) leading-(--ui-btn-height) font-(--ui-btn-font-weight) --style-outline-no-accent ui-btn-xs rounded-(--ui-btn-radius) normal-case --air">
+      <!--v-if-->
+      <div data-slot="baseLine" class="w-full inline-flex items-center justify-center gap-(--ui-btn-icon-space) ps-(--ui-btn-padding-left) pe-(--ui-btn-padding-right) h-(--ui-btn-height)">
+        <!--v-if--><span data-slot="label" class="h-(--ui-btn-height) max-w-full inline-flex flex-row items-center tracking-(--ui-btn-letter-spacing) overflow-visible text-clip"><span data-slot="labelInner" class="truncate inline-block max-w-full mt-(--ui-btn-title-compensation)">Approve</span></span>
+        <!--v-if-->
+      </div>
+    </button><button type="button" data-slot="base" class="ui-btn font-[family-name:var(--ui-font-family-primary)] select-none cursor-pointer inline-flex items-center relative outline-transparent focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed aria-disabled:cursor-not-allowed disabled:opacity-30 aria-disabled:opacity-30 transition duration-0 ease-linear border-(length:--ui-btn-border-width) text-(--ui-btn-color) bg-(--ui-btn-background) border-(--ui-btn-border-color) hover:text-(--ui-btn-color-hover) hover:bg-(--ui-btn-background-hover) hover:border-(--ui-btn-border-color-hover) focus:text-(--ui-btn-color-hover) focus:bg-(--ui-btn-background-hover) focus:border-(--ui-btn-border-color-hover) active:text-(--ui-btn-color-active) active:bg-(--ui-btn-background-active) active:border-(--ui-btn-border-color-active) disabled:bg-(--ui-btn-background) disabled:border-(--ui-btn-border-color) aria-disabled:bg-(--ui-btn-background) aria-disabled:border-(--ui-btn-border-color) focus-visible:outline-(--ui-btn-background) ring-(--ui-btn-background-hover) focus:outline-none focus-visible:ring-(--ui-btn-background-hover) h-(--ui-btn-height) text-(length:--ui-btn-font-size) leading-(--ui-btn-height) font-(--ui-btn-font-weight) --style-outline-no-accent ui-btn-xs rounded-(--ui-btn-radius) normal-case --air">
+      <!--v-if-->
+      <div data-slot="baseLine" class="w-full inline-flex items-center justify-center gap-(--ui-btn-icon-space) ps-(--ui-btn-padding-left) pe-(--ui-btn-padding-right) h-(--ui-btn-height)">
+        <!--v-if--><span data-slot="label" class="h-(--ui-btn-height) max-w-full inline-flex flex-row items-center tracking-(--ui-btn-letter-spacing) overflow-visible text-clip"><span data-slot="labelInner" class="truncate inline-block max-w-full mt-(--ui-btn-title-compensation)">Deny</span></span>
+        <!--v-if-->
+      </div>
+    </button></div>
+</div>"
+`;
+
+exports[`ChatTool > renders with actions correctly 1`] = `
+"<div data-state="closed" data-slot="root" class=""><button type="button" aria-controls="" aria-expanded="false" data-state="closed" disabled="" data-slot="trigger" class="group w-full min-w-0 flex items-center gap-1.5 text-muted text-sm disabled:cursor-default disabled:hover:text-muted hover:text-default focus-visible:outline-offset-2 focus-visible:outline-primary transition-colors">
+    <!--v-if--><span data-slot="label" class="truncate">Searching components<!--v-if--></span>
+    <!--v-if-->
+  </button>
+  <div data-slot="content" class="motion-safe:data-[state=open]:animate-[collapsible-down_200ms_ease-out] motion-safe:data-[state=closed]:animate-[collapsible-up_200ms_ease-out] overflow-hidden" id="reka-collapsible-content-v-0-0-0" hidden="" data-state="closed" style="--reka-collapsible-content-height: 0px; --reka-collapsible-content-width: 0px;">
+    <div data-slot="body" class="text-sm text-dimmed whitespace-pre-wrap pt-2"></div>
+  </div>
+  <div data-slot="actions" data-state="closed" class="flex items-center justify-end gap-1.5 pt-2"><button type="button" data-slot="base" class="ui-btn font-[family-name:var(--ui-font-family-primary)] select-none cursor-pointer inline-flex items-center relative outline-transparent focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed aria-disabled:cursor-not-allowed disabled:opacity-30 aria-disabled:opacity-30 transition duration-0 ease-linear border-(length:--ui-btn-border-width) text-(--ui-btn-color) bg-(--ui-btn-background) border-(--ui-btn-border-color) hover:text-(--ui-btn-color-hover) hover:bg-(--ui-btn-background-hover) hover:border-(--ui-btn-border-color-hover) focus:text-(--ui-btn-color-hover) focus:bg-(--ui-btn-background-hover) focus:border-(--ui-btn-border-color-hover) active:text-(--ui-btn-color-active) active:bg-(--ui-btn-background-active) active:border-(--ui-btn-border-color-active) disabled:bg-(--ui-btn-background) disabled:border-(--ui-btn-border-color) aria-disabled:bg-(--ui-btn-background) aria-disabled:border-(--ui-btn-border-color) focus-visible:outline-(--ui-btn-background) ring-(--ui-btn-background-hover) focus:outline-none focus-visible:ring-(--ui-btn-background-hover) h-(--ui-btn-height) text-(length:--ui-btn-font-size) leading-(--ui-btn-height) font-(--ui-btn-font-weight) --style-outline-no-accent ui-btn-xs rounded-(--ui-btn-radius) normal-case --air">
+      <!--v-if-->
+      <div data-slot="baseLine" class="w-full inline-flex items-center justify-center gap-(--ui-btn-icon-space) ps-(--ui-btn-padding-left) pe-(--ui-btn-padding-right) h-(--ui-btn-height)">
+        <!--v-if--><span data-slot="label" class="h-(--ui-btn-height) max-w-full inline-flex flex-row items-center tracking-(--ui-btn-letter-spacing) overflow-visible text-clip"><span data-slot="labelInner" class="truncate inline-block max-w-full mt-(--ui-btn-title-compensation)">Approve</span></span>
+        <!--v-if-->
+      </div>
+    </button><button type="button" data-slot="base" class="ui-btn font-[family-name:var(--ui-font-family-primary)] select-none cursor-pointer inline-flex items-center relative outline-transparent focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed aria-disabled:cursor-not-allowed disabled:opacity-30 aria-disabled:opacity-30 transition duration-0 ease-linear border-(length:--ui-btn-border-width) text-(--ui-btn-color) bg-(--ui-btn-background) border-(--ui-btn-border-color) hover:text-(--ui-btn-color-hover) hover:bg-(--ui-btn-background-hover) hover:border-(--ui-btn-border-color-hover) focus:text-(--ui-btn-color-hover) focus:bg-(--ui-btn-background-hover) focus:border-(--ui-btn-border-color-hover) active:text-(--ui-btn-color-active) active:bg-(--ui-btn-background-active) active:border-(--ui-btn-border-color-active) disabled:bg-(--ui-btn-background) disabled:border-(--ui-btn-border-color) aria-disabled:bg-(--ui-btn-background) aria-disabled:border-(--ui-btn-border-color) focus-visible:outline-(--ui-btn-background) ring-(--ui-btn-background-hover) focus:outline-none focus-visible:ring-(--ui-btn-background-hover) h-(--ui-btn-height) text-(length:--ui-btn-font-size) leading-(--ui-btn-height) font-(--ui-btn-font-weight) --style-tinted ui-btn-xs rounded-(--ui-btn-radius) normal-case --air">
+      <!--v-if-->
+      <div data-slot="baseLine" class="w-full inline-flex items-center justify-center gap-(--ui-btn-icon-space) ps-(--ui-btn-padding-left) pe-(--ui-btn-padding-right) h-(--ui-btn-height)">
+        <!--v-if--><span data-slot="label" class="h-(--ui-btn-height) max-w-full inline-flex flex-row items-center tracking-(--ui-btn-letter-spacing) overflow-visible text-clip"><span data-slot="labelInner" class="truncate inline-block max-w-full mt-(--ui-btn-title-compensation)">Deny</span></span>
+        <!--v-if-->
+      </div>
+    </button></div>
+</div>"
+`;
+
+exports[`ChatTool > renders with actions slot correctly 1`] = `
+"<div data-state="closed" data-slot="root" class=""><button type="button" aria-controls="" aria-expanded="false" data-state="closed" disabled="" data-slot="trigger" class="group w-full min-w-0 flex items-center gap-1.5 text-muted text-sm disabled:cursor-default disabled:hover:text-muted hover:text-default focus-visible:outline-offset-2 focus-visible:outline-primary transition-colors">
+    <!--v-if--><span data-slot="label" class="truncate">Searching components<!--v-if--></span>
+    <!--v-if-->
+  </button>
+  <div data-slot="content" class="motion-safe:data-[state=open]:animate-[collapsible-down_200ms_ease-out] motion-safe:data-[state=closed]:animate-[collapsible-up_200ms_ease-out] overflow-hidden" id="reka-collapsible-content-v-0-0-0" hidden="" data-state="closed" style="--reka-collapsible-content-height: 0px; --reka-collapsible-content-width: 0px;">
+    <div data-slot="body" class="text-sm text-dimmed whitespace-pre-wrap pt-2"></div>
+  </div>
+  <div data-slot="actions" data-state="closed" class="flex items-center justify-end gap-1.5 pt-2">Custom actions</div>
+</div>"
+`;
+
+exports[`ChatTool > renders with actions variant card correctly 1`] = `
+"<div data-state="closed" data-slot="root" class="light:[--leftmenu-group-stroke:var(--ui-color-base-30)] rounded-md ring ring-(--leftmenu-group-stroke) overflow-hidden"><button type="button" aria-controls="" aria-expanded="false" data-state="closed" disabled="" data-slot="trigger" class="group w-full min-w-0 flex items-center gap-1.5 text-muted text-sm disabled:cursor-default disabled:hover:text-muted hover:text-default focus-visible:outline-offset-2 focus-visible:outline-primary transition-colors px-2 py-1">
+    <!--v-if--><span data-slot="label" class="truncate">Searching components<!--v-if--></span>
+    <!--v-if-->
+  </button>
+  <div data-slot="content" class="motion-safe:data-[state=open]:animate-[collapsible-down_200ms_ease-out] motion-safe:data-[state=closed]:animate-[collapsible-up_200ms_ease-out] overflow-hidden" id="reka-collapsible-content-v-0-0-0" hidden="" data-state="closed" style="--reka-collapsible-content-height: 0px; --reka-collapsible-content-width: 0px;">
+    <div data-slot="body" class="text-sm text-dimmed whitespace-pre-wrap border-t border-(--leftmenu-group-stroke) p-2 max-h-[200px] overflow-y-auto"></div>
+  </div>
+  <div data-slot="actions" data-state="closed" class="flex items-center justify-end gap-1.5 border-t border-(--leftmenu-group-stroke) p-2"><button type="button" data-slot="base" class="ui-btn font-[family-name:var(--ui-font-family-primary)] select-none cursor-pointer inline-flex items-center relative outline-transparent focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed aria-disabled:cursor-not-allowed disabled:opacity-30 aria-disabled:opacity-30 transition duration-0 ease-linear border-(length:--ui-btn-border-width) text-(--ui-btn-color) bg-(--ui-btn-background) border-(--ui-btn-border-color) hover:text-(--ui-btn-color-hover) hover:bg-(--ui-btn-background-hover) hover:border-(--ui-btn-border-color-hover) focus:text-(--ui-btn-color-hover) focus:bg-(--ui-btn-background-hover) focus:border-(--ui-btn-border-color-hover) active:text-(--ui-btn-color-active) active:bg-(--ui-btn-background-active) active:border-(--ui-btn-border-color-active) disabled:bg-(--ui-btn-background) disabled:border-(--ui-btn-border-color) aria-disabled:bg-(--ui-btn-background) aria-disabled:border-(--ui-btn-border-color) focus-visible:outline-(--ui-btn-background) ring-(--ui-btn-background-hover) focus:outline-none focus-visible:ring-(--ui-btn-background-hover) h-(--ui-btn-height) text-(length:--ui-btn-font-size) leading-(--ui-btn-height) font-(--ui-btn-font-weight) --style-outline-no-accent ui-btn-xs rounded-(--ui-btn-radius) normal-case --air">
+      <!--v-if-->
+      <div data-slot="baseLine" class="w-full inline-flex items-center justify-center gap-(--ui-btn-icon-space) ps-(--ui-btn-padding-left) pe-(--ui-btn-padding-right) h-(--ui-btn-height)">
+        <!--v-if--><span data-slot="label" class="h-(--ui-btn-height) max-w-full inline-flex flex-row items-center tracking-(--ui-btn-letter-spacing) overflow-visible text-clip"><span data-slot="labelInner" class="truncate inline-block max-w-full mt-(--ui-btn-title-compensation)">Approve</span></span>
+        <!--v-if-->
+      </div>
+    </button><button type="button" data-slot="base" class="ui-btn font-[family-name:var(--ui-font-family-primary)] select-none cursor-pointer inline-flex items-center relative outline-transparent focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed aria-disabled:cursor-not-allowed disabled:opacity-30 aria-disabled:opacity-30 transition duration-0 ease-linear border-(length:--ui-btn-border-width) text-(--ui-btn-color) bg-(--ui-btn-background) border-(--ui-btn-border-color) hover:text-(--ui-btn-color-hover) hover:bg-(--ui-btn-background-hover) hover:border-(--ui-btn-border-color-hover) focus:text-(--ui-btn-color-hover) focus:bg-(--ui-btn-background-hover) focus:border-(--ui-btn-border-color-hover) active:text-(--ui-btn-color-active) active:bg-(--ui-btn-background-active) active:border-(--ui-btn-border-color-active) disabled:bg-(--ui-btn-background) disabled:border-(--ui-btn-border-color) aria-disabled:bg-(--ui-btn-background) aria-disabled:border-(--ui-btn-border-color) focus-visible:outline-(--ui-btn-background) ring-(--ui-btn-background-hover) focus:outline-none focus-visible:ring-(--ui-btn-background-hover) h-(--ui-btn-height) text-(length:--ui-btn-font-size) leading-(--ui-btn-height) font-(--ui-btn-font-weight) --style-outline-no-accent ui-btn-xs rounded-(--ui-btn-radius) normal-case --air">
+      <!--v-if-->
+      <div data-slot="baseLine" class="w-full inline-flex items-center justify-center gap-(--ui-btn-icon-space) ps-(--ui-btn-padding-left) pe-(--ui-btn-padding-right) h-(--ui-btn-height)">
+        <!--v-if--><span data-slot="label" class="h-(--ui-btn-height) max-w-full inline-flex flex-row items-center tracking-(--ui-btn-letter-spacing) overflow-visible text-clip"><span data-slot="labelInner" class="truncate inline-block max-w-full mt-(--ui-btn-title-compensation)">Deny</span></span>
+        <!--v-if-->
+      </div>
+    </button></div>
+</div>"
+`;
+
 exports[`ChatTool > renders with b24ui correctly 1`] = `
 "<div data-state="closed" data-slot="root" class=""><button type="button" aria-controls="" aria-expanded="false" data-state="closed" disabled="" data-slot="trigger" class="group w-full min-w-0 flex items-center gap-1.5 text-muted text-sm disabled:cursor-default disabled:hover:text-muted hover:text-default focus-visible:outline-offset-2 focus-visible:outline-primary transition-colors">
     <!--v-if--><span data-slot="label" class="truncate">Searching components<!--v-if--></span>
@@ -8,16 +93,18 @@ exports[`ChatTool > renders with b24ui correctly 1`] = `
   <div data-slot="content" class="motion-safe:data-[state=open]:animate-[collapsible-down_200ms_ease-out] motion-safe:data-[state=closed]:animate-[collapsible-up_200ms_ease-out] overflow-hidden" id="reka-collapsible-content-v-0-0-0" hidden="" data-state="closed" style="--reka-collapsible-content-height: 0px; --reka-collapsible-content-width: 0px;">
     <div data-slot="body" class="text-sm whitespace-pre-wrap pt-2 text-muted"></div>
   </div>
+  <!--v-if-->
 </div>"
 `;
 
 exports[`ChatTool > renders with chevron leading and icon correctly 1`] = `
-"<div data-state="closed" data-slot="root" class=""><button type="button" aria-controls="" aria-expanded="false" data-state="closed" disabled="" data-slot="trigger" class="group w-full min-w-0 flex items-center gap-1.5 text-muted text-sm disabled:cursor-default disabled:hover:text-muted hover:text-default focus-visible:outline-offset-2 focus-visible:outline-primary transition-colors"><span data-slot="leading" class="relative shrink-0 size-5"><svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" aria-hidden="true" data-slot="icon" class="shrink-0 size-5 group-hover:opacity-0"><path fill="currentColor" fill-rule="evenodd" d="M11.985 3a1.706 1.706 0 0 0-1.699 1.825L6.774 7.304h-1.7a1 1 0 0 0-1 1v9.203a1 1 0 0 0 1 1h13.822a1 1 0 0 0 1-1V8.304a1 1 0 0 0-1-1H17.19l-3.51-2.447q.006-.075.007-.15c0-.94-.763-1.707-1.703-1.707M10.8 5.931a1.694 1.694 0 0 0 2.35.019l1.943 1.354H8.855zm-4.231 4.744a.8.8 0 0 1 .8-.8h7.115a.8.8 0 0 1 .8.8v.137a.8.8 0 0 1-.8.8H7.37a.8.8 0 0 1-.8-.8zm.8 2.845a.8.8 0 0 0-.8.8v.137a.8.8 0 0 0 .8.8H13.1a.8.8 0 0 0 .8-.8v-.138a.8.8 0 0 0-.8-.8z" clip-rule="evenodd"></path></svg><!--v-if--></span><span data-slot="label" class="truncate">Searching components<!--v-if--></span>
+"<div data-state="closed" data-slot="root" class=""><button type="button" aria-controls="" aria-expanded="false" data-state="closed" disabled="" data-slot="trigger" class="group w-full min-w-0 flex items-center gap-1.5 text-muted text-sm disabled:cursor-default disabled:hover:text-muted hover:text-default focus-visible:outline-offset-2 focus-visible:outline-primary transition-colors"><span data-slot="leading" class="relative shrink-0 size-5"><svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" aria-hidden="true" data-slot="icon" class="shrink-0 size-5"><path fill="currentColor" fill-rule="evenodd" d="M11.985 3a1.706 1.706 0 0 0-1.699 1.825L6.774 7.304h-1.7a1 1 0 0 0-1 1v9.203a1 1 0 0 0 1 1h13.822a1 1 0 0 0 1-1V8.304a1 1 0 0 0-1-1H17.19l-3.51-2.447q.006-.075.007-.15c0-.94-.763-1.707-1.703-1.707M10.8 5.931a1.694 1.694 0 0 0 2.35.019l1.943 1.354H8.855zm-4.231 4.744a.8.8 0 0 1 .8-.8h7.115a.8.8 0 0 1 .8.8v.137a.8.8 0 0 1-.8.8H7.37a.8.8 0 0 1-.8-.8zm.8 2.845a.8.8 0 0 0-.8.8v.137a.8.8 0 0 0 .8.8H13.1a.8.8 0 0 0 .8-.8v-.138a.8.8 0 0 0-.8-.8z" clip-rule="evenodd"></path></svg><!--v-if--></span><span data-slot="label" class="truncate">Searching components<!--v-if--></span>
     <!--v-if-->
   </button>
   <div data-slot="content" class="motion-safe:data-[state=open]:animate-[collapsible-down_200ms_ease-out] motion-safe:data-[state=closed]:animate-[collapsible-up_200ms_ease-out] overflow-hidden" id="reka-collapsible-content-v-0-0-0" hidden="" data-state="closed" style="--reka-collapsible-content-height: 0px; --reka-collapsible-content-width: 0px;">
     <div data-slot="body" class="text-sm text-dimmed whitespace-pre-wrap pt-2"></div>
   </div>
+  <!--v-if-->
 </div>"
 `;
 
@@ -29,6 +116,18 @@ exports[`ChatTool > renders with chevron leading correctly 1`] = `
   <div data-slot="content" class="motion-safe:data-[state=open]:animate-[collapsible-down_200ms_ease-out] motion-safe:data-[state=closed]:animate-[collapsible-up_200ms_ease-out] overflow-hidden" id="reka-collapsible-content-v-0-0-0" hidden="" data-state="closed" style="--reka-collapsible-content-height: 0px; --reka-collapsible-content-width: 0px;">
     <div data-slot="body" class="text-sm text-dimmed whitespace-pre-wrap pt-2"></div>
   </div>
+  <!--v-if-->
+</div>"
+`;
+
+exports[`ChatTool > renders with chevron leading, icon and content correctly 1`] = `
+"<div data-state="closed" data-slot="root" class=""><button type="button" aria-controls="" aria-expanded="false" data-state="closed" data-slot="trigger" class="group w-full min-w-0 flex items-center gap-1.5 text-muted text-sm disabled:cursor-default disabled:hover:text-muted hover:text-default focus-visible:outline-offset-2 focus-visible:outline-primary transition-colors"><span data-slot="leading" class="relative shrink-0 size-5"><svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" aria-hidden="true" data-slot="icon" class="shrink-0 size-5 absolute inset-0 group-hover:opacity-0 group-data-[state=open]:opacity-0 transition-opacity duration-200"><path fill="currentColor" fill-rule="evenodd" d="M11.985 3a1.706 1.706 0 0 0-1.699 1.825L6.774 7.304h-1.7a1 1 0 0 0-1 1v9.203a1 1 0 0 0 1 1h13.822a1 1 0 0 0 1-1V8.304a1 1 0 0 0-1-1H17.19l-3.51-2.447q.006-.075.007-.15c0-.94-.763-1.707-1.703-1.707M10.8 5.931a1.694 1.694 0 0 0 2.35.019l1.943 1.354H8.855zm-4.231 4.744a.8.8 0 0 1 .8-.8h7.115a.8.8 0 0 1 .8.8v.137a.8.8 0 0 1-.8.8H7.37a.8.8 0 0 1-.8-.8zm.8 2.845a.8.8 0 0 0-.8.8v.137a.8.8 0 0 0 .8.8H13.1a.8.8 0 0 0 .8-.8v-.138a.8.8 0 0 0-.8-.8z" clip-rule="evenodd"></path></svg><svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" aria-hidden="true" data-slot="icon" class="shrink-0 group-data-[state=open]:rotate-180 absolute inset-0 opacity-0 group-hover:opacity-100 group-data-[state=open]:opacity-100 transition-[rotate,opacity] duration-200"><path fill="currentColor" fill-rule="evenodd" d="M5.505 9.505a.7.7 0 0 1 .99 0L12 15.01l5.505-5.505a.7.7 0 0 1 .99.99l-6 6a.7.7 0 0 1-.99 0l-6-6a.7.7 0 0 1 0-.99" clip-rule="evenodd"></path></svg></span><span data-slot="label" class="truncate">Searching components<!--v-if--></span>
+    <!--v-if-->
+  </button>
+  <div data-slot="content" class="motion-safe:data-[state=open]:animate-[collapsible-down_200ms_ease-out] motion-safe:data-[state=closed]:animate-[collapsible-up_200ms_ease-out] overflow-hidden" id="reka-collapsible-content-v-0-0-0" hidden="" data-state="closed" style="--reka-collapsible-content-height: 0px; --reka-collapsible-content-width: 0px;">
+    <div data-slot="body" class="text-sm text-dimmed whitespace-pre-wrap pt-2">Tool output content</div>
+  </div>
+  <!--v-if-->
 </div>"
 `;
 
@@ -40,6 +139,7 @@ exports[`ChatTool > renders with chevronIcon correctly 1`] = `
   <div data-slot="content" class="motion-safe:data-[state=open]:animate-[collapsible-down_200ms_ease-out] motion-safe:data-[state=closed]:animate-[collapsible-up_200ms_ease-out] overflow-hidden" id="reka-collapsible-content-v-0-0-0" hidden="" data-state="closed" style="--reka-collapsible-content-height: 0px; --reka-collapsible-content-width: 0px;">
     <div data-slot="body" class="text-sm text-dimmed whitespace-pre-wrap pt-2"></div>
   </div>
+  <!--v-if-->
 </div>"
 `;
 
@@ -51,6 +151,7 @@ exports[`ChatTool > renders with class correctly 1`] = `
   <div data-slot="content" class="motion-safe:data-[state=open]:animate-[collapsible-down_200ms_ease-out] motion-safe:data-[state=closed]:animate-[collapsible-up_200ms_ease-out] overflow-hidden" id="reka-collapsible-content-v-0-0-0" hidden="" data-state="closed" style="--reka-collapsible-content-height: 0px; --reka-collapsible-content-width: 0px;">
     <div data-slot="body" class="text-sm text-dimmed whitespace-pre-wrap pt-2"></div>
   </div>
+  <!--v-if-->
 </div>"
 `;
 
@@ -63,6 +164,7 @@ exports[`ChatTool > renders with default slot correctly 1`] = `
   <div data-slot="content" class="motion-safe:data-[state=open]:animate-[collapsible-down_200ms_ease-out] motion-safe:data-[state=closed]:animate-[collapsible-up_200ms_ease-out] overflow-hidden" id="reka-collapsible-content-v-0-0-0" hidden="" data-state="closed" style="--reka-collapsible-content-height: 0px; --reka-collapsible-content-width: 0px;">
     <div data-slot="body" class="text-sm text-dimmed whitespace-pre-wrap pt-2">Tool output content</div>
   </div>
+  <!--v-if-->
 </div>"
 `;
 
@@ -74,6 +176,7 @@ exports[`ChatTool > renders with defaultOpen correctly 1`] = `
   <div data-slot="content" class="motion-safe:data-[state=open]:animate-[collapsible-down_200ms_ease-out] motion-safe:data-[state=closed]:animate-[collapsible-up_200ms_ease-out] overflow-hidden" id="reka-collapsible-content-v-0-0-0" style="--reka-collapsible-content-height: 0px; --reka-collapsible-content-width: 0px; transition-duration: 0s; animation-name: none;">
     <div data-slot="body" class="text-sm text-dimmed whitespace-pre-wrap pt-2"></div>
   </div>
+  <!--v-if-->
 </div>"
 `;
 
@@ -84,6 +187,7 @@ exports[`ChatTool > renders with icon correctly 1`] = `
   <div data-slot="content" class="motion-safe:data-[state=open]:animate-[collapsible-down_200ms_ease-out] motion-safe:data-[state=closed]:animate-[collapsible-up_200ms_ease-out] overflow-hidden" id="reka-collapsible-content-v-0-0-0" hidden="" data-state="closed" style="--reka-collapsible-content-height: 0px; --reka-collapsible-content-width: 0px;">
     <div data-slot="body" class="text-sm text-dimmed whitespace-pre-wrap pt-2"></div>
   </div>
+  <!--v-if-->
 </div>"
 `;
 
@@ -94,6 +198,7 @@ exports[`ChatTool > renders with loading and loadingIcon correctly 1`] = `
   <div data-slot="content" class="motion-safe:data-[state=open]:animate-[collapsible-down_200ms_ease-out] motion-safe:data-[state=closed]:animate-[collapsible-up_200ms_ease-out] overflow-hidden" id="reka-collapsible-content-v-0-0-0" hidden="" data-state="closed" style="--reka-collapsible-content-height: 0px; --reka-collapsible-content-width: 0px;">
     <div data-slot="body" class="text-sm text-dimmed whitespace-pre-wrap pt-2"></div>
   </div>
+  <!--v-if-->
 </div>"
 `;
 
@@ -104,6 +209,7 @@ exports[`ChatTool > renders with loading correctly 1`] = `
   <div data-slot="content" class="motion-safe:data-[state=open]:animate-[collapsible-down_200ms_ease-out] motion-safe:data-[state=closed]:animate-[collapsible-up_200ms_ease-out] overflow-hidden" id="reka-collapsible-content-v-0-0-0" hidden="" data-state="closed" style="--reka-collapsible-content-height: 0px; --reka-collapsible-content-width: 0px;">
     <div data-slot="body" class="text-sm text-dimmed whitespace-pre-wrap pt-2"></div>
   </div>
+  <!--v-if-->
 </div>"
 `;
 
@@ -116,6 +222,7 @@ exports[`ChatTool > renders with streaming correctly 1`] = `
   <div data-slot="content" class="motion-safe:data-[state=open]:animate-[collapsible-down_200ms_ease-out] motion-safe:data-[state=closed]:animate-[collapsible-up_200ms_ease-out] overflow-hidden" id="reka-collapsible-content-v-0-0-0" hidden="" data-state="closed" style="--reka-collapsible-content-height: 0px; --reka-collapsible-content-width: 0px;">
     <div data-slot="body" class="text-sm text-dimmed whitespace-pre-wrap pt-2"></div>
   </div>
+  <!--v-if-->
 </div>"
 `;
 
@@ -127,6 +234,7 @@ exports[`ChatTool > renders with suffix correctly 1`] = `
   <div data-slot="content" class="motion-safe:data-[state=open]:animate-[collapsible-down_200ms_ease-out] motion-safe:data-[state=closed]:animate-[collapsible-up_200ms_ease-out] overflow-hidden" id="reka-collapsible-content-v-0-0-0" hidden="" data-state="closed" style="--reka-collapsible-content-height: 0px; --reka-collapsible-content-width: 0px;">
     <div data-slot="body" class="text-sm text-dimmed whitespace-pre-wrap pt-2"></div>
   </div>
+  <!--v-if-->
 </div>"
 `;
 
@@ -138,6 +246,7 @@ exports[`ChatTool > renders with text correctly 1`] = `
   <div data-slot="content" class="motion-safe:data-[state=open]:animate-[collapsible-down_200ms_ease-out] motion-safe:data-[state=closed]:animate-[collapsible-up_200ms_ease-out] overflow-hidden" id="reka-collapsible-content-v-0-0-0" hidden="" data-state="closed" style="--reka-collapsible-content-height: 0px; --reka-collapsible-content-width: 0px;">
     <div data-slot="body" class="text-sm text-dimmed whitespace-pre-wrap pt-2"></div>
   </div>
+  <!--v-if-->
 </div>"
 `;
 
@@ -149,6 +258,7 @@ exports[`ChatTool > renders with variant card correctly 1`] = `
   <div data-slot="content" class="motion-safe:data-[state=open]:animate-[collapsible-down_200ms_ease-out] motion-safe:data-[state=closed]:animate-[collapsible-up_200ms_ease-out] overflow-hidden" id="reka-collapsible-content-v-0-0-0" hidden="" data-state="closed" style="--reka-collapsible-content-height: 0px; --reka-collapsible-content-width: 0px;">
     <div data-slot="body" class="text-sm text-dimmed whitespace-pre-wrap border-t border-(--leftmenu-group-stroke) p-2 max-h-[200px] overflow-y-auto"></div>
   </div>
+  <!--v-if-->
 </div>"
 `;
 
@@ -160,5 +270,6 @@ exports[`ChatTool > renders with variant inline correctly 1`] = `
   <div data-slot="content" class="motion-safe:data-[state=open]:animate-[collapsible-down_200ms_ease-out] motion-safe:data-[state=closed]:animate-[collapsible-up_200ms_ease-out] overflow-hidden" id="reka-collapsible-content-v-0-0-0" hidden="" data-state="closed" style="--reka-collapsible-content-height: 0px; --reka-collapsible-content-width: 0px;">
     <div data-slot="body" class="text-sm text-dimmed whitespace-pre-wrap pt-2"></div>
   </div>
+  <!--v-if-->
 </div>"
 `;


### PR DESCRIPTION
Syncs upstream nuxt/ui commit [`1a3a9dc`](https://github.com/nuxt/ui/commit/1a3a9dc35b6a4e7a3aea57d93532b155de51c0ec) — *feat(ChatTool): add `actions` prop for tool approval*.

## What
Ports the version-agnostic **ChatTool actions** feature:

- **`ChatTool.vue`** — new `actions?: ButtonProps[]` prop rendering a button row below the trigger, plus an `actions` slot. Auto-opens once when actions first appear (uncontrolled only, respects an explicit `defaultOpen`) so the tool content is visible while the user decides.
- **`theme/chat-tool.ts`** — `actions` slot with `inline`/`card` variant classes; the `chevron.leading` / `alone.false` leading-icon hover-swap is refactored so `group-hover:opacity-0` only applies when the icon overlaps the chevron.
- **`utils/ai.ts`** — `isToolApprovalPending()` and `isToolStreaming` now treats `approval-requested` as a paused state. Pure string-state helpers; harmless on b24ui's AI-SDK v6 line (the state simply never occurs).
- **Docs / playgrounds / tests** — added the **Actions** doc section (adapted to a b24ui icon + `air-secondary` color), the actions demo in the nuxt & demo playgrounds (kept in parity), and the new render + unit tests (auto-open ×3, onClick, no-actions).

## Deferred / deviations
- The **v7 tool-approval flow** (`toolApproval`, `addToolApprovalResponse`, `lastAssistantMessageIsCompleteWithApprovalResponses`, `approval-requested` wiring in `chat.md` / `chat.vue` / `chat.post.ts` / the new `ChatToolApprovalExample.vue`) is **not** ported — b24ui stays on the deferred AI-SDK v6 line. Only the version-agnostic component/theme/util feature is synced.
- Upstream's `chat-message.ts` `body: 'w-full'` tweak targets the `naked` variant, which b24ui's chat-message theme does not have, so it has no applicable target and was skipped.

## Verify (`CI=true`)
`dev:prepare` · `lint` · `typecheck` · `test` · `build` — all green. Test suite **5309 passed / 6 skipped** (was 5289; +20 from the new ChatTool cases). 40 ChatTool snapshots updated (10 new actions cases + the benign hover-swap refactor on existing `chevron leading` cases).

Ledger: cursor advanced to `1a3a9dc`; previous entry `c256997` reconciled to PR #256.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JS8ypVfQSFzYVZzkTHhURb)_