### PR TITLE
docs(sidebar): render examples with gpu transform

### DIFF
--- a/.sync/log/a037b71f830d624041ed70a0226a4b97f2a6a57e.md
+++ b/.sync/log/a037b71f830d624041ed70a0226a4b97f2a6a57e.md
@@ -1,0 +1,27 @@
+# Port: docs(sidebar): render examples with gpu transform (#6291)
+
+**Upstream:** `a037b71f830d624041ed70a0226a4b97f2a6a57e` (nuxt/ui)
+**Decision:** port — docs-only, direct 1:1
+
+## Upstream change
+Appends `transform-gpu` to the `class` of all 14 `::component-code` /
+`::component-example` blocks in `sidebar.md`
+(`!p-0 !justify-start h-[500px] contain-[paint]` → `… transform-gpu`), forcing
+GPU-accelerated rendering of the sidebar examples (#6291).
+
+## b24ui port
+b24ui's `docs/content/docs/2.components/sidebar.md` had the identical class on all
+14 example blocks. Appended ` transform-gpu` to each.
+
+### Note — pre-existing typo (not touched)
+One block (the first `sidebar-example`) carries a pre-existing fork typo in
+b24ui: `!justify-st2art` (stray `2`). Left as-is — fixing it is unrelated to this
+transform-gpu sync and would be a separate change; only ` transform-gpu` was
+appended.
+
+## Tests
+Docs-content (Markdown frontmatter) only — no runtime/theme/test/snapshot impact.
+Full suite unchanged: 5477 passed / 6 skipped.
+
+## Verify (CI=true)
+`dev:prepare` · `lint` · `typecheck` · `test` · `build` — all green.

--- a/.sync/nuxt-ui.json
+++ b/.sync/nuxt-ui.json
@@ -2,7 +2,7 @@
   "upstream": "nuxt/ui",
   "branch": "v4",
   "sync_enabled": false,
-  "cursor": "76ee17697fdf2bf7a2e79fbe3c2d389b05934163",
+  "cursor": "a037b71f830d624041ed70a0226a4b97f2a6a57e",
   "_cursor_note": "cursor = last upstream commit ported into b24ui (oldest-first, manual cadence). sync_enabled stays false until Phase 2 (porter workflow #67 + CLAUDE_CODE_OAUTH_TOKEN) is wired and trusted. `processed` is maintained per port from now on (backfilled #68-#72 on 2026-06-09).",
   "stats": {
     "queue_depth": 0,
@@ -1001,10 +1001,16 @@
       "summary": "fix(useToast): dedupe duplicate ids and handle max of 0 (#6698) — extract mergeDuplicate helper; dedupe at display time in processQueue (merges same-id toasts across separate useToast instances that share toasts); max<=0 clears list instead of slice(-0) keeping all; nextTick moved to loop top. b24ui composable matched, applied verbatim. Created useToast.spec.ts verbatim. +2 test files (241), tests 5467."
     },
     "76ee17697fdf2bf7a2e79fbe3c2d389b05934163": {
+      "pr": 266,
+      "b24ui_sha": "f79adba74aa55cb9b4a8fc24d9ce94209a3e4570",
+      "decision": "port",
+      "summary": "fix(defineShortcuts): defer standalone shortcuts that prefix a chain (#5654) — a standalone that is the first key of a chain (f and f-h) is held back (pendingShortcut + pendingTimer via useTimeoutFn) until the chain completes (cancel), delay elapses (run), or a non-completing key arrives (run then new key); re-resolved before firing to honor state changes. Cached chainedShortcuts/standardShortcuts/chainPrefixes computeds. b24ui composable matched, applied verbatim. Deviation: rewrote toHaveBeenCalledBefore (no jest-extended in b24ui) as mock.invocationCallOrder compare. +5 tests. Tests 5477."
+    },
+    "a037b71f830d624041ed70a0226a4b97f2a6a57e": {
       "pr": null,
       "b24ui_sha": "pending-merge",
       "decision": "port",
-      "summary": "fix(defineShortcuts): defer standalone shortcuts that prefix a chain (#5654) — a standalone that is the first key of a chain (f and f-h) is held back (pendingShortcut + pendingTimer via useTimeoutFn) until the chain completes (cancel), delay elapses (run), or a non-completing key arrives (run then new key); re-resolved before firing to honor state changes. Cached chainedShortcuts/standardShortcuts/chainPrefixes computeds. b24ui composable matched, applied verbatim. Deviation: rewrote toHaveBeenCalledBefore (no jest-extended in b24ui) as mock.invocationCallOrder compare. +5 tests. Tests 5477."
+      "summary": "docs(sidebar): render examples with gpu transform (#6291) — append transform-gpu to class of all 14 sidebar.md example blocks. b24ui had identical class; appended to each. Left pre-existing !justify-st2art typo untouched. Docs-content only, no test/snapshot impact. Tests 5477."
     }
   }
 }

--- a/docs/content/docs/2.components/sidebar.md
+++ b/docs/content/docs/2.components/sidebar.md
@@ -30,7 +30,7 @@ collapse: true
 prettier: true
 name: 'sidebar-example'
 overflowHidden: true
-class: '!p-0 !justify-st2art h-[500px] contain-[paint]'
+class: '!p-0 !justify-st2art h-[500px] contain-[paint] transform-gpu'
 ---
 ::
 
