### PR TITLE
fix(useResizable): recover from corrupted persisted storage

### DIFF
--- a/.sync/log/4c607453fe405705e715c24801939bdc7acf6ba6.md
+++ b/.sync/log/4c607453fe405705e715c24801939bdc7acf6ba6.md
@@ -1,0 +1,33 @@
+# Port: fix(useResizable): recover from corrupted persisted storage (#6704)
+
+**Upstream:** `4c607453fe405705e715c24801939bdc7acf6ba6` (nuxt/ui)
+**Decision:** port — direct 1:1
+
+## Upstream change
+A persisted `null` (corrupted cookie/localStorage, or a cookie removed at
+runtime) bypasses the storage defaults and would crash on every property access.
+Fix: a `writeStorage(patch)` helper heals on write (assigns into
+`storageData.value` when present, else re-seeds from `defaultStorageValue`), and
+the `isCollapsed` / `size` getters use `?.` + a default fallback. The external
+`collapsed` watch now assigns through `isCollapsed.value` (which heals storage)
+instead of writing `storageData.value.collapsed` directly. Adds a full
+`useResizable.spec.ts`.
+
+## b24ui port
+b24ui's `src/runtime/composables/useResizable.ts` matched upstream (its
+storage/getter/watch shape is a 1:1 fork), so all four hunks applied verbatim:
+`writeStorage` helper; `isCollapsed`/`size` guarded getters + `writeStorage`
+setters; the initial-sync `storageData.value?.collapsed` guard; and the watch
+routing through `isCollapsed.value`. Created `test/composables/useResizable.spec.ts`
+verbatim — b24ui's `useResizable(key, options, { collapsed })` signature, return
+shape, and defaults (defaultSize 0, side left, unit px, …) match upstream, so the
+spec runs unadapted.
+
+## Tests
+No snapshots. New spec: 13 tests × (nuxt/vue) → +2 test files (237→239). The
+corrupted-storage cases exercise the fix (literal `null` in localStorage / cookie
+→ recover with defaults). Suite 5437 passed / 6 skipped (was 5411). Targeted run:
+26 passed.
+
+## Verify (CI=true)
+`dev:prepare` · `lint` · `typecheck` · `test` · `build` — all green.

--- a/.sync/nuxt-ui.json
+++ b/.sync/nuxt-ui.json
@@ -2,7 +2,7 @@
   "upstream": "nuxt/ui",
   "branch": "v4",
   "sync_enabled": false,
-  "cursor": "730a54c023c5750a696df73879dbc806981e2d85",
+  "cursor": "4c607453fe405705e715c24801939bdc7acf6ba6",
   "_cursor_note": "cursor = last upstream commit ported into b24ui (oldest-first, manual cadence). sync_enabled stays false until Phase 2 (porter workflow #67 + CLAUDE_CODE_OAUTH_TOKEN) is wired and trusted. `processed` is maintained per port from now on (backfilled #68-#72 on 2026-06-09).",
   "stats": {
     "queue_depth": 0,
@@ -983,10 +983,16 @@
       "summary": "test(composables): add specs for defineLocale, useKbd and useFormField (#6701) — test-only, 3 new specs. b24ui adaptations: defineLocale baseOptions +locale:'en' (b24ui requires locale field); useFormField error color assertion 'error'->'air-primary-alert' (b24ui token). useKbd verbatim. +6 test files (237), tests 5411."
     },
     "730a54c023c5750a696df73879dbc806981e2d85": {
+      "pr": 263,
+      "b24ui_sha": "82874398bfb9dc22082d8c0d440164061e64693b",
+      "decision": "port",
+      "summary": "fix(useResizable): share resize logic between mouse and touch (#6705) — dedupe onMouseMove/onTouchMove into one resize(clientX,...) helper; hoist getComputedStyle fontSize read out of per-move path via getRootFontSize() called once per drag (returns 1 when unit != rem). b24ui composable matched, applied verbatim; onTouchMove removed. No tests/snapshots. Tests 5411."
+    },
+    "4c607453fe405705e715c24801939bdc7acf6ba6": {
       "pr": null,
       "b24ui_sha": "pending-merge",
       "decision": "port",
-      "summary": "fix(useResizable): share resize logic between mouse and touch (#6705) — dedupe onMouseMove/onTouchMove into one resize(clientX,...) helper; hoist getComputedStyle fontSize read out of per-move path via getRootFontSize() called once per drag (returns 1 when unit != rem). b24ui composable matched, applied verbatim; onTouchMove removed. No tests/snapshots. Tests 5411."
+      "summary": "fix(useResizable): recover from corrupted persisted storage (#6704) — persisted null (corrupted cookie/localStorage) bypassed defaults and crashed on access. writeStorage(patch) heals on write; isCollapsed/size getters use ?. + default fallback; external collapsed watch routes through isCollapsed.value. b24ui composable matched, applied verbatim. Created useResizable.spec.ts verbatim (signature/defaults match). +2 test files (239), tests 5437."
     }
   }
 }

