### PR TITLE
chore(sync): no-op upstream page-hero mdc formatting fix

### DIFF
--- a/.sync/log/0f2b9da04eabe99619418c15cc9f26964896aaa7.md
+++ b/.sync/log/0f2b9da04eabe99619418c15cc9f26964896aaa7.md
@@ -1,0 +1,23 @@
+# No-op: docs(page-hero): wrong mdc formatting
+
+**Upstream:** `0f2b9da04eabe99619418c15cc9f26964896aaa7` (nuxt/ui)
+**Decision:** no-op (not applicable to b24ui)
+
+## Upstream change
+Removes a stray `#default{unwrap="p"}` MDC slot line from
+`docs/content/docs/2.components/page-hero.md` (invalid formatting in the
+PageHero component's example).
+
+## Why no-op for b24ui
+b24ui has **no `PageHero` component and no `page-hero.md` docs**. The fork ships
+its own `Page*` family (`Page`, `PageAside`, `PageBody`, `PageCard`,
+`PageCardGroup`, `PageColumns`, `PageFeature`, `PageGrid`, `PageHeader`,
+`PageLinks`, `PageList`, `PageSection`) but never included `PageHero`. There is no
+file to edit and no equivalent doc carrying the malformed MDC slot, so nothing to
+port.
+
+A repo-wide search for the exact malformed line (`#default{unwrap="p"}`) under
+`docs/content` returned no matches — confirming b24ui isn't affected.
+
+## Verify
+No code change (ledger/log only). Cursor advanced past `0f2b9da`.

--- a/.sync/nuxt-ui.json
+++ b/.sync/nuxt-ui.json
@@ -2,7 +2,7 @@
   "upstream": "nuxt/ui",
   "branch": "v4",
   "sync_enabled": false,
-  "cursor": "a037b71f830d624041ed70a0226a4b97f2a6a57e",
+  "cursor": "0f2b9da04eabe99619418c15cc9f26964896aaa7",
   "_cursor_note": "cursor = last upstream commit ported into b24ui (oldest-first, manual cadence). sync_enabled stays false until Phase 2 (porter workflow #67 + CLAUDE_CODE_OAUTH_TOKEN) is wired and trusted. `processed` is maintained per port from now on (backfilled #68-#72 on 2026-06-09).",
   "stats": {
     "queue_depth": 0,
@@ -1007,10 +1007,16 @@
       "summary": "fix(defineShortcuts): defer standalone shortcuts that prefix a chain (#5654) — a standalone that is the first key of a chain (f and f-h) is held back (pendingShortcut + pendingTimer via useTimeoutFn) until the chain completes (cancel), delay elapses (run), or a non-completing key arrives (run then new key); re-resolved before firing to honor state changes. Cached chainedShortcuts/standardShortcuts/chainPrefixes computeds. b24ui composable matched, applied verbatim. Deviation: rewrote toHaveBeenCalledBefore (no jest-extended in b24ui) as mock.invocationCallOrder compare. +5 tests. Tests 5477."
     },
     "a037b71f830d624041ed70a0226a4b97f2a6a57e": {
-      "pr": null,
-      "b24ui_sha": "pending-merge",
+      "pr": 267,
+      "b24ui_sha": "ca02e0f0079ef8714b47552f55465d017984e5f9",
       "decision": "port",
       "summary": "docs(sidebar): render examples with gpu transform (#6291) — append transform-gpu to class of all 14 sidebar.md example blocks. b24ui had identical class; appended to each. Left pre-existing !justify-st2art typo untouched. Docs-content only, no test/snapshot impact. Tests 5477."
+    },
+    "0f2b9da04eabe99619418c15cc9f26964896aaa7": {
+      "pr": null,
+      "b24ui_sha": "pending-merge",
+      "decision": "no-op",
+      "summary": "docs(page-hero): wrong mdc formatting — removes stray #default{unwrap=\"p\"} line from page-hero.md. NOT APPLICABLE: b24ui has no PageHero component and no page-hero.md docs (fork never included PageHero; ships its own Page* family). Repo-wide search for the malformed line found no matches. No-op."
     }
   }
 }


### PR DESCRIPTION
Records upstream nuxt/ui commit [`0f2b9da`](https://github.com/nuxt/ui/commit/0f2b9da04eabe99619418c15cc9f26964896aaa7) — *docs(page-hero): wrong mdc formatting* — as a **no-op** for b24ui.

## Why no-op
Upstream removes a stray `#default{unwrap="p"}` MDC slot line from `docs/content/docs/2.components/page-hero.md`. b24ui has **no `PageHero` component and no `page-hero.md`** — the fork ships its own `Page*` family (`Page`, `PageAside`, `PageBody`, `PageCard`, `PageCardGroup`, `PageColumns`, `PageFeature`, `PageGrid`, `PageHeader`, `PageLinks`, `PageList`, `PageSection`) but never included `PageHero`. A repo-wide search for the malformed line under `docs/content` returned no matches, so there is nothing to edit.

Ledger/log only — no code change. Cursor advanced to `0f2b9da`; previous entry `a037b71` reconciled to PR #267.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JS8ypVfQSFzYVZzkTHhURb)_