### PR TITLE
fix(defineShortcuts): add missing arrowdown to shiftable keys

### DIFF
--- a/.sync/log/2128414292aeec7d8fc3c724745eb6ea81d086b8.md
+++ b/.sync/log/2128414292aeec7d8fc3c724745eb6ea81d086b8.md
@@ -1,0 +1,23 @@
+# Port: fix(defineShortcuts): add missing `arrowdown` to shiftable keys (#6702)
+
+**Upstream:** `2128414292aeec7d8fc3c724745eb6ea81d086b8` (nuxt/ui)
+**Decision:** port — direct 1:1
+
+## Upstream change
+`shiftableKeys` listed `arrowright` twice and omitted `arrowdown`, so
+`shift_arrowdown` shortcuts never fired. Replace the duplicate `arrowright`
+with `arrowdown`. Adds two tests (shift_arrowdown fires; bare arrowdown does not
+fire when Shift is held).
+
+## b24ui port
+b24ui's `src/runtime/composables/defineShortcuts.ts:41` had the identical bug.
+Fixed the array verbatim. Ported both tests into
+`test/composables/defineShortcuts.spec.ts` (inserted after `shift_escape`,
+before the `chained shortcuts` describe — matching upstream placement).
+
+## Tests
+No snapshots. 2 new tests × (nuxt/vue projects) → suite 5313 passed / 6 skipped
+(was 5309). Targeted `defineShortcuts.spec.ts` run: 100 passed.
+
+## Verify (CI=true)
+`dev:prepare` · `lint` · `typecheck` · `test` · `build` — all green.

--- a/.sync/nuxt-ui.json
+++ b/.sync/nuxt-ui.json
@@ -2,7 +2,7 @@
   "upstream": "nuxt/ui",
   "branch": "v4",
   "sync_enabled": false,
-  "cursor": "64b9f7dd93863370ada09dc3be31bb05a8a5a4ce",
+  "cursor": "2128414292aeec7d8fc3c724745eb6ea81d086b8",
   "_cursor_note": "cursor = last upstream commit ported into b24ui (oldest-first, manual cadence). sync_enabled stays false until Phase 2 (porter workflow #67 + CLAUDE_CODE_OAUTH_TOKEN) is wired and trusted. `processed` is maintained per port from now on (backfilled #68-#72 on 2026-06-09).",
   "stats": {
     "queue_depth": 0,
@@ -953,10 +953,16 @@
       "summary": "feat(ChatTool): add actions prop for tool approval (#6699) — ChatTool gains actions?: ButtonProps[] rendering a button row below the trigger + actions slot, auto-opens once when actions appear (uncontrolled, respects defaultOpen). Theme: actions slot (inline/card), chevron.leading->'' with group-hover:opacity-0 moved into alone.false.leadingIcon. ai.ts: isToolApprovalPending() + isToolStreaming treats approval-requested as paused (pure string helpers, harmless on v6). Ported component/theme/util/docs/playgrounds/tests. DEFERRED the v7 tool-approval flow (chat.md, chat.vue, chat.post.ts, ChatToolApprovalExample.vue — toolApproval/addToolApprovalResponse). Skipped chat-message.ts body:w-full (b24ui has no naked variant). Tests 5309."
     },
     "64b9f7dd93863370ada09dc3be31bb05a8a5a4ce": {
+      "pr": 258,
+      "b24ui_sha": "c723febd34aa17651f0e984f95e3fc15b4866a8c",
+      "decision": "port",
+      "summary": "feat(ContentToc): scroll list independently and center active link (#6697) — desktop TOC list scrolls independently (root lg:overflow-hidden + content lg:overflow-y-auto) and active link is centered via activeIndex computed + watch scrolling contentRef; useScrollShadow on content. b24ui adapted: sticky/max-h stays on docs class prop; theme root flex flex-col lg:overflow-hidden, container/top/bottom/trigger get min-h-0/shrink-0, content lg:overflow-y-auto. Deviation: no scrollbar-none in b24ui -> lg:scrollbar-thin lg:scrollbar-transparent. Not ported: [...slug].vue highlight/circuit (b24ui unsupported). 16 snapshots class-only. Tests 5309."
+    },
+    "2128414292aeec7d8fc3c724745eb6ea81d086b8": {
       "pr": null,
       "b24ui_sha": "pending-merge",
       "decision": "port",
-      "summary": "feat(ContentToc): scroll list independently and center active link (#6697) — desktop TOC list scrolls independently (root lg:overflow-hidden + content lg:overflow-y-auto) and active link is centered via activeIndex computed + watch scrolling contentRef; useScrollShadow on content. b24ui adapted: sticky/max-h stays on docs class prop; theme root flex flex-col lg:overflow-hidden, container/top/bottom/trigger get min-h-0/shrink-0, content lg:overflow-y-auto. Deviation: no scrollbar-none in b24ui -> lg:scrollbar-thin lg:scrollbar-transparent. Not ported: [...slug].vue highlight/circuit (b24ui unsupported). 16 snapshots class-only. Tests 5309."
+      "summary": "fix(defineShortcuts): add missing arrowdown to shiftable keys (#6702) — shiftableKeys had arrowright twice, omitted arrowdown, so shift_arrowdown never fired. b24ui composables/defineShortcuts.ts:41 had identical bug; fixed verbatim. Ported 2 tests (shift_arrowdown fires, bare arrowdown doesn't with Shift). No snapshots. Tests 5313."
     }
   }
 }

