### PR TITLE
fix(Editor): prevent suggestion menu blinking on keystroke

### DIFF
--- a/.sync/log/7e6d8b0e69c6de392c2df45008f4722c1eda740d.md
+++ b/.sync/log/7e6d8b0e69c6de392c2df45008f4722c1eda740d.md
@@ -1,0 +1,29 @@
+# Port: fix(Editor): prevent suggestion menu blinking on keystroke (#6712)
+
+**Upstream:** `7e6d8b0e69c6de392c2df45008f4722c1eda740d` (nuxt/ui)
+**Decision:** port — direct 1:1
+
+## Upstream change
+The tiptap suggestion plugin emits a **loading pass** (placeholder/empty items)
+before the resolved items arrive. `useEditorMenu`'s `onStart`/`onUpdate` acted on
+that pass, opening the menu with no items and destroying+recreating it on every
+keystroke (blinking). Fix:
+- **`onStart`** — move the `filteredItems` assignment below a
+  `if (suggestionProps.loading) return` guard (placed after `triggerClientRect`),
+  so the loading pass is skipped and the menu doesn't open empty.
+- **`onUpdate`** — hoist `commandFn = …` to the top (so the command stays current
+  even during loading), then `if (suggestionProps.loading) return` before
+  re-filtering, so the mounted menu isn't torn down and rebuilt mid-fetch.
+
+## b24ui port
+b24ui's `src/runtime/composables/useEditorMenu.ts` `handlers` matched upstream's
+pre-fix shape, so both hunks applied 1:1 (reordered `onStart` body + loading
+guard; hoisted `commandFn` + loading guard in `onUpdate`). `suggestionProps.loading`
+typechecks against the tiptap `SuggestionProps` b24ui already uses.
+
+## Tests
+No test changes upstream. No snapshots. Suite unchanged: 5477 passed / 6 skipped.
+Typecheck confirms the `loading` field resolves.
+
+## Verify (CI=true)
+`dev:prepare` · `lint` · `typecheck` · `test` · `build` — all green.

--- a/.sync/nuxt-ui.json
+++ b/.sync/nuxt-ui.json
@@ -2,7 +2,7 @@
   "upstream": "nuxt/ui",
   "branch": "v4",
   "sync_enabled": false,
-  "cursor": "d56e39a06c9bb8aee24ce2f294e41c4533ff086d",
+  "cursor": "7e6d8b0e69c6de392c2df45008f4722c1eda740d",
   "_cursor_note": "cursor = last upstream commit ported into b24ui (oldest-first, manual cadence). sync_enabled stays false until Phase 2 (porter workflow #67 + CLAUDE_CODE_OAUTH_TOKEN) is wired and trusted. `processed` is maintained per port from now on (backfilled #68-#72 on 2026-06-09).",
   "stats": {
     "queue_depth": 0,
@@ -1019,10 +1019,16 @@
       "summary": "docs(page-hero): wrong mdc formatting — removes stray #default{unwrap=\"p\"} line from page-hero.md. NOT APPLICABLE: b24ui has no PageHero component and no page-hero.md docs (fork never included PageHero; ships its own Page* family). Repo-wide search for the malformed line found no matches. No-op."
     },
     "d56e39a06c9bb8aee24ce2f294e41c4533ff086d": {
+      "pr": 269,
+      "b24ui_sha": "72890090a7625dba298a24d4b501697f43b6f780",
+      "decision": "port",
+      "summary": "fix(types): type prose components in app config (#6711) — TVConfig now recurses for the prose key (P extends 'prose' ? TVConfig<T[P]> : {...}) so nested prose component configs are typed. Upstream edits both halves of its intersected mapped type; b24ui has a single merged mapped type (compoundVariants inline), so the fix collapses to one edit. Type-only. Tests 5477."
+    },
+    "7e6d8b0e69c6de392c2df45008f4722c1eda740d": {
       "pr": null,
       "b24ui_sha": "pending-merge",
       "decision": "port",
-      "summary": "fix(types): type prose components in app config (#6711) — TVConfig now recurses for the prose key (P extends 'prose' ? TVConfig<T[P]> : {...}) so nested prose component configs are typed. Upstream edits both halves of its intersected mapped type; b24ui has a single merged mapped type (compoundVariants inline), so the fix collapses to one edit. Type-only. Tests 5477."
+      "summary": "fix(Editor): prevent suggestion menu blinking on keystroke (#6712) — tiptap suggestion plugin emits a loading pass (placeholder items) before resolved items; onStart/onUpdate acted on it, opening empty and tearing down/recreating the menu each keystroke. onStart: move filteredItems below a `if (suggestionProps.loading) return` guard; onUpdate: hoist commandFn to top then loading guard before re-filtering. b24ui handlers matched, applied 1:1. Type-only tiptap loading field typechecks. Tests 5477."
     }
   }
 }

