### PR TITLE
fix(useToast): dedupe duplicate ids and handle max of 0

### DIFF
--- a/.sync/log/71c623b900a2b0997b60304e43e73397fea11dac.md
+++ b/.sync/log/71c623b900a2b0997b60304e43e73397fea11dac.md
@@ -1,0 +1,33 @@
+# Port: fix(useToast): dedupe duplicate ids and handle max of 0 (#6698)
+
+**Upstream:** `71c623b900a2b0997b60304e43e73397fea11dac` (nuxt/ui)
+**Decision:** port — direct 1:1
+
+## Upstream change
+Two fixes to `useToast`:
+1. **Dedupe at display time** — the duplicate-id merge is extracted into a
+   `mergeDuplicate(index, toast)` helper and applied inside `processQueue` (not
+   only in `add`), so two adds with the same id that queue before the list
+   drains — including from two separate `useToast()` instances, which each have
+   their own queue but share `toasts` — merge instead of double-inserting.
+2. **`max <= 0`** — `processQueue` now reads `maxValue = max?.value ?? 5` and,
+   when it's `<= 0`, clears `toasts` and skips the insert (previously
+   `slice(-0)` kept the whole array).
+   `await nextTick()` moved to the top of the loop.
+
+## b24ui port
+b24ui's `src/runtime/composables/useToast.ts` matched upstream exactly. Applied
+verbatim: added `mergeDuplicate`, rewrote the `processQueue` loop (nextTick →
+maxValue guard → display-time dedupe → slice), and replaced the inline merge in
+`add` with `mergeDuplicate(existingIndex, body)`. Created
+`test/composables/useToast.spec.ts` verbatim (composable-only; b24ui exports
+`useToast`, `toastMaxInjectionKey`, `Toast`; import paths identical).
+
+## Tests
+No snapshots. New spec: 15 tests × (nuxt/vue) → +2 test files (239→241). Covers
+add/dedupe (same-tick, cross-instance), max (default 5, provided, 0), update,
+remove (incl. `_updated` guard), clear. Suite 5467 passed / 6 skipped (was 5437).
+Targeted run: 30 passed.
+
+## Verify (CI=true)
+`dev:prepare` · `lint` · `typecheck` · `test` · `build` — all green.

--- a/.sync/nuxt-ui.json
+++ b/.sync/nuxt-ui.json
@@ -2,7 +2,7 @@
   "upstream": "nuxt/ui",
   "branch": "v4",
   "sync_enabled": false,
-  "cursor": "4c607453fe405705e715c24801939bdc7acf6ba6",
+  "cursor": "71c623b900a2b0997b60304e43e73397fea11dac",
   "_cursor_note": "cursor = last upstream commit ported into b24ui (oldest-first, manual cadence). sync_enabled stays false until Phase 2 (porter workflow #67 + CLAUDE_CODE_OAUTH_TOKEN) is wired and trusted. `processed` is maintained per port from now on (backfilled #68-#72 on 2026-06-09).",
   "stats": {
     "queue_depth": 0,
@@ -989,10 +989,16 @@
       "summary": "fix(useResizable): share resize logic between mouse and touch (#6705) — dedupe onMouseMove/onTouchMove into one resize(clientX,...) helper; hoist getComputedStyle fontSize read out of per-move path via getRootFontSize() called once per drag (returns 1 when unit != rem). b24ui composable matched, applied verbatim; onTouchMove removed. No tests/snapshots. Tests 5411."
     },
     "4c607453fe405705e715c24801939bdc7acf6ba6": {
+      "pr": 264,
+      "b24ui_sha": "70278936ee672acd7fa8d74cf2c3eef1b65c0c2b",
+      "decision": "port",
+      "summary": "fix(useResizable): recover from corrupted persisted storage (#6704) — persisted null (corrupted cookie/localStorage) bypassed defaults and crashed on access. writeStorage(patch) heals on write; isCollapsed/size getters use ?. + default fallback; external collapsed watch routes through isCollapsed.value. b24ui composable matched, applied verbatim. Created useResizable.spec.ts verbatim (signature/defaults match). +2 test files (239), tests 5437."
+    },
+    "71c623b900a2b0997b60304e43e73397fea11dac": {
       "pr": null,
       "b24ui_sha": "pending-merge",
       "decision": "port",
-      "summary": "fix(useResizable): recover from corrupted persisted storage (#6704) — persisted null (corrupted cookie/localStorage) bypassed defaults and crashed on access. writeStorage(patch) heals on write; isCollapsed/size getters use ?. + default fallback; external collapsed watch routes through isCollapsed.value. b24ui composable matched, applied verbatim. Created useResizable.spec.ts verbatim (signature/defaults match). +2 test files (239), tests 5437."
+      "summary": "fix(useToast): dedupe duplicate ids and handle max of 0 (#6698) — extract mergeDuplicate helper; dedupe at display time in processQueue (merges same-id toasts across separate useToast instances that share toasts); max<=0 clears list instead of slice(-0) keeping all; nextTick moved to loop top. b24ui composable matched, applied verbatim. Created useToast.spec.ts verbatim. +2 test files (241), tests 5467."
     }
   }
 }

