### PR TITLE
fix(useResizable): share resize logic between mouse and touch

### DIFF
--- a/.sync/log/730a54c023c5750a696df73879dbc806981e2d85.md
+++ b/.sync/log/730a54c023c5750a696df73879dbc806981e2d85.md
@@ -1,0 +1,25 @@
+# Port: fix(useResizable): share resize logic between mouse and touch (#6705)
+
+**Upstream:** `730a54c023c5750a696df73879dbc806981e2d85` (nuxt/ui)
+**Decision:** port — direct 1:1
+
+## Upstream change
+Deduplicates the identical `onMouseMove` / `onTouchMove` bodies into one
+`resize(clientX, initialPos, initialSize, rootFontSize)` helper. Also hoists the
+`getComputedStyle(...).fontSize` read out of the per-move path: a new
+`getRootFontSize()` is called **once per drag** in `onMouseDown` / `onTouchStart`
+(returns `1` when the unit isn't `rem`), avoiding a style recalc on every pointer
+move. Handlers now call `resize(e.clientX, …)` and `resize(e.touches[0].clientX, …)`
+(with a touch guard). `onTouchMove` is removed.
+
+## b24ui port
+b24ui's `src/runtime/composables/useResizable.ts` matched upstream exactly.
+Applied verbatim: replaced `onMouseMove` with `getRootFontSize` + `resize`,
+threaded `rootFontSize` through both start handlers, rewired `handleMouseMove` /
+`handleTouchMove`, and deleted `onTouchMove`.
+
+## Tests
+No test changes upstream. No snapshots. Suite unchanged: 5411 passed / 6 skipped.
+
+## Verify (CI=true)
+`dev:prepare` · `lint` · `typecheck` · `test` · `build` — all green.

--- a/.sync/nuxt-ui.json
+++ b/.sync/nuxt-ui.json
@@ -2,7 +2,7 @@
   "upstream": "nuxt/ui",
   "branch": "v4",
   "sync_enabled": false,
-  "cursor": "c257686a254906f7ffd333ed5da29c112924f7dd",
+  "cursor": "730a54c023c5750a696df73879dbc806981e2d85",
   "_cursor_note": "cursor = last upstream commit ported into b24ui (oldest-first, manual cadence). sync_enabled stays false until Phase 2 (porter workflow #67 + CLAUDE_CODE_OAUTH_TOKEN) is wired and trusted. `processed` is maintained per port from now on (backfilled #68-#72 on 2026-06-09).",
   "stats": {
     "queue_depth": 0,
@@ -977,10 +977,16 @@
       "summary": "fix(useScrollspy): unobserve previous headings on update (#6700) — observerCallback batches entry changes into a Set + single write (watcher runs once per callback); updateHeadings disconnect()s observer and resets visibleHeadings before re-observing so navigations don't accumulate stale targets. b24ui composable matched, applied verbatim. Created test/composables/useScrollspy.spec.ts verbatim (mock IntersectionObserver). +2 test files (231), tests 5355."
     },
     "c257686a254906f7ffd333ed5da29c112924f7dd": {
+      "pr": 262,
+      "b24ui_sha": "23db1a24c4182557ffa721c92753e392a3d4efad",
+      "decision": "port",
+      "summary": "test(composables): add specs for defineLocale, useKbd and useFormField (#6701) — test-only, 3 new specs. b24ui adaptations: defineLocale baseOptions +locale:'en' (b24ui requires locale field); useFormField error color assertion 'error'->'air-primary-alert' (b24ui token). useKbd verbatim. +6 test files (237), tests 5411."
+    },
+    "730a54c023c5750a696df73879dbc806981e2d85": {
       "pr": null,
       "b24ui_sha": "pending-merge",
       "decision": "port",
-      "summary": "test(composables): add specs for defineLocale, useKbd and useFormField (#6701) — test-only, 3 new specs. b24ui adaptations: defineLocale baseOptions +locale:'en' (b24ui requires locale field); useFormField error color assertion 'error'->'air-primary-alert' (b24ui token). useKbd verbatim. +6 test files (237), tests 5411."
+      "summary": "fix(useResizable): share resize logic between mouse and touch (#6705) — dedupe onMouseMove/onTouchMove into one resize(clientX,...) helper; hoist getComputedStyle fontSize read out of per-move path via getRootFontSize() called once per drag (returns 1 when unit != rem). b24ui composable matched, applied verbatim; onTouchMove removed. No tests/snapshots. Tests 5411."
     }
   }
 }