--- a/src/runtime/composables/useEditorMenu.ts
+++ b/src/runtime/composables/useEditorMenu.ts
@@ -572,11 +572,6 @@ export function useEditorMenu<T = any>(options: EditorMenuOptions<T>) {
 
       const handlers = {
         onStart: (suggestionProps: SuggestionProps) => {
-          // When ignoreFilter is true, always use fresh items from the reactive source
-          filteredItems.value = options.ignoreFilter
-            ? items.value.slice(0, limit)
-            : suggestionProps.items as T[]
-
           // Start at first selectable item (index 0 in selectableItems)
           selectedIndex.value = 0
 
@@ -586,6 +581,17 @@ export function useEditorMenu<T = any>(options: EditorMenuOptions<T>) {
           // Store the trigger position (where the `/`, `@`, or `:` is)
           triggerClientRect = suggestionProps.clientRect as () => DOMRect | null
 
+          // The suggestion plugin emits a loading pass with placeholder (empty) items
+          // before the resolved items arrive; skip it to avoid opening with no items.
+          if (suggestionProps.loading) {
+            return
+          }
+
+          // When ignoreFilter is true, always use fresh items from the reactive source
+          filteredItems.value = options.ignoreFilter
+            ? items.value.slice(0, limit)
+            : suggestionProps.items as T[]
+
           // Only show menu if there are items
           if (!filteredItems.value.length) {
             return
@@ -594,13 +600,19 @@ export function useEditorMenu<T = any>(options: EditorMenuOptions<T>) {
           showMenu()
         },
         onUpdate: (suggestionProps: SuggestionProps) => {
+          // Update the command function
+          commandFn = (item: T) => suggestionProps.command(item)
+
+          // Skip the loading pass (placeholder items) so the menu stays mounted while the
+          // resolved items are fetched, otherwise it is destroyed and recreated on every keystroke.
+          if (suggestionProps.loading) {
+            return
+          }
+
           // When ignoreFilter is true, always use fresh items from the reactive source
           filteredItems.value = options.ignoreFilter
             ? items.value.slice(0, limit)
             : suggestionProps.items as T[]
-
-          // Update the command function
-          commandFn = (item: T) => suggestionProps.command(item)
 
           // Reset selected index if out of bounds (comparing against selectableItems)
           if (selectedIndex.value >= selectableItems.value.length) {


### PR DESCRIPTION
Syncs upstream nuxt/ui commit [`7e6d8b0`](https://github.com/nuxt/ui/commit/7e6d8b0e69c6de392c2df45008f4722c1eda740d) — *fix(Editor): prevent suggestion menu blinking on keystroke (#6712)*.

## What
The tiptap suggestion plugin emits a **loading pass** (placeholder/empty items) before the resolved items arrive. `useEditorMenu`'s `onStart`/`onUpdate` acted on that pass — opening the menu with no items and destroying + recreating it on every keystroke (the blinking). The fix guards both handlers:

- **`onStart`** — the `filteredItems` assignment moves below a `if (suggestionProps.loading) return` guard (after `triggerClientRect`), so the loading pass no longer opens the menu empty.
- **`onUpdate`** — `commandFn = …` is hoisted to the top (so the command stays current even during loading), then `if (suggestionProps.loading) return` runs before re-filtering, so the mounted menu isn't torn down and rebuilt mid-fetch.

b24ui's `useEditorMenu.ts` `handlers` matched upstream's pre-fix shape, so both hunks applied 1:1.

## Verify (`CI=true`)
`dev:prepare` · `lint` · `typecheck` · `test` · `build` — all green. `suggestionProps.loading` typechecks against the tiptap `SuggestionProps` b24ui already uses. Suite **5477 passed / 6 skipped**. No test/snapshot changes (composable-only).

Ledger: cursor advanced to `7e6d8b0`; previous entry `d56e39a` reconciled to PR #269.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JS8ypVfQSFzYVZzkTHhURb)_