--- a/src/runtime/composables/useToast.ts
+++ b/src/runtime/composables/useToast.ts
@@ -24,6 +24,14 @@ export function useToast() {
 
   const generateId = () => `${Date.now()}-${Math.random().toString(36).slice(2, 9)}`
 
+  function mergeDuplicate(index: number, toast: Toast) {
+    toasts.value[index] = {
+      ...toasts.value[index] as Toast,
+      ...toast,
+      _duplicate: ((toasts.value[index] as Toast)._duplicate || 0) + 1
+    }
+  }
+
   async function processQueue() {
     if (running.value || queue.length === 0) {
       return
@@ -32,11 +40,25 @@ export function useToast() {
     running.value = true
 
     while (queue.length > 0) {
-      const toast = queue.shift()!
-
       await nextTick()
 
-      toasts.value = [...toasts.value, toast].slice(-(max?.value ?? 5))
+      const toast = queue.shift()!
+      const maxValue = max?.value ?? 5
+      if (maxValue <= 0) {
+        if (toasts.value.length) {
+          toasts.value = []
+        }
+        continue
+      }
+
+      // Dedupe at display time so duplicate ids merge no matter which useToast() instance queued them.
+      const existingIndex = toasts.value.findIndex((t: Toast) => t.id === toast.id)
+      if (existingIndex !== -1) {
+        mergeDuplicate(existingIndex, toast)
+        continue
+      }
+
+      toasts.value = [...toasts.value, toast].slice(-maxValue)
     }
 
     running.value = false
@@ -51,11 +73,7 @@ export function useToast() {
 
     const existingIndex = toasts.value.findIndex((t: Toast) => t.id === body.id)
     if (existingIndex !== -1) {
-      toasts.value[existingIndex] = {
-        ...toasts.value[existingIndex] as Toast,
-        ...body,
-        _duplicate: ((toasts.value[existingIndex] as Toast)._duplicate || 0) + 1
-      }
+      mergeDuplicate(existingIndex, body)
 
       return body
     }

--- a/test/composables/useToast.spec.ts
+++ b/test/composables/useToast.spec.ts
@@ -1,0 +1,206 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { defineComponent, h, provide, ref } from 'vue'
+import { mountSuspended } from '@nuxt/test-utils/runtime'
+import { useToast, toastMaxInjectionKey } from '../../src/runtime/composables/useToast'
+import type { Toast } from '../../src/runtime/composables/useToast'
+
+describe('useToast', () => {
+  let toast: ReturnType<typeof useToast>
+
+  beforeEach(() => {
+    toast = useToast()
+    toast.clear()
+  })
+
+  afterEach(() => {
+    toast.clear()
+  })
+
+  describe('add', () => {
+    it('returns a toast with a generated id and open state', () => {
+      const body = toast.add({ title: 'Hello' })
+
+      expect(body.id).toBeDefined()
+      expect(body.open).toBe(true)
+      expect(body.title).toBe('Hello')
+    })
+
+    it('keeps an explicit id', () => {
+      const body = toast.add({ id: 'custom', title: 'Hello' })
+
+      expect(body.id).toBe('custom')
+    })
+
+    it('pushes the toast to the list after the queue drains', async () => {
+      toast.add({ id: 'a', title: 'A' })
+
+      await vi.waitFor(() => expect(toast.toasts.value).toHaveLength(1))
+      expect(toast.toasts.value[0]!.id).toBe('a')
+    })
+
+    it('increments _duplicate instead of adding a toast with an existing id', async () => {
+      toast.add({ id: 'dup', title: 'First' })
+      await vi.waitFor(() => expect(toast.toasts.value).toHaveLength(1))
+
+      toast.add({ id: 'dup', title: 'Second' })
+
+      expect(toast.toasts.value).toHaveLength(1)
+      expect(toast.toasts.value[0]!.title).toBe('Second')
+      expect(toast.toasts.value[0]!._duplicate).toBe(1)
+    })
+
+    it('does not duplicate a toast added twice with the same id in the same tick', async () => {
+      // Both adds land before the queue drains, so dedup must happen at display time.
+      toast.add({ id: 'dup', title: 'First' })
+      toast.add({ id: 'dup', title: 'Second' })
+
+      await vi.waitFor(() => expect(toast.toasts.value).toHaveLength(1))
+      await new Promise(resolve => setTimeout(resolve, 20))
+
+      expect(toast.toasts.value).toHaveLength(1)
+      expect(toast.toasts.value[0]!.title).toBe('Second')
+      expect(toast.toasts.value[0]!._duplicate).toBe(1)
+    })
+
+    it('does not duplicate a toast added from two useToast instances in the same tick', async () => {
+      // Each instance has its own queue, only `toasts` is shared, so the queues can't see each other.
+      const other = useToast()
+
+      toast.add({ id: 'cross-dup', title: 'First' })
+      other.add({ id: 'cross-dup', title: 'Second' })
+
+      await vi.waitFor(() => expect(toast.toasts.value).toHaveLength(1))
+      await new Promise(resolve => setTimeout(resolve, 20))
+
+      expect(toast.toasts.value).toHaveLength(1)
+      expect(toast.toasts.value[0]!.title).toBe('Second')
+      expect(toast.toasts.value[0]!._duplicate).toBe(1)
+    })
+  })
+
+  describe('max', () => {
+    it('keeps at most 5 toasts by default', async () => {
+      for (let i = 0; i < 7; i++) {
+        toast.add({ id: `t${i}`, title: `T${i}` })
+      }
+
+      await vi.waitFor(() => expect(toast.toasts.value).toHaveLength(5))
+      // Oldest are dropped, keeping the last 5.
+      expect(toast.toasts.value.map((t: Toast) => t.id)).toEqual(['t2', 't3', 't4', 't5', 't6'])
+    })
+
+    // `max` is injected, so it must be provided by an ancestor, not the same setup.
+    async function mountWithMax(maxValue: number) {
+      let scoped!: ReturnType<typeof useToast>
+      const Child = defineComponent({
+        setup() {
+          scoped = useToast()
+          return () => null
+        }
+      })
+      const Parent = defineComponent({
+        setup() {
+          provide(toastMaxInjectionKey, ref(maxValue))
+          return () => h(Child)
+        }
+      })
+      const wrapper = await mountSuspended(Parent)
+      scoped.clear()
+      return { scoped, wrapper }
+    }
+
+    it('respects a provided max', async () => {
+      const { scoped, wrapper } = await mountWithMax(2)
+
+      for (let i = 0; i < 4; i++) {
+        scoped.add({ id: `m${i}`, title: `M${i}` })
+      }
+
+      await vi.waitFor(() => expect(scoped.toasts.value).toHaveLength(2))
+      expect(scoped.toasts.value.map((t: Toast) => t.id)).toEqual(['m2', 'm3'])
+
+      wrapper.unmount()
+    })
+
+    it('displays no toasts when max is 0', async () => {
+      const { scoped, wrapper } = await mountWithMax(0)
+
+      scoped.add({ id: 'a' })
+      scoped.add({ id: 'b' })
+
+      await new Promise(resolve => setTimeout(resolve, 50))
+
+      expect(scoped.toasts.value).toHaveLength(0)
+
+      wrapper.unmount()
+    })
+  })
+
+  describe('update', () => {
+    it('updates the fields of an existing toast', async () => {
+      toast.add({ id: 'u', title: 'Before' })
+      await vi.waitFor(() => expect(toast.toasts.value).toHaveLength(1))
+
+      toast.update('u', { title: 'After' })
+
+      expect(toast.toasts.value[0]!.title).toBe('After')
+      expect(toast.toasts.value[0]!.open).toBe(true)
+    })
+
+    it('does nothing for an unknown id', async () => {
+      toast.add({ id: 'u', title: 'Before' })
+      await vi.waitFor(() => expect(toast.toasts.value).toHaveLength(1))
+
+      toast.update('missing', { title: 'After' })
+
+      expect(toast.toasts.value[0]!.title).toBe('Before')
+    })
+  })
+
+  describe('remove', () => {
+    it('closes then removes the toast after the exit delay', async () => {
+      toast.add({ id: 'r', title: 'Bye' })
+      await vi.waitFor(() => expect(toast.toasts.value).toHaveLength(1))
+
+      toast.remove('r')
+
+      // Closed immediately so the exit transition can play...
+      expect(toast.toasts.value[0]!.open).toBe(false)
+      // ...then dropped from the list once the transition is done.
+      await vi.waitFor(() => expect(toast.toasts.value).toHaveLength(0))
+    })
+
+    it('does not remove a toast that was just updated', async () => {
+      toast.add({ id: 'g', title: 'Keep' })
+      await vi.waitFor(() => expect(toast.toasts.value).toHaveLength(1))
+
+      // `update` flags the toast as `_updated` for the current tick.
+      toast.update('g', { title: 'Updated' })
+      toast.remove('g')
+
+      // The remove is ignored while the toast is flagged as updated.
+      expect(toast.toasts.value).toHaveLength(1)
+      expect(toast.toasts.value[0]!.open).toBe(true)
+    })
+
+    it('does nothing for an unknown id', async () => {
+      toast.add({ id: 'r', title: 'Bye' })
+      await vi.waitFor(() => expect(toast.toasts.value).toHaveLength(1))
+
+      expect(() => toast.remove('missing')).not.toThrow()
+      expect(toast.toasts.value).toHaveLength(1)
+    })
+  })
+
+  describe('clear', () => {
+    it('removes all toasts', async () => {
+      toast.add({ id: 'a' })
+      toast.add({ id: 'b' })
+      await vi.waitFor(() => expect(toast.toasts.value.length).toBeGreaterThan(0))
+
+      toast.clear()
+
+      expect(toast.toasts.value).toHaveLength(0)
+    })
+  })
+})


### PR DESCRIPTION
Syncs upstream nuxt/ui commit [`71c623b`](https://github.com/nuxt/ui/commit/71c623b900a2b0997b60304e43e73397fea11dac) — *fix(useToast): dedupe duplicate ids and handle max of 0 (#6698)*.

## What
Two fixes to the `useToast` composable:

1. **Dedupe at display time** — the duplicate-id merge is extracted into a `mergeDuplicate(index, toast)` helper and now also runs inside `processQueue`, not only in `add`. So two toasts with the same id that queue before the list drains — including from two separate `useToast()` instances (each has its own queue but shares `toasts`) — merge into one (incrementing `_duplicate`) instead of double-inserting.
2. **`max <= 0`** — `processQueue` reads `maxValue = max?.value ?? 5` and, when it's `<= 0`, clears `toasts` and skips the insert (previously `slice(-0)` kept the entire array). `await nextTick()` moved to the top of the loop.

b24ui's composable matched upstream exactly, so the changes applied verbatim. Added the upstream `test/composables/useToast.spec.ts` (composable-only; b24ui exports `useToast`, `toastMaxInjectionKey`, `Toast`; import paths identical) — covering add/dedupe (same-tick and cross-instance), max (default 5, provided, 0), update, remove (incl. the `_updated` guard), and clear.

## Verify (`CI=true`)
`dev:prepare` · `lint` · `typecheck` · `test` · `build` — all green. Suite **5467 passed / 6 skipped** (+2 test files, 239→241). No snapshot changes.

Ledger: cursor advanced to `71c623b`; previous entry `4c60745` reconciled to PR #264.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JS8ypVfQSFzYVZzkTHhURb)_