### PR TITLE
fix(defineShortcuts): defer standalone shortcuts that prefix a chain

### DIFF
--- a/.sync/log/76ee17697fdf2bf7a2e79fbe3c2d389b05934163.md
+++ b/.sync/log/76ee17697fdf2bf7a2e79fbe3c2d389b05934163.md
@@ -1,0 +1,37 @@
+# Port: fix(defineShortcuts): defer standalone shortcuts that prefix a chain (#5654)
+
+**Upstream:** `76ee17697fdf2bf7a2e79fbe3c2d389b05934163` (nuxt/ui)
+**Decision:** port — direct 1:1 (test matcher adapted)
+
+## Upstream change
+When a standalone shortcut (`f`) is also the first key of a chained shortcut
+(`f-h`), pressing `f` used to fire the standalone immediately and swallow the
+chain. Fix: hold the standalone back (`pendingShortcut` + `pendingTimer` via
+`useTimeoutFn`) until the chain either completes (cancel the pending standalone),
+the delay elapses (run it), or a non-completing key arrives (run it, then the new
+key). The held standalone is **re-resolved** before firing so a state change
+(e.g. focus moved into an input → disabled) is honored. Adds cached
+`chainedShortcuts` / `standardShortcuts` / `chainPrefixes` computeds so keydown
+doesn't re-filter each time. Adds 5 regression tests.
+
+## b24ui port
+b24ui's `src/runtime/composables/defineShortcuts.ts` matched upstream exactly, so
+all hunks applied verbatim: `useTimeoutFn` import; `chainDelay` +
+`pendingShortcut` / `cancelPendingShortcut` / `runPendingShortcut` /
+`pendingTimer`; the `onKeyDown` chain loop (`chainedShortcuts.value`,
+cancel/run-pending branches) and standard loop (`standardShortcuts.value` +
+chain-prefix hold-back); and the three cached computeds.
+
+### Deviation — test matcher
+b24ui's vitest setup registers only `vitest-axe/matchers` (no jest-extended), so
+`toHaveBeenCalledBefore` isn't available. The one order assertion was rewritten
+as `expect(f.mock.invocationCallOrder[0]).toBeLessThan(x.mock.invocationCallOrder[0])`
+(with a comment). All other test lines are verbatim, incl. the `afterEach`
+`document.body.innerHTML = ''` teardown.
+
+## Tests
+No snapshots. +5 tests × (nuxt/vue) in `defineShortcuts.spec.ts`. Suite 5477
+passed / 6 skipped (was 5467). Targeted run: 110 passed.
+
+## Verify (CI=true)
+`dev:prepare` · `lint` · `typecheck` · `test` · `build` — all green.

--- a/.sync/nuxt-ui.json
+++ b/.sync/nuxt-ui.json
@@ -2,7 +2,7 @@
   "upstream": "nuxt/ui",
   "branch": "v4",
   "sync_enabled": false,