--- a/src/runtime/composables/defineShortcuts.ts
+++ b/src/runtime/composables/defineShortcuts.ts
@@ -38,7 +38,7 @@ interface Shortcut {
 const chainedShortcutRegex = /^[^-]+.*-.*[^-]+$/
 const combinedShortcutRegex = /^[^_]+.*_.*[^_]+$/
 // keyboard keys which can be combined with Shift modifier (in addition to alphabet keys)
-const shiftableKeys = ['arrowleft', 'arrowright', 'arrowup', 'arrowright', 'tab', 'escape', 'enter', 'backspace']
+const shiftableKeys = ['arrowleft', 'arrowright', 'arrowup', 'arrowdown', 'tab', 'escape', 'enter', 'backspace']
 
 // Simple key to code conversion for layout independence
 function convertKeyToCode(key: string): string {

--- a/test/composables/defineShortcuts.spec.ts
+++ b/test/composables/defineShortcuts.spec.ts
@@ -302,6 +302,22 @@ describe('defineShortcuts', () => {
       fireKeydown('Escape', { shiftKey: true })
       expect(handler).toHaveBeenCalledOnce()
     })
+
+    it('shift_arrowdown triggers with Shift+ArrowDown', async () => {
+      const handler = vi.fn()
+      await registerShortcuts({ shift_arrowdown: handler })
+
+      fireKeydown('ArrowDown', { shiftKey: true })
+      expect(handler).toHaveBeenCalledOnce()
+    })
+
+    it('arrowdown does NOT trigger with Shift+ArrowDown', async () => {
+      const handler = vi.fn()
+      await registerShortcuts({ arrowdown: handler })
+
+      fireKeydown('ArrowDown', { shiftKey: true })
+      expect(handler).not.toHaveBeenCalled()
+    })
   })
 
   describe('chained shortcuts', () => {


### PR DESCRIPTION
Syncs upstream nuxt/ui commit [`2128414`](https://github.com/nuxt/ui/commit/2128414292aeec7d8fc3c724745eb6ea81d086b8) — *fix(defineShortcuts): add missing `arrowdown` to shiftable keys (#6702)*.

## What
`shiftableKeys` listed `arrowright` **twice** and omitted `arrowdown`, so `shift_arrowdown` shortcuts never fired. Replaced the duplicate `arrowright` with `arrowdown` (b24ui had the identical bug at `defineShortcuts.ts:41`).

Ported both upstream regression tests: `shift_arrowdown` fires on Shift+ArrowDown, and a bare `arrowdown` shortcut does **not** fire when Shift is held.

## Verify (`CI=true`)
`dev:prepare` · `lint` · `typecheck` · `test` · `build` — all green. Suite **5313 passed / 6 skipped** (+4 from the two new tests across the nuxt & vue projects). No snapshot changes.

Ledger: cursor advanced to `2128414`; previous entry `64b9f7d` reconciled to PR #258.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JS8ypVfQSFzYVZzkTHhURb)_