--- a/src/runtime/composables/useResizable.ts
+++ b/src/runtime/composables/useResizable.ts
@@ -116,8 +116,18 @@ export function useResizable(key: string, options: Ref<UseResizableProps> | UseR
       : useStorage<StorageType>(key, defaultStorageValue, undefined, opts.value.storageOptions)
     : ref(defaultStorageValue)
 
+  // A persisted `null` (corrupted cookie/localStorage or cookie removed at runtime) bypasses
+  // the storage defaults and would crash every access, so guard reads and heal on write (#6517).
+  const writeStorage = (patch: Partial<StorageType>) => {
+    if (storageData.value) {
+      Object.assign(storageData.value, patch)
+    } else {
+      storageData.value = { ...defaultStorageValue, ...patch }
+    }
+  }
+
   const isCollapsed = computed({
-    get: () => storageData.value.collapsed,
+    get: () => storageData.value?.collapsed ?? defaultStorageValue.collapsed,
     set: (value: boolean) => {
       if (!opts.value.collapsible) {
         return
@@ -126,15 +136,17 @@ export function useResizable(key: string, options: Ref<UseResizableProps> | UseR
       if (isRef(collapsed)) {
         collapsed.value = value
       }
-      storageData.value.collapsed = value
+      writeStorage({ collapsed: value })
     }
   })
 
   const previousSize = ref(opts.value.defaultSize)
 
   const size = computed({
-    get: () => storageData.value.size,
-    set: (value) => { storageData.value.size = value }
+    get: () => storageData.value?.size ?? opts.value.defaultSize,
+    set: (value) => {
+      writeStorage({ size: value })
+    }
   })
 
   const currentSize = computed(() => isCollapsed.value ? opts.value.collapsedSize : size.value)
@@ -287,7 +299,7 @@ export function useResizable(key: string, options: Ref<UseResizableProps> | UseR
   }
 
   // Initial sync of storage value to external collapsed ref
-  if (isRef(collapsed) && storageData.value.collapsed) {
+  if (isRef(collapsed) && storageData.value?.collapsed) {
     collapsed.value = storageData.value.collapsed
   }
 
@@ -298,8 +310,8 @@ export function useResizable(key: string, options: Ref<UseResizableProps> | UseR
         return
       }
 
-      if (storageData.value.collapsed !== value) {
-        storageData.value.collapsed = value
+      if (storageData.value?.collapsed !== value) {
+        isCollapsed.value = value
       }
     })
   }

--- a/test/composables/useResizable.spec.ts
+++ b/test/composables/useResizable.spec.ts
@@ -1,0 +1,195 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import { ref, nextTick } from 'vue'
+import { useResizable } from '../../src/runtime/composables/useResizable'
+
+// A fake pointer event carrying just what the handlers read.
+function mouseEvent(clientX = 0): MouseEvent {
+  return { clientX, preventDefault() {}, stopPropagation() {} } as unknown as MouseEvent
+}
+
+function touchEvent(clientX = 0): TouchEvent {
+  return { touches: [{ clientX }], preventDefault() {}, stopPropagation() {} } as unknown as TouchEvent
+}
+
+// An element with a known width whose parent has a known width, so the
+// percentage math in the drag handlers is deterministic.
+function mockEl(width = 100, parentWidth = 200): HTMLElement {
+  const parent = document.createElement('div')
+  Object.defineProperty(parent, 'offsetWidth', { value: parentWidth, configurable: true })
+  const el = document.createElement('div')
+  parent.appendChild(el)
+  el.getBoundingClientRect = () => ({ width, height: 0, top: 0, left: 0, right: 0, bottom: 0, x: 0, y: 0, toJSON: () => ({}) })
+  return el
+}
+
+describe('useResizable', () => {
+  afterEach(() => {
+    // The corrupted-storage tests write real localStorage/cookies; keep them out of other suites.
+    localStorage.clear()
+    for (const cookie of document.cookie.split(';')) {
+      const name = cookie.split('=')[0]!.trim()
+      if (name) {
+        document.cookie = `${name}=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/`
+      }
+    }
+  })
+
+  describe('defaults', () => {
+    it('exposes sensible defaults', () => {
+      const r = useResizable('def', { persistent: false })
+
+      expect(r.size.value).toBe(0)
+      expect(r.isDragging.value).toBe(false)
+      expect(r.isCollapsed.value).toBe(false)
+    })
+
+    it('uses the provided default size', () => {
+      const r = useResizable('ds', { persistent: false, defaultSize: 42 })
+
+      expect(r.size.value).toBe(42)
+    })
+  })
+
+  describe('collapse', () => {
+    it('toggles collapse and reports the collapsed size while collapsed', () => {
+      const r = useResizable('col', { persistent: false, collapsible: true, defaultSize: 60, collapsedSize: 5 })
+
+      expect(r.isCollapsed.value).toBe(false)
+      expect(r.size.value).toBe(60)
+
+      r.collapse()
+      expect(r.isCollapsed.value).toBe(true)
+      expect(r.size.value).toBe(5)
+
+      // Expanding restores the previous size.
+      r.collapse()
+      expect(r.isCollapsed.value).toBe(false)
+      expect(r.size.value).toBe(60)
+    })
+
+    it('accepts an explicit collapsed value', () => {
+      const r = useResizable('col-explicit', { persistent: false, collapsible: true, defaultSize: 30, collapsedSize: 0 })
+
+      r.collapse(true)
+      expect(r.isCollapsed.value).toBe(true)
+
+      r.collapse(true)
+      expect(r.isCollapsed.value).toBe(true)
+    })
+
+    it('does nothing when collapsible is false', () => {
+      const r = useResizable('no-col', { persistent: false, collapsible: false, defaultSize: 30 })
+
+      r.collapse(true)
+
+      expect(r.isCollapsed.value).toBe(false)
+      expect(r.size.value).toBe(30)
+    })
+
+    it('syncs with an external collapsed ref both ways', async () => {
+      const collapsed = ref(false)
+      const r = useResizable('ext', { persistent: false, collapsible: true, defaultSize: 50, collapsedSize: 0 }, { collapsed })
+
+      // Internal -> external
+      r.collapse(true)
+      await nextTick()
+      expect(collapsed.value).toBe(true)
+      expect(r.isCollapsed.value).toBe(true)
+
+      // External -> internal
+      collapsed.value = false
+      await nextTick()
+      expect(r.isCollapsed.value).toBe(false)
+    })
+  })
+
+  describe('onDoubleClick', () => {
+    it('expands a collapsed panel and resets to the default size', () => {
+      const r = useResizable('dbl', { persistent: false, collapsible: true, defaultSize: 40, collapsedSize: 0 })
+      r.el.value = mockEl()
+
+      r.collapse(true)
+      expect(r.size.value).toBe(0)
+
+      r.onDoubleClick(mouseEvent())
+
+      expect(r.isCollapsed.value).toBe(false)
+      expect(r.size.value).toBe(40)
+    })
+  })
+
+  describe('mouse drag', () => {
+    it('starts dragging, resizes as a percentage, then stops on mouseup', () => {
+      const r = useResizable('drag', { persistent: false, unit: '%', side: 'left', minSize: 0, maxSize: 100 })
+      r.el.value = mockEl(100, 200)
+
+      r.onMouseDown(mouseEvent(0))
+      expect(r.isDragging.value).toBe(true)
+
+      // width 100 + 50px delta = 150px over a 200px parent = 75%.
+      document.dispatchEvent(new MouseEvent('mousemove', { clientX: 50 }))
+      expect(r.size.value).toBe(75)
+
+      document.dispatchEvent(new MouseEvent('mouseup'))
+      expect(r.isDragging.value).toBe(false)
+    })
+
+    it('clamps the size to maxSize', () => {
+      const r = useResizable('clamp', { persistent: false, unit: '%', side: 'left', minSize: 10, maxSize: 60 })
+      r.el.value = mockEl(100, 200)
+
+      r.onMouseDown(mouseEvent(0))
+      // 100 + 300 = 400px over 200px = 200%, clamped to 60.
+      document.dispatchEvent(new MouseEvent('mousemove', { clientX: 300 }))
+      expect(r.size.value).toBe(60)
+
+      document.dispatchEvent(new MouseEvent('mouseup'))
+    })
+
+    it('ignores drag when not resizable', () => {
+      const r = useResizable('not-resizable', { persistent: false, resizable: false })
+      r.el.value = mockEl(100, 200)
+
+      r.onMouseDown(mouseEvent(0))
+
+      expect(r.isDragging.value).toBe(false)
+    })
+  })
+
+  describe('corrupted storage (#6517)', () => {
+    it('recovers with defaults when localStorage holds a literal null', () => {
+      // A literal `"null"` JSON-parses to `null`, bypassing the storage initial value.
+      localStorage.setItem('corrupted-local', 'null')
+
+      const r = useResizable('corrupted-local', { storage: 'local', collapsible: true, defaultSize: 25 })
+
+      expect(r.isCollapsed.value).toBe(false)
+      expect(r.size.value).toBe(25)
+
+      r.collapse(true)
+      expect(r.isCollapsed.value).toBe(true)
+    })
+
+    it('recovers with defaults when the persisted cookie parses to null', () => {
+      document.cookie = 'corrupted-cookie=null; path=/'
+
+      const r = useResizable('corrupted-cookie', { collapsible: true, defaultSize: 25 })
+
+      expect(r.isCollapsed.value).toBe(false)
+      expect(r.size.value).toBe(25)
+    })
+  })
+
+  describe('touch drag', () => {
+    it('starts dragging on touchstart and stops on touchend', () => {
+      const r = useResizable('touch', { persistent: false })
+      r.el.value = mockEl(100, 200)
+
+      r.onTouchStart(touchEvent(0))
+      expect(r.isDragging.value).toBe(true)
+
+      document.dispatchEvent(new Event('touchend'))
+      expect(r.isDragging.value).toBe(false)
+    })
+  })
+})


### PR DESCRIPTION
Syncs upstream nuxt/ui commit [`4c60745`](https://github.com/nuxt/ui/commit/4c607453fe405705e715c24801939bdc7acf6ba6) — *fix(useResizable): recover from corrupted persisted storage (#6704)*.

## What
A persisted `null` (corrupted cookie/localStorage, or a cookie removed at runtime) bypasses the storage defaults and would crash on every property access. The fix:

- Adds a `writeStorage(patch)` helper that **heals on write** — assigning into `storageData.value` when present, else re-seeding from `defaultStorageValue`.
- Guards the `isCollapsed` / `size` getters with `?.` + a default fallback so reads never crash on a `null` store.
- Routes the external `collapsed` watch through `isCollapsed.value` (which heals storage) instead of writing `storageData.value.collapsed` directly.

b24ui's composable matched upstream (its storage/getter/watch shape is a 1:1 fork), so all four hunks applied verbatim. Added the upstream `test/composables/useResizable.spec.ts` — b24ui's `useResizable(key, options, { collapsed })` signature, return shape, and defaults (defaultSize 0, side left, unit px, …) match upstream, so the spec runs unadapted; its corrupted-storage cases exercise the fix directly.

## Verify (`CI=true`)
`dev:prepare` · `lint` · `typecheck` · `test` · `build` — all green. Suite **5437 passed / 6 skipped** (+2 test files, 237→239). No snapshot changes.

Ledger: cursor advanced to `4c60745`; previous entry `730a54c` reconciled to PR #263.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JS8ypVfQSFzYVZzkTHhURb)_