-  "cursor": "71c623b900a2b0997b60304e43e73397fea11dac",
+  "cursor": "76ee17697fdf2bf7a2e79fbe3c2d389b05934163",
   "_cursor_note": "cursor = last upstream commit ported into b24ui (oldest-first, manual cadence). sync_enabled stays false until Phase 2 (porter workflow #67 + CLAUDE_CODE_OAUTH_TOKEN) is wired and trusted. `processed` is maintained per port from now on (backfilled #68-#72 on 2026-06-09).",
   "stats": {
     "queue_depth": 0,
@@ -995,10 +995,16 @@
       "summary": "fix(useResizable): recover from corrupted persisted storage (#6704) — persisted null (corrupted cookie/localStorage) bypassed defaults and crashed on access. writeStorage(patch) heals on write; isCollapsed/size getters use ?. + default fallback; external collapsed watch routes through isCollapsed.value. b24ui composable matched, applied verbatim. Created useResizable.spec.ts verbatim (signature/defaults match). +2 test files (239), tests 5437."
     },
     "71c623b900a2b0997b60304e43e73397fea11dac": {
+      "pr": 265,
+      "b24ui_sha": "80ec6f1057329d6d6fdfaa0dba676f9ac799b150",
+      "decision": "port",
+      "summary": "fix(useToast): dedupe duplicate ids and handle max of 0 (#6698) — extract mergeDuplicate helper; dedupe at display time in processQueue (merges same-id toasts across separate useToast instances that share toasts); max<=0 clears list instead of slice(-0) keeping all; nextTick moved to loop top. b24ui composable matched, applied verbatim. Created useToast.spec.ts verbatim. +2 test files (241), tests 5467."
+    },
+    "76ee17697fdf2bf7a2e79fbe3c2d389b05934163": {
       "pr": null,
       "b24ui_sha": "pending-merge",
       "decision": "port",
-      "summary": "fix(useToast): dedupe duplicate ids and handle max of 0 (#6698) — extract mergeDuplicate helper; dedupe at display time in processQueue (merges same-id toasts across separate useToast instances that share toasts); max<=0 clears list instead of slice(-0) keeping all; nextTick moved to loop top. b24ui composable matched, applied verbatim. Created useToast.spec.ts verbatim. +2 test files (241), tests 5467."
+      "summary": "fix(defineShortcuts): defer standalone shortcuts that prefix a chain (#5654) — a standalone that is the first key of a chain (f and f-h) is held back (pendingShortcut + pendingTimer via useTimeoutFn) until the chain completes (cancel), delay elapses (run), or a non-completing key arrives (run then new key); re-resolved before firing to honor state changes. Cached chainedShortcuts/standardShortcuts/chainPrefixes computeds. b24ui composable matched, applied verbatim. Deviation: rewrote toHaveBeenCalledBefore (no jest-extended in b24ui) as mock.invocationCallOrder compare. +5 tests. Tests 5477."
     }
   }
 }

--- a/src/runtime/composables/defineShortcuts.ts
+++ b/src/runtime/composables/defineShortcuts.ts
@@ -2,7 +2,7 @@
 /* eslint-disable regexp/no-super-linear-backtracking */
 import { ref, computed, toValue } from 'vue'
 import type { MaybeRef } from 'vue'
-import { useEventListener, useActiveElement, useDebounceFn } from '@vueuse/core'
+import { useEventListener, useActiveElement, useDebounceFn, useTimeoutFn } from '@vueuse/core'
 import { useKbd } from './useKbd'
 
 type Handler = (e?: any) => void
