### PR TITLE
fix(types): type prose components in app config

### DIFF
--- a/.sync/log/d56e39a06c9bb8aee24ce2f294e41c4533ff086d.md
+++ b/.sync/log/d56e39a06c9bb8aee24ce2f294e41c4533ff086d.md
@@ -1,0 +1,34 @@
+# Port: fix(types): type prose components in app config (#6711)
+
+**Upstream:** `d56e39a06c9bb8aee24ce2f294e41c4533ff086d` (nuxt/ui)
+**Decision:** port — adapted to b24ui's merged `TVConfig`
+
+## Upstream change
+`TVConfig` treated every app-config key as a flat component config, so the
+`prose` key (itself a namespace of prose components — `prose.prompt`, `prose.pre`,
+…) wasn't typed correctly. Fix: for `P extends 'prose'`, recurse `TVConfig<T[P]>`
+so nested prose component configs are typed. Upstream applies the conditional to
+**both** halves of its intersected mapped type (the base/slots/variants block and
+the separate compoundVariants block).
+
+## b24ui port — single mapped type
+b24ui's `TVConfig` diverges: it's a **single** mapped type that already folds
+`compoundVariants` into the `K extends 'base' | 'slots' | 'variants' |
+'compoundVariants' | 'defaultVariants'` union (upstream splits it into two
+intersected mapped types). So the fix collapses to one edit — the `prose`
+conditional on b24ui's single `[P in keyof T]?:`:
+
+```ts
+[P in keyof T]?: P extends 'prose' ? TVConfig<T[P]> : { … }
+```
+
+Same semantics: `appConfig.b24ui.prose.<component>` is now recursively typed via
+`TVConfig` instead of as a flat component config.
+
+## Tests
+Type-only change; no test/snapshot impact. Typecheck (`vue-tsc` + all `nuxt
+typecheck` projects) green — the recursion resolves without regressions. Suite
+5477 passed / 6 skipped.
+
+## Verify (CI=true)
+`dev:prepare` · `lint` · `typecheck` · `test` · `build` — all green.

--- a/.sync/nuxt-ui.json
+++ b/.sync/nuxt-ui.json
@@ -2,7 +2,7 @@
   "upstream": "nuxt/ui",
   "branch": "v4",
   "sync_enabled": false,
-  "cursor": "0f2b9da04eabe99619418c15cc9f26964896aaa7",
+  "cursor": "d56e39a06c9bb8aee24ce2f294e41c4533ff086d",
   "_cursor_note": "cursor = last upstream commit ported into b24ui (oldest-first, manual cadence). sync_enabled stays false until Phase 2 (porter workflow #67 + CLAUDE_CODE_OAUTH_TOKEN) is wired and trusted. `processed` is maintained per port from now on (backfilled #68-#72 on 2026-06-09).",
   "stats": {
     "queue_depth": 0,
@@ -1013,10 +1013,16 @@
       "summary": "docs(sidebar): render examples with gpu transform (#6291) — append transform-gpu to class of all 14 sidebar.md example blocks. b24ui had identical class; appended to each. Left pre-existing !justify-st2art typo untouched. Docs-content only, no test/snapshot impact. Tests 5477."
     },
     "0f2b9da04eabe99619418c15cc9f26964896aaa7": {
-      "pr": null,
-      "b24ui_sha": "pending-merge",
+      "pr": 268,
+      "b24ui_sha": "2a8f9fe847bb9cce8581e0923d21fc7c7fce7b40",
       "decision": "no-op",
       "summary": "docs(page-hero): wrong mdc formatting — removes stray #default{unwrap=\"p\"} line from page-hero.md. NOT APPLICABLE: b24ui has no PageHero component and no page-hero.md docs (fork never included PageHero; ships its own Page* family). Repo-wide search for the malformed line found no matches. No-op."
+    },
+    "d56e39a06c9bb8aee24ce2f294e41c4533ff086d": {
+      "pr": null,
+      "b24ui_sha": "pending-merge",
+      "decision": "port",
+      "summary": "fix(types): type prose components in app config (#6711) — TVConfig now recurses for the prose key (P extends 'prose' ? TVConfig<T[P]> : {...}) so nested prose component configs are typed. Upstream edits both halves of its intersected mapped type; b24ui has a single merged mapped type (compoundVariants inline), so the fix collapses to one edit. Type-only. Tests 5477."
     }
   }
 }

--- a/src/runtime/types/tv.ts
+++ b/src/runtime/types/tv.ts
@@ -18,7 +18,7 @@ export type SlotClass = ClassValue | SlotClassReplacer
  * Defines the AppConfig object based on the tailwind-variants configuration.
  */
 export type TVConfig<T extends Record<string, any>> = {
-  [P in keyof T]?: {
+  [P in keyof T]?: P extends 'prose' ? TVConfig<T[P]> : {
     [K in keyof T[P]as K extends 'base' | 'slots' | 'variants' | 'compoundVariants' | 'defaultVariants' ? K : never]?: K extends 'base' ? SlotClass
       : K extends 'slots' ? {
         [S in keyof T[P]['slots']]?: SlotClass


### PR DESCRIPTION
Syncs upstream nuxt/ui commit [`d56e39a`](https://github.com/nuxt/ui/commit/d56e39a06c9bb8aee24ce2f294e41c4533ff086d) — *fix(types): type prose components in app config (#6711)*.

## What
`TVConfig` treated every app-config key as a flat component config, so the `prose` key — itself a namespace of prose components (`prose.prompt`, `prose.pre`, …) — wasn't typed correctly. The fix recurses `TVConfig<T[P]>` when `P extends 'prose'`, so nested prose component configs get proper typing.

## Adaptation
Upstream applies the conditional to **both** halves of its intersected mapped type (the base/slots/variants block and the separate `compoundVariants` block). b24ui's `TVConfig` diverges — it's a **single** mapped type that already folds `compoundVariants` into the `K extends …` union — so the fix collapses to one edit on b24ui's single `[P in keyof T]?:`:

```ts
[P in keyof T]?: P extends 'prose' ? TVConfig<T[P]> : { … }
```

Same semantics: `appConfig.b24ui.prose.<component>` is now recursively typed via `TVConfig` instead of as a flat component config.

## Verify (`CI=true`)
`dev:prepare` · `lint` · `typecheck` · `test` · `build` — all green. Type-only change; typecheck (`vue-tsc` + all `nuxt typecheck` projects) resolves the recursion with no regressions. Suite **5477 passed / 6 skipped**. No snapshot changes.

Ledger: cursor advanced to `d56e39a`; previous entry `0f2b9da` reconciled to PR #268.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JS8ypVfQSFzYVZzkTHhURb)_