@@ -52,7 +52,7 @@ options:
       - floating
       - inset
     default: 'inset'
-class: '!p-0 !justify-start h-[500px] contain-[paint]'
+class: '!p-0 !justify-start h-[500px] contain-[paint] transform-gpu'
 ---
 ::
 
@@ -85,7 +85,7 @@ options:
       - floating
       - inset
     default: 'sidebar'
-class: '!p-0 !justify-start h-[500px] contain-[paint]'
+class: '!p-0 !justify-start h-[500px] contain-[paint] transform-gpu'
 ---
 ::
 
@@ -110,7 +110,7 @@ options:
       - left
       - right
     default: 'right'
-class: '!p-0 !justify-start h-[500px] contain-[paint]'
+class: '!p-0 !justify-start h-[500px] contain-[paint] transform-gpu'
 ---
 ::
 
@@ -134,7 +134,7 @@ slots:
   default: |
 
     <Placeholder class="h-full" />
-class: '!p-0 !justify-start h-[500px] contain-[paint]'
+class: '!p-0 !justify-start h-[500px] contain-[paint] transform-gpu'
 ---
 
 :placeholder{class="h-full"}
@@ -162,7 +162,7 @@ slots:
   default: |
 
     <Placeholder class="h-full" />
-class: '!p-0 !justify-start h-[500px] contain-[paint]'
+class: '!p-0 !justify-start h-[500px] contain-[paint] transform-gpu'
 ---
 
 :placeholder{class="h-full"}
@@ -190,7 +190,7 @@ slots:
   default: |
 
     <Placeholder class="h-full" />
-class: '!p-0 !justify-start h-[500px] contain-[paint]'
+class: '!p-0 !justify-start h-[500px] contain-[paint] transform-gpu'
 ---
 
 :placeholder{class="h-full"}
@@ -227,7 +227,7 @@ slots:
   default: |
 
     <Placeholder class="h-full" />
-class: '!p-0 !justify-start h-[500px] contain-[paint]'
+class: '!p-0 !justify-start h-[500px] contain-[paint] transform-gpu'
 ---
 
 :placeholder{class="h-full"}
@@ -269,7 +269,7 @@ slots:
   default: |
 
     <Placeholder class="h-full" />
-class: '!p-0 !justify-start h-[500px] contain-[paint]'
+class: '!p-0 !justify-start h-[500px] contain-[paint] transform-gpu'
 ---
 
 :placeholder{class="h-full"}
@@ -316,7 +316,7 @@ collapse: true
 prettier: true
 name: 'sidebar-open-example'
 overflowHidden: true
-class: '!p-0 !justify-start h-[500px] contain-[paint]'
+class: '!p-0 !justify-start h-[500px] contain-[paint] transform-gpu'
 ---
 ::
 
@@ -334,7 +334,7 @@ collapse: true
 prettier: true
 name: 'sidebar-persist-example'
 overflowHidden: true
-class: '!p-0 !justify-start h-[500px] contain-[paint]'
+class: '!p-0 !justify-start h-[500px] contain-[paint] transform-gpu'
 ---
 ::
 
@@ -354,7 +354,7 @@ collapse: true
 prettier: true
 name: 'sidebar-width-example'
 overflowHidden: true
-class: '!p-0 !justify-start h-[500px] contain-[paint]'
+class: '!p-0 !justify-start h-[500px] contain-[paint] transform-gpu'
 ---
 ::
 
@@ -368,7 +368,7 @@ collapse: true
 prettier: true
 name: 'sidebar-header-example'
 overflowHidden: true
-class: '!p-0 !justify-start h-[500px] contain-[paint]'
+class: '!p-0 !justify-start h-[500px] contain-[paint] transform-gpu'
 ---
 ::
 
@@ -386,7 +386,7 @@ collapse: true
 prettier: true
 name: 'sidebar-chat-example'
 overflowHidden: true
-class: '!p-0 !justify-start h-[500px] contain-[paint]'
+class: '!p-0 !justify-start h-[500px] contain-[paint] transform-gpu'
 ---
 ::
 


### PR DESCRIPTION
Syncs upstream nuxt/ui commit [`a037b71`](https://github.com/nuxt/ui/commit/a037b71f830d624041ed70a0226a4b97f2a6a57e) — *docs(sidebar): render examples with gpu transform (#6291)*.

## What
Appends `transform-gpu` to the `class` of all 14 example blocks in `sidebar.md` (`!p-0 !justify-start h-[500px] contain-[paint]` → `… transform-gpu`), forcing GPU-accelerated rendering of the sidebar examples. Docs-content (Markdown frontmatter) only — no runtime, theme, or test changes.

b24ui's `sidebar.md` had the identical class on all 14 blocks, so the change applied 1:1.

**Note:** one block carries a pre-existing fork typo (`!justify-st2art`, stray `2`). I left it untouched — fixing it is unrelated to this transform-gpu sync; only ` transform-gpu` was appended.

## Verify (`CI=true`)
`dev:prepare` · `lint` · `typecheck` · `test` · `build` — all green. Suite **5477 passed / 6 skipped** (unchanged; docs-content only). No snapshot changes.

Ledger: cursor advanced to `a037b71`; previous entry `76ee176` reconciled to PR #266.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JS8ypVfQSFzYVZzkTHhURb)_