--- a/src/runtime/composables/useResizable.ts
+++ b/src/runtime/composables/useResizable.ts
@@ -141,7 +141,10 @@ export function useResizable(key: string, options: Ref<UseResizableProps> | UseR
 
   const isDragging = ref(false)
 
-  const onMouseMove = (e: MouseEvent, initialPos: number, initialSize: number): void => {
+  // Read once per drag: `getComputedStyle` on every pointer move forces a style recalc.
+  const getRootFontSize = () => opts.value.unit === 'rem' ? Number.parseFloat(getComputedStyle(document.documentElement).fontSize) : 1
+
+  const resize = (clientX: number, initialPos: number, initialSize: number, rootFontSize: number): void => {
     if (!el.value || !opts.value.resizable) {
       return
     }
@@ -152,11 +155,9 @@ export function useResizable(key: string, options: Ref<UseResizableProps> | UseR
     // In RTL mode, we need to invert the delta calculation
     let delta: number
     if (isRtl) {
-      // In RTL mode, invert the logic
-      delta = opts.value.side === 'left' ? initialPos - e.clientX : e.clientX - initialPos
+      delta = opts.value.side === 'left' ? initialPos - clientX : clientX - initialPos
     } else {
-      // Original LTR logic
-      delta = opts.value.side === 'left' ? e.clientX - initialPos : initialPos - e.clientX
+      delta = opts.value.side === 'left' ? clientX - initialPos : initialPos - clientX
     }
 
     const newSize = initialSize + delta
@@ -165,7 +166,6 @@ export function useResizable(key: string, options: Ref<UseResizableProps> | UseR
     let newValue: number
     if (opts.value.unit === 'rem') {
       // Convert pixels to rem
-      const rootFontSize = Number.parseFloat(getComputedStyle(document.documentElement).fontSize)
       newValue = newSize / rootFontSize
     } else if (opts.value.unit === 'px') {
       // Use pixel value directly
@@ -201,11 +201,12 @@ export function useResizable(key: string, options: Ref<UseResizableProps> | UseR
 
     const initialX = e.clientX
     const initialWidth = elWidth
+    const rootFontSize = getRootFontSize()
 
     isDragging.value = true
 
     const handleMouseMove = (e: MouseEvent) => {
-      onMouseMove(e, initialX, initialWidth)
+      resize(e.clientX, initialX, initialWidth, rootFontSize)
     }
 
     const handleMouseUp = () => {
@@ -216,51 +217,6 @@ export function useResizable(key: string, options: Ref<UseResizableProps> | UseR
 
     document.addEventListener('mousemove', handleMouseMove)
     document.addEventListener('mouseup', handleMouseUp)
-  }
-
-  const onTouchMove = (e: TouchEvent, initialPos: number, initialSize: number): void => {
-    if (!el.value || !opts.value.resizable || !e.touches[0]) {
-      return
-    }
-
-    const parentSize = el.value.parentElement?.offsetWidth || 1
-    const isRtl = dir.value === 'rtl'
-
-    // In RTL mode, we need to invert the delta calculation
-    let delta: number
-    if (isRtl) {
-      // In RTL mode, invert the logic
-      delta = opts.value.side === 'left' ? initialPos - e.touches[0].clientX : e.touches[0].clientX - initialPos
-    } else {
-      // Original LTR logic
-      delta = opts.value.side === 'left' ? e.touches[0].clientX - initialPos : initialPos - e.touches[0].clientX
-    }
-
-    const newSize = initialSize + delta
-
-    // Calculate size based on the selected unit
-    let newValue: number
-    if (opts.value.unit === 'rem') {
-      // Convert pixels to rem
-      const rootFontSize = Number.parseFloat(getComputedStyle(document.documentElement).fontSize)
-      newValue = newSize / rootFontSize
-    } else if (opts.value.unit === 'px') {
-      // Use pixel value directly
-      newValue = newSize
-    } else {
-      // Default percentage calculation
-      newValue = (newSize / parentSize) * 100
-    }
-
-    // Auto collapse when dragging near collapsedSize
-    if (opts.value.collapsible && newValue < (opts.value.collapsedSize + 4)) {
-      collapse(true)
-      return
-    } else if (isCollapsed.value) {
-      collapse(false)
-    }
-
-    size.value = Math.min(opts.value.maxSize, Math.max(opts.value.minSize, newValue))
   }
 
   const onTouchStart = (e: TouchEvent) => {
@@ -278,11 +234,14 @@ export function useResizable(key: string, options: Ref<UseResizableProps> | UseR
 
     const initialX = e.touches[0].clientX
     const initialWidth = elWidth
+    const rootFontSize = getRootFontSize()
 
     isDragging.value = true
 
     const handleTouchMove = (e: TouchEvent) => {
-      onTouchMove(e, initialX, initialWidth)
+      if (e.touches[0]) {
+        resize(e.touches[0].clientX, initialX, initialWidth, rootFontSize)
+      }
     }
 
     const handleTouchEnd = () => {


### PR DESCRIPTION
Syncs upstream nuxt/ui commit [`730a54c`](https://github.com/nuxt/ui/commit/730a54c023c5750a696df73879dbc806981e2d85) — *fix(useResizable): share resize logic between mouse and touch (#6705)*.

## What
Deduplicates the identical `onMouseMove` / `onTouchMove` bodies into a single `resize(clientX, initialPos, initialSize, rootFontSize)` helper, and moves the `getComputedStyle(...).fontSize` read out of the per-move hot path: a new `getRootFontSize()` runs **once per drag** in `onMouseDown` / `onTouchStart` (returning `1` when the unit isn't `rem`), avoiding a forced style recalc on every pointer move. The mouse/touch handlers now call `resize()` with the pointer's `clientX` (touch guarded on `e.touches[0]`), and `onTouchMove` is removed.

b24ui's composable matched upstream exactly, so the refactor applied verbatim.

## Verify (`CI=true`)
`dev:prepare` · `lint` · `typecheck` · `test` · `build` — all green. Suite **5411 passed / 6 skipped** (unchanged — no test/snapshot changes; the commit is composable-only).

Ledger: cursor advanced to `730a54c`; previous entry `c257686` reconciled to PR #262.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JS8ypVfQSFzYVZzkTHhURb)_