@@ -94,11 +94,39 @@ export function extractShortcuts(items: any[] | any[][], separator: '_' | '-' = 
 }
 
 export function defineShortcuts(config: MaybeRef<ShortcutsConfig>, options: ShortcutsOptions = {}) {
+  const chainDelay = options.chainDelay ?? 800
   const chainedInputs = ref<string[]>([])
   const clearChainedInput = () => {
     chainedInputs.value.splice(0, chainedInputs.value.length)
   }
-  const debouncedClearChainedInput = useDebounceFn(clearChainedInput, options.chainDelay ?? 800)
+  const debouncedClearChainedInput = useDebounceFn(clearChainedInput, chainDelay)
+
+  // A standalone shortcut that is also the first key of a chained shortcut (e.g. `f` and `f-h`)
+  // is held back until the chain either completes or the delay elapses, so pressing `f` doesn't
+  // fire the standalone and swallow the chain (#5654). Its `preventDefault` already ran on keydown.
+  let pendingShortcut: { shortcut: Shortcut, event: KeyboardEvent } | undefined
+  const cancelPendingShortcut = () => {
+    pendingShortcut = undefined
+    pendingTimer.stop()
+  }
+  const runPendingShortcut = () => {
+    const pending = pendingShortcut
+    cancelPendingShortcut()
+    if (!pending) {
+      return
+    }
+
+    // Re-resolve instead of trusting the held snapshot: `enabled` may have changed in the
+    // meantime (e.g. focus moved into an input), and the pending shortcut is always unmodified.
+    const shortcut = standardShortcuts.value.find(s => s.key === pending.shortcut.key && !s.metaKey && !s.ctrlKey && !s.altKey && !s.shiftKey)
+    if (shortcut?.enabled) {
+      shortcut.handler(pending.event)
+    }
+  }
+  const pendingTimer = useTimeoutFn(() => {
+    runPendingShortcut()
+    clearChainedInput()
+  }, chainDelay, { immediate: false })
 
   const { macOS } = useKbd()
   const activeElement = useActiveElement()
@@ -124,22 +152,31 @@ export function defineShortcuts(config: MaybeRef<ShortcutsConfig>, options: Shor
     if (chainedInputs.value.length >= 2) {
       chainedKey = chainedInputs.value.slice(-2).join('-')
 
-      for (const shortcut of shortcuts.value.filter(s => s.chained)) {
+      for (const shortcut of chainedShortcuts.value) {
         if (shortcut.key !== chainedKey) {
           continue
         }
 
         if (shortcut.enabled) {
+          // The chain completed, so the held-back standalone from its first key must not fire.
+          cancelPendingShortcut()
+
           e.preventDefault()
           shortcut.handler(e)
+        } else {
+          // A disabled chain must not swallow the held-back standalone.
+          runPendingShortcut()
         }
         clearChainedInput()
         return
       }
     }
 
+    // This key didn't complete a chain, so honor any standalone held back by the previous key.
+    runPendingShortcut()
+
     // try matching a standard shortcut
-    for (const shortcut of shortcuts.value.filter(s => !s.chained)) {
+    for (const shortcut of standardShortcuts.value) {
       if (layoutIndependent) {
         // compare by code
         if (e.code !== shortcut.key) {
@@ -170,6 +207,18 @@ export function defineShortcuts(config: MaybeRef<ShortcutsConfig>, options: Shor
       // Without meta/ctrl, shift changes the key itself (e.g. / -> ?) so the check is skipped.
       if ((alphabetKey || shiftableKey || shortcut.shiftKey || (e.shiftKey && (e.metaKey || e.ctrlKey))) && e.shiftKey !== shortcut.shiftKey) {
         continue
+      }
+
+      // If this key also starts a chained shortcut, hold it back until the chain can complete.
+      const isUnmodified = !shortcut.metaKey && !shortcut.ctrlKey && !shortcut.altKey && !shortcut.shiftKey
+      if (isUnmodified && chainPrefixes.value.has(shortcut.key)) {
+        if (shortcut.enabled) {
+          // Must run now: preventDefault is a no-op once the event finished dispatching.
+          e.preventDefault()
+        }
+        pendingShortcut = { shortcut, event: e }
+        pendingTimer.start()
+        return
       }
 
       if (shortcut.enabled) {
@@ -280,6 +329,12 @@ export function defineShortcuts(config: MaybeRef<ShortcutsConfig>, options: Shor
       return shortcut
     }).filter(Boolean) as Shortcut[]
   })
+
+  // Cached so each keydown doesn't re-filter (and re-allocate) the shortcuts list.
+  const chainedShortcuts = computed(() => shortcuts.value.filter(s => s.chained))
+  const standardShortcuts = computed(() => shortcuts.value.filter(s => !s.chained))
+  // First key of every chained shortcut, used to hold back a matching standalone shortcut.
+  const chainPrefixes = computed(() => new Set(chainedShortcuts.value.map(s => s.key.split('-')[0])))
 
   return useEventListener('keydown', onKeyDown)
 }

--- a/test/composables/defineShortcuts.spec.ts
+++ b/test/composables/defineShortcuts.spec.ts
@@ -19,6 +19,8 @@ describe('defineShortcuts', () => {
 
   afterEach(() => {
     wrapper?.unmount()
+    // Failure-safe teardown for tests that focus an input, so a thrown assertion can't leak focus.
+    document.body.innerHTML = ''
   })
 
   async function registerShortcuts(config: ShortcutsConfig, options?: ShortcutsOptions) {
@@ -470,6 +472,88 @@ describe('defineShortcuts', () => {
 
       fireKeydown('!', { shiftKey: true })
       expect(handler).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('chained shortcut sharing a prefix with a standalone (#5654)', () => {
+    it('fires the chain, not the standalone, when the sequence completes', async () => {
+      const f = vi.fn()
+      const fh = vi.fn()
+      const h = vi.fn()
+      await registerShortcuts({ f, 'f-h': fh, h })
+
+      fireKeydown('f')
+      fireKeydown('h')
+
+      expect(fh).toHaveBeenCalledOnce()
+      expect(f).not.toHaveBeenCalled()
+      expect(h).not.toHaveBeenCalled()
+    })
+
+    it('fires the standalone alone once the chain delay elapses', async () => {
+      const f = vi.fn()
+      const fh = vi.fn()
+      await registerShortcuts({ f, 'f-h': fh }, { chainDelay: 50 })
+
+      fireKeydown('f')
+      // Deferred: the standalone waits in case a chain follows.
+      expect(f).not.toHaveBeenCalled()
+
+      await new Promise(resolve => setTimeout(resolve, 80))
+
+      expect(f).toHaveBeenCalledOnce()
+      expect(fh).not.toHaveBeenCalled()
+    })
+
+    it('fires the pending standalone then the next key when the sequence does not complete', async () => {
+      const f = vi.fn()
+      const fh = vi.fn()
+      const x = vi.fn()
+      await registerShortcuts({ f, 'f-h': fh, x }, { chainDelay: 50 })
+
+      fireKeydown('f')
+      fireKeydown('x')
+
+      expect(f).toHaveBeenCalledOnce()
+      expect(x).toHaveBeenCalledOnce()
+      // b24ui's test setup registers only vitest-axe matchers (no jest-extended
+      // `toHaveBeenCalledBefore`), so assert order via the mock invocation order.
+      expect(f.mock.invocationCallOrder[0]!).toBeLessThan(x.mock.invocationCallOrder[0]!)
+      expect(fh).not.toHaveBeenCalled()
+    })
+
+    it('fires the held standalone when the completing chain is disabled', async () => {
+      const f = vi.fn()
+      const fh = vi.fn()
+      // The standalone stays enabled inside inputs, the chain does not.
+      await registerShortcuts({ 'f': { handler: f, usingInput: true }, 'f-h': fh }, { chainDelay: 50 })
+
+      const input = document.createElement('input')
+      document.body.appendChild(input)
+      input.focus()
+
+      fireKeydown('f')
+      fireKeydown('h')
+
+      expect(f).toHaveBeenCalledOnce()
+      expect(fh).not.toHaveBeenCalled()
+    })
+
+    it('does not fire a held standalone that got disabled before the delay elapsed', async () => {
+      const f = vi.fn()
+      const fh = vi.fn()
+      await registerShortcuts({ f, 'f-h': fh }, { chainDelay: 50 })
+
+      fireKeydown('f')
+
+      // Moving focus into an input disables the shortcut while it's still held back.
+      const input = document.createElement('input')
+      document.body.appendChild(input)
+      input.focus()
+
+      await new Promise(resolve => setTimeout(resolve, 80))
+
+      expect(f).not.toHaveBeenCalled()
     })
   })
 })


### PR DESCRIPTION
Syncs upstream nuxt/ui commit [`76ee176`](https://github.com/nuxt/ui/commit/76ee17697fdf2bf7a2e79fbe3c2d389b05934163) — *fix(defineShortcuts): defer standalone shortcuts that prefix a chain (#5654)*.

## What
When a standalone shortcut (`f`) is also the first key of a chained shortcut (`f-h`), pressing `f` used to fire the standalone immediately and swallow the chain. The fix holds the standalone back (`pendingShortcut` + `pendingTimer` via `useTimeoutFn`) until one of:

- **the chain completes** → cancel the pending standalone, fire the chain;
- **the chain delay elapses** → fire the standalone;
- **a non-completing key arrives** → fire the standalone, then the new key.

The held shortcut is **re-resolved** just before firing, so a state change in the meantime (e.g. focus moved into an input, disabling it) is honored. Also adds cached `chainedShortcuts` / `standardShortcuts` / `chainPrefixes` computeds so each keydown doesn't re-filter the shortcut list.

b24ui's composable matched upstream exactly, so the runtime hunks applied verbatim.

## Deviation — test matcher
b24ui's vitest setup registers only `vitest-axe/matchers` (no `jest-extended`), so `toHaveBeenCalledBefore` isn't available. The single call-order assertion was rewritten as `expect(f.mock.invocationCallOrder[0]).toBeLessThan(x.mock.invocationCallOrder[0])`. Everything else (the 5 new regression tests + the `document.body.innerHTML = ''` teardown) is verbatim.

## Verify (`CI=true`)
`dev:prepare` · `lint` · `typecheck` · `test` · `build` — all green. Suite **5477 passed / 6 skipped** (+10 across the two projects). No snapshot changes.

Ledger: cursor advanced to `76ee176`; previous entry `71c623b` reconciled to PR #265.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JS8ypVfQSFzYVZzkTHhURb)_