### PR TITLE
fix(useFileUpload): keep dropzone type filter reactive to accept

### DIFF
--- a/.sync/log/000aba433df85a8b28dc16127a587fc18822b32f.md
+++ b/.sync/log/000aba433df85a8b28dc16127a587fc18822b32f.md
@@ -1,0 +1,28 @@
+# Port: fix(useFileUpload): keep dropzone type filter reactive to accept (#6699)
+
+**Upstream:** `000aba433df85a8b28dc16127a587fc18822b32f` (nuxt/ui)
+**Decision:** port — direct 1:1
+
+## Upstream change
+`useFileUpload` passed `dataTypes.value` (a static snapshot) to `useDropZone`,
+so the dropzone MIME filter stopped tracking `accept` changes. Fix: pass the
+computed `dataTypes` ref directly. `parseAcceptToDataTypes` now returns `[]`
+(instead of `undefined`) for unrestricted input — an empty list means "no
+restriction" for `useDropZone` — and `dataTypes` is typed `readonly string[]`.
+Adds a full `useFileUpload.spec.ts` (drop/dialog/isDragging/accept-parsing/
+reactivity/dropzone/refs).
+
+## b24ui port
+b24ui's `src/runtime/composables/useFileUpload.ts` matched upstream exactly.
+Applied the three changes verbatim (`parseAcceptToDataTypes` → `string[]` + `[]`
++ comment; `dataTypes` computed typed `readonly string[]`; `useDropZone` gets
+`{ dataTypes }` not `{ dataTypes: dataTypes.value }`). Created
+`test/composables/useFileUpload.spec.ts` verbatim (composable-only; import paths
+identical in b24ui).
+
+## Tests
+No snapshots. New spec adds 14 tests × (nuxt/vue) → +2 test files (227→229),
+suite 5341 passed / 6 skipped (was 5313). Targeted run: 28 passed.
+
+## Verify (CI=true)
+`dev:prepare` · `lint` · `typecheck` · `test` · `build` — all green.

--- a/.sync/nuxt-ui.json
+++ b/.sync/nuxt-ui.json
@@ -2,7 +2,7 @@
   "upstream": "nuxt/ui",
   "branch": "v4",
   "sync_enabled": false,
-  "cursor": "2128414292aeec7d8fc3c724745eb6ea81d086b8",
+  "cursor": "000aba433df85a8b28dc16127a587fc18822b32f",
   "_cursor_note": "cursor = last upstream commit ported into b24ui (oldest-first, manual cadence). sync_enabled stays false until Phase 2 (porter workflow #67 + CLAUDE_CODE_OAUTH_TOKEN) is wired and trusted. `processed` is maintained per port from now on (backfilled #68-#72 on 2026-06-09).",
   "stats": {
     "queue_depth": 0,
@@ -959,10 +959,16 @@
       "summary": "feat(ContentToc): scroll list independently and center active link (#6697) — desktop TOC list scrolls independently (root lg:overflow-hidden + content lg:overflow-y-auto) and active link is centered via activeIndex computed + watch scrolling contentRef; useScrollShadow on content. b24ui adapted: sticky/max-h stays on docs class prop; theme root flex flex-col lg:overflow-hidden, container/top/bottom/trigger get min-h-0/shrink-0, content lg:overflow-y-auto. Deviation: no scrollbar-none in b24ui -> lg:scrollbar-thin lg:scrollbar-transparent. Not ported: [...slug].vue highlight/circuit (b24ui unsupported). 16 snapshots class-only. Tests 5309."
     },
     "2128414292aeec7d8fc3c724745eb6ea81d086b8": {
+      "pr": 259,
+      "b24ui_sha": "491d7c133a396b749a21f5fd6f84a30c0414402b",
+      "decision": "port",
+      "summary": "fix(defineShortcuts): add missing arrowdown to shiftable keys (#6702) — shiftableKeys had arrowright twice, omitted arrowdown, so shift_arrowdown never fired. b24ui composables/defineShortcuts.ts:41 had identical bug; fixed verbatim. Ported 2 tests (shift_arrowdown fires, bare arrowdown doesn't with Shift). No snapshots. Tests 5313."
+    },
+    "000aba433df85a8b28dc16127a587fc18822b32f": {
       "pr": null,
       "b24ui_sha": "pending-merge",
       "decision": "port",
-      "summary": "fix(defineShortcuts): add missing arrowdown to shiftable keys (#6702) — shiftableKeys had arrowright twice, omitted arrowdown, so shift_arrowdown never fired. b24ui composables/defineShortcuts.ts:41 had identical bug; fixed verbatim. Ported 2 tests (shift_arrowdown fires, bare arrowdown doesn't with Shift). No snapshots. Tests 5313."
+      "summary": "fix(useFileUpload): keep dropzone type filter reactive to accept (#6699) — useDropZone got dataTypes.value (static snapshot); pass computed ref dataTypes instead. parseAcceptToDataTypes returns [] not undefined for unrestricted; dataTypes typed readonly string[]. b24ui composable matched, applied verbatim. Created test/composables/useFileUpload.spec.ts verbatim (composable-only). +2 test files (229), tests 5341."
     }
   }
 }

--- a/src/runtime/composables/useFileUpload.ts
+++ b/src/runtime/composables/useFileUpload.ts
@@ -15,12 +15,13 @@ export interface UseFileUploadOptions {
   onUpdate: (files: File[]) => void
 }
 
-function parseAcceptToDataTypes(accept: string): string[] | undefined {
+function parseAcceptToDataTypes(accept: string): string[] {
+  // An empty list means no restriction (useDropZone allows all types).
   if (!accept || accept === '*') {
-    return undefined
+    return []
   }
 
-  const types = accept
+  return accept
     .split(',')
     .map((type) => {
       const trimmedType = type.trim()
@@ -33,8 +34,6 @@ function parseAcceptToDataTypes(accept: string): string[] | undefined {
     .filter((type) => {
       return !type.startsWith('.')
     })
-
-  return types.length > 0 ? types : undefined
 }
 
 export function useFileUpload(options: UseFileUploadOptions) {
@@ -48,7 +47,7 @@ export function useFileUpload(options: UseFileUploadOptions) {
   const inputRef = ref<ComponentPublicInstance>()
   const dropzoneRef = ref<HTMLDivElement>()
 
-  const dataTypes = computed(() => parseAcceptToDataTypes(unref(accept)))
+  const dataTypes = computed<readonly string[]>(() => parseAcceptToDataTypes(unref(accept)))
 
   const onDrop = (files: FileList | File[] | null, fromDropZone = false) => {
     if (!files || files.length === 0) {
@@ -87,7 +86,7 @@ export function useFileUpload(options: UseFileUploadOptions) {
 
   onMounted(() => {
     const { isOverDropZone } = dropzone
-      ? useDropZone(dropzoneRef, { dataTypes: dataTypes.value, onDrop: files => onDrop(files, true) })
+      ? useDropZone(dropzoneRef, { dataTypes, onDrop: files => onDrop(files, true) })
       : { isOverDropZone: ref(false) }
 
     watch(isOverDropZone, (value) => {

--- a/test/composables/useFileUpload.spec.ts
+++ b/test/composables/useFileUpload.spec.ts
@@ -1,0 +1,204 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { defineComponent, nextTick, ref, unref } from 'vue'
+import type { MaybeRef } from 'vue'
+import { mountSuspended } from '@nuxt/test-utils/runtime'
+import { useFileUpload } from '../../src/runtime/composables/useFileUpload'
+import type { UseFileUploadOptions } from '../../src/runtime/composables/useFileUpload'
+
+// Captures the callbacks that `useFileUpload` registers with the VueUse hooks
+// inside `onMounted`, so the test can drive drops and dialog changes directly.
+const vueuse = vi.hoisted(() => ({
+  dropOptions: undefined as { dataTypes?: MaybeRef<readonly string[]>, onDrop: (files: File[] | FileList | null) => void } | undefined,
+  onChangeCb: undefined as ((files: FileList | File[] | null) => void) | undefined,
+  open: undefined as ReturnType<typeof vi.fn> | undefined,
+  isOver: undefined as { value: boolean } | undefined
+}))
+
+vi.mock('@vueuse/core', async () => {
+  // Spread the real module so unrelated consumers (Nuxt internals) keep working.
+  const actual = await vi.importActual<typeof import('@vueuse/core')>('@vueuse/core')
+  const { ref } = await import('vue')
+
+  return {
+    ...actual,
+    useDropZone: (_target: unknown, options: any) => {
+      vueuse.dropOptions = options
+      vueuse.isOver = ref(false)
+      return { isOverDropZone: vueuse.isOver }
+    },
+    useFileDialog: () => {
+      vueuse.open = vi.fn()
+      return {
+        onChange: (cb: any) => {
+          vueuse.onChangeCb = cb
+        },
+        open: vueuse.open
+      }
+    }
+  }
+})
+
+function file(name: string): File {
+  return new File(['data'], name, { type: 'text/plain' })
+}
+
+async function mountUpload(options: UseFileUploadOptions) {
+  let api!: ReturnType<typeof useFileUpload>
+  const component = defineComponent({
+    setup() {
+      api = useFileUpload(options)
+      return () => null
+    }
+  })
+  const wrapper = await mountSuspended(component)
+  return { api, wrapper }
+}
+
+describe('useFileUpload', () => {
+  beforeEach(() => {
+    vueuse.dropOptions = undefined
+    vueuse.onChangeCb = undefined
+    vueuse.open = undefined
+    vueuse.isOver = undefined
+  })
+
+  describe('onDrop (drop zone)', () => {
+    it('forwards dropped files to onUpdate', async () => {
+      const onUpdate = vi.fn()
+      await mountUpload({ onUpdate, multiple: true })
+      const a = file('a.txt')
+      const b = file('b.txt')
+
+      vueuse.dropOptions!.onDrop([a, b])
+
+      expect(onUpdate).toHaveBeenCalledWith([a, b])
+    })
+
+    it('keeps only the first file when not multiple', async () => {
+      const onUpdate = vi.fn()
+      await mountUpload({ onUpdate, multiple: false })
+      const a = file('a.txt')
+      const b = file('b.txt')
+
+      vueuse.dropOptions!.onDrop([a, b])
+
+      expect(onUpdate).toHaveBeenCalledWith([a])
+    })
+
+    it('ignores an empty drop', async () => {
+      const onUpdate = vi.fn()
+      await mountUpload({ onUpdate })
+
+      vueuse.dropOptions!.onDrop([])
+
+      expect(onUpdate).not.toHaveBeenCalled()
+    })
+
+    it('ignores a null drop', async () => {
+      const onUpdate = vi.fn()
+      await mountUpload({ onUpdate })
+
+      vueuse.dropOptions!.onDrop(null)
+
+      expect(onUpdate).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('onChange (file dialog)', () => {
+    it('forwards selected files to onUpdate', async () => {
+      const onUpdate = vi.fn()
+      await mountUpload({ onUpdate })
+      const a = file('a.txt')
+
+      vueuse.onChangeCb!([a])
+
+      expect(onUpdate).toHaveBeenCalledWith([a])
+    })
+  })
+
+  describe('open', () => {
+    it('opens the native file dialog', async () => {
+      const onUpdate = vi.fn()
+      const { api } = await mountUpload({ onUpdate })
+
+      api.open()
+
+      expect(vueuse.open).toHaveBeenCalled()
+    })
+  })
+
+  describe('isDragging', () => {
+    it('follows the drop zone hover state', async () => {
+      const onUpdate = vi.fn()
+      const { api } = await mountUpload({ onUpdate })
+
+      expect(api.isDragging.value).toBe(false)
+
+      vueuse.isOver!.value = true
+      await nextTick()
+
+      expect(api.isDragging.value).toBe(true)
+    })
+  })
+
+  describe('accept parsing', () => {
+    it('passes wildcard MIME types to the drop zone as their base type', async () => {
+      await mountUpload({ onUpdate: vi.fn(), accept: 'image/*' })
+
+      expect(unref(vueuse.dropOptions!.dataTypes)).toEqual(['image'])
+    })
+
+    it('keeps full MIME types and drops extension filters', async () => {
+      // Drag items only expose MIME types, so `.pdf` can't be checked on drop.
+      await mountUpload({ onUpdate: vi.fn(), accept: '.pdf, image/png' })
+
+      expect(unref(vueuse.dropOptions!.dataTypes)).toEqual(['image/png'])
+    })
+
+    it('allows all types for the default accept', async () => {
+      // An empty list means no restriction for `useDropZone`.
+      await mountUpload({ onUpdate: vi.fn(), accept: '*' })
+
+      expect(unref(vueuse.dropOptions!.dataTypes)).toEqual([])
+    })
+
+    it('allows all types when accept only contains extensions', async () => {
+      await mountUpload({ onUpdate: vi.fn(), accept: '.pdf,.docx' })
+
+      expect(unref(vueuse.dropOptions!.dataTypes)).toEqual([])
+    })
+
+    it('keeps the drop zone filter reactive to accept changes', async () => {
+      const accept = ref('image/*')
+      await mountUpload({ onUpdate: vi.fn(), accept })
+
+      expect(unref(vueuse.dropOptions!.dataTypes)).toEqual(['image'])
+
+      accept.value = 'video/*'
+      await nextTick()
+
+      expect(unref(vueuse.dropOptions!.dataTypes)).toEqual(['video'])
+    })
+  })
+
+  describe('dropzone option', () => {
+    it('does not register a drop zone when dropzone is false', async () => {
+      const onUpdate = vi.fn()
+      await mountUpload({ onUpdate, dropzone: false })
+
+      expect(vueuse.dropOptions).toBeUndefined()
+    })
+  })
+
+  describe('refs', () => {
+    it('exposes input and drop zone refs', async () => {
+      const onUpdate = vi.fn()
+      const { api } = await mountUpload({ onUpdate })
+
+      expect(api.inputRef).toBeDefined()
+      expect(api.dropzoneRef).toBeDefined()
+      expect('value' in api.inputRef).toBe(true)
+      expect('value' in api.dropzoneRef).toBe(true)
+    })
+  })
+})


### PR DESCRIPTION
Syncs upstream nuxt/ui commit [`000aba4`](https://github.com/nuxt/ui/commit/000aba433df85a8b28dc16127a587fc18822b32f) — *fix(useFileUpload): keep dropzone type filter reactive to accept (#6699)*.

## What
`useFileUpload` passed `dataTypes.value` — a static snapshot — to `useDropZone`, so the dropzone MIME filter stopped tracking `accept` changes after mount. The fix passes the computed `dataTypes` ref directly so the filter stays reactive.

- `parseAcceptToDataTypes` now returns `[]` instead of `undefined` for unrestricted input (an empty list means "no restriction" for `useDropZone`), and `dataTypes` is typed `readonly string[]`.
- b24ui's composable matched upstream exactly, so the three changes applied verbatim.
- Added the upstream `test/composables/useFileUpload.spec.ts` (composable-only; import paths are identical in b24ui) — covering drop/dialog forwarding, `isDragging`, accept-parsing, the reactivity regression, the `dropzone: false` path, and exposed refs.

## Verify (`CI=true`)
`dev:prepare` · `lint` · `typecheck` · `test` · `build` — all green. Suite **5341 passed / 6 skipped** (+2 test files, 227→229). No snapshot changes.

Ledger: cursor advanced to `000aba4`; previous entry `2128414` reconciled to PR #259.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JS8ypVfQSFzYVZzkTHhURb)_