### PR TITLE
feat(ChatPrompt): add body slot

### DIFF
--- a/.sync/log/123184b5c72fd3f7d4b6c032a6dd4b52a5046e6e.md
+++ b/.sync/log/123184b5c72fd3f7d4b6c032a6dd4b52a5046e6e.md
@@ -1,0 +1,49 @@
+# Port: feat(ChatPrompt): add body slot and focus highlight (#6709)
+
+**Upstream:** `123184b5c72fd3f7d4b6c032a6dd4b52a5046e6e` (nuxt/ui)
+**Decision:** port (partial — body slot ported; color / focus-highlight deferred)
+
+## Upstream change
+Two features:
+1. **`body` slot** — replaces the internal textarea (e.g. render an Editor with
+   mentions), exposing `submit`/`close`/`placeholder`/`disabled`/`ui`. `submit`
+   and `close` become event-optional (`e ?? new Event(...)`) so a custom body can
+   call them without a DOM event.
+2. **`color` prop + focus highlight** — the theme becomes a function of module
+   `options`, adds a `color` variant driven by `options.theme.colors`, and
+   compound variants that ring/outline-highlight the prompt when the inner
+   `textarea` / `[contenteditable]` is `:focus-visible` (a `focusHighlight`
+   helper using `ring-${color}` / `outline-${color}` / `inverted`).
+
+## b24ui port — body slot only
+b24ui's `ChatPrompt.vue` matched the pre-fix textarea structure, so the **body
+slot** ported cleanly (adapted to b24ui: `B24Textarea`, `b24ui` prop instead of
+`ui`, and the slot exposes `:b24ui="b24ui"`):
+- `ChatPromptSlots` gains `body?(props: { submit, close, placeholder, disabled, b24ui })`;
+- `getProxySlots` also omits `body`;
+- `submit(e?: Event)` / `blur(e?: Event)` → `emits(..., e ?? new Event(...))`;
+- template wraps `B24Textarea` as the `body` slot's default content.
+Ported the 3 upstream body-slot tests + the `with body slot` render case.
+
+### Deferred — `color` prop + focus highlight
+b24ui's `chat-prompt.ts` theme is a **static** object with the fork's own air
+`variant` set (`outline`/`tinted`/`filled`/`plain`, using `--ui-color-design-*`
+tokens) — it has no `color` variant and does not use upstream's
+`options.theme.colors` palette. The `color` prop, the theme's function
+conversion, and the `focusHighlight` compound variants (`ring-${color}` /
+`outline-${color}` / `inverted`) are all tied to that absent color system, so
+they're deferred to a dedicated b24ui ChatPrompt design pass — the `color?` prop
+and `color: props.color` `tv()` argument were **not** added. (Same split as the
+ChatTool `actions` port vs its v7-entangled flow.)
+
+Docs/playground: the upstream docs/playground additions demonstrate the color +
+Editor-body examples; the b24ui-relevant Editor-body example depends on the
+deferred color styling, so docs weren't touched in this port.
+
+## Tests
+New `with body slot` render case → 2 snapshots **written**, 0 existing updated (a
+slot with default content renders the same DOM when unused, so no churn). +3
+body-slot unit tests × (nuxt/vue). Suite 5485 passed / 6 skipped (was 5477).
+
+## Verify (CI=true)
+`dev:prepare` · `lint` · `typecheck` · `test` · `build` — all green.

--- a/.sync/nuxt-ui.json
+++ b/.sync/nuxt-ui.json
@@ -2,7 +2,7 @@
   "upstream": "nuxt/ui",
   "branch": "v4",
   "sync_enabled": false,
-  "cursor": "76d613c590ed8f0ac7884aa3c3ca2cd5027da6e2",
+  "cursor": "123184b5c72fd3f7d4b6c032a6dd4b52a5046e6e",
   "_cursor_note": "cursor = last upstream commit ported into b24ui (oldest-first, manual cadence). sync_enabled stays false until Phase 2 (porter workflow #67 + CLAUDE_CODE_OAUTH_TOKEN) is wired and trusted. `processed` is maintained per port from now on (backfilled #68-#72 on 2026-06-09).",
   "stats": {
     "queue_depth": 0,
@@ -1031,10 +1031,16 @@
       "summary": "fix(Editor): prevent suggestion menu blinking on keystroke (#6712) — tiptap suggestion plugin emits a loading pass (placeholder items) before resolved items; onStart/onUpdate acted on it, opening empty and tearing down/recreating the menu each keystroke. onStart: move filteredItems below a `if (suggestionProps.loading) return` guard; onUpdate: hoist commandFn to top then loading guard before re-filtering. b24ui handlers matched, applied 1:1. Type-only tiptap loading field typechecks. Tests 5477."
     },
     "76d613c590ed8f0ac7884aa3c3ca2cd5027da6e2": {
+      "pr": 271,
+      "b24ui_sha": "3ef8d015d8e59157c3705524a3f93f5718372128",
+      "decision": "port",
+      "summary": "feat(Editor): allow disabling starter kit for plain text (#6713) — starterKit prop now boolean | Partial<StarterKitOptions> (default true); false gives plain-text editor (plainText override disables all formatting, keeps essential nodes), Code/HorizontalRule gated behind props.starterKit !== false. b24ui Editor.vue matched, applied verbatim; kept b24ui dropcursor token var(--ui-color-accent-main-primary). Docs: added ::tip in editor.md. Default true reproduces prior config -> no snapshot churn. Tests 5477."
+    },
+    "123184b5c72fd3f7d4b6c032a6dd4b52a5046e6e": {
       "pr": null,
       "b24ui_sha": "pending-merge",
       "decision": "port",
-      "summary": "feat(Editor): allow disabling starter kit for plain text (#6713) — starterKit prop now boolean | Partial<StarterKitOptions> (default true); false gives plain-text editor (plainText override disables all formatting, keeps essential nodes), Code/HorizontalRule gated behind props.starterKit !== false. b24ui Editor.vue matched, applied verbatim; kept b24ui dropcursor token var(--ui-color-accent-main-primary). Docs: added ::tip in editor.md. Default true reproduces prior config -> no snapshot churn. Tests 5477."
+      "summary": "feat(ChatPrompt): add body slot and focus highlight (#6709) — PARTIAL. Ported the body slot (replaces internal textarea; exposes submit/close/placeholder/disabled/b24ui; submit/blur event-optional via e ?? new Event) adapted to b24ui (B24Textarea, b24ui prop). +3 body-slot tests + render case; 2 snapshots written, no existing churn. DEFERRED the color prop + focus-highlight theme: b24ui chat-prompt.ts is a static theme with air variant set (outline/tinted/filled/plain, --ui-color-design-* tokens), no color variant / options.theme.colors, so the color variant + function conversion + focusHighlight compoundVariants are entangled with an absent color system. Tests 5485."
     }
   }
 }

--- a/src/runtime/components/ChatPrompt.vue
+++ b/src/runtime/components/ChatPrompt.vue
@@ -43,6 +43,10 @@ export interface ChatPromptSlots extends Omit<TextareaSlots, 'default'> {
   // @memo: this is our modification.
   default?(props: { b24ui: ChatPrompt['slots'] }): VNode[]
   footer?(props?: {}): VNode[]
+  /**
+   * Replace the internal textarea, e.g. to render an [Editor](/docs/components/editor/) with mentions.
+   */
+  body?(props: { submit: (event?: Event) => void, close: (event?: Event) => void, placeholder: string, disabled: boolean, b24ui: any }): VNode[]
 }
 </script>
 
@@ -80,7 +84,7 @@ const appConfig = useAppConfig() as ChatPrompt['AppConfig']
 
 const textareaProps = useForwardProps(reactivePick(props, 'rows', 'autofocus', 'autofocusDelay', 'autoresize', 'autoresizeDelay', 'maxrows', 'icon', 'avatar', 'loading'))
 
-const getProxySlots = () => omit(slots, ['header', 'footer', 'default'])
+const getProxySlots = () => omit(slots, ['header', 'footer', 'default', 'body'])
 
 // eslint-disable-next-line vue/no-dupe-keys
 const b24ui = computed(() => tv({ extend: theme, ...(appConfig.b24ui?.chatPrompt || {}) })({
@@ -89,18 +93,18 @@ const b24ui = computed(() => tv({ extend: theme, ...(appConfig.b24ui?.chatPrompt
 
 const textareaRef = useTemplateRef('textareaRef')
 
-function submit(e: Event) {
+function submit(e?: Event) {
   if (model.value.trim() === '') {
     return
   }
 
-  emits('submit', e)
+  emits('submit', e ?? new Event('submit'))
 }
 
-function blur(e: Event) {
+function blur(e?: Event) {
   textareaRef.value?.textareaRef?.blur()
 
-  emits('close', e)
+  emits('close', e ?? new Event('close'))
 }
 
 const { onKeydown: onEnter, onCompositionEnd } = useIMEGuard((event) => {
@@ -138,24 +142,33 @@ defineExpose({
       <slot name="header" />
     </div>
 
-    <B24Textarea
-      ref="textareaRef"
-      v-model="model"
+    <slot
+      name="body"
+      :submit="submit"
+      :close="blur"
       :placeholder="props.placeholder || t('chatPrompt.placeholder')"
       :disabled="Boolean(props.error) || props.disabled"
-      no-border
-      fixed
-      v-bind="{ ...textareaProps, ...$attrs }"
-      :b24ui="transformUI(omit(b24ui, ['root', 'body', 'header', 'footer']), props.b24ui)"
-      data-slot="body"
-      :class="b24ui.body({ class: props.b24ui?.body })"
-      @keydown="onKeydown"
-      @compositionend="onCompositionEnd"
+      :b24ui="b24ui"
     >
-      <template v-for="(_, name) in getProxySlots()" #[name]="slotData">
-        <slot :name="name" v-bind="slotData" />
-      </template>
-    </B24Textarea>
+      <B24Textarea
+        ref="textareaRef"
+        v-model="model"
+        :placeholder="props.placeholder || t('chatPrompt.placeholder')"
+        :disabled="Boolean(props.error) || props.disabled"
+        no-border
+        fixed
+        v-bind="{ ...textareaProps, ...$attrs }"
+        :b24ui="transformUI(omit(b24ui, ['root', 'body', 'header', 'footer']), props.b24ui)"
+        data-slot="body"
+        :class="b24ui.body({ class: props.b24ui?.body })"
+        @keydown="onKeydown"
+        @compositionend="onCompositionEnd"
+      >
+        <template v-for="(_, name) in getProxySlots()" #[name]="slotData">
+          <slot :name="name" v-bind="slotData" />
+        </template>
+      </B24Textarea>
+    </slot>
 
     <div data-slot="footer" :class="b24ui.footer({ class: props.b24ui?.footer })">
       <slot name="footer" />

--- a/test/components/ChatPrompt.spec.ts
+++ b/test/components/ChatPrompt.spec.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi } from 'vitest'
+import { h } from 'vue'
 import { axe } from 'vitest-axe'
 import { mountSuspended } from '@nuxt/test-utils/runtime'
 import { renderEach } from '../component-render'
@@ -18,7 +19,8 @@ describe('ChatPrompt', () => {
     ['with b24ui', { props: { b24ui: { footer: 'justify-end' } } }],
     // Slots
     ['with header slot', { slots: { header: () => 'Header slot' } }],
-    ['with footer slot', { slots: { footer: () => 'Footer slot' } }]
+    ['with footer slot', { slots: { footer: () => 'Footer slot' } }],
+    ['with body slot', { slots: { body: () => 'Body slot' } }]
   ])
 
   it('emits submit on Enter', async () => {
@@ -102,6 +104,52 @@ describe('ChatPrompt', () => {
     await textarea.trigger('keydown', { key: 'Enter', metaKey: true })
 
     expect(wrapper.emitted('submit')).toHaveLength(1)
+  })
+
+  it('replaces the textarea with the body slot', async () => {
+    const wrapper = await mountSuspended(ChatPrompt, {
+      slots: { body: () => h('div', { 'data-test': 'editor' }, 'Custom body') }
+    })
+
+    expect(wrapper.find('textarea').exists()).toBe(false)
+    expect(wrapper.find('[data-test="editor"]').text()).toBe('Custom body')
+  })
+
+  it('exposes submit and close to the body slot', async () => {
+    const slotProps: { submit?: () => void, close?: () => void } = {}
+    const wrapper = await mountSuspended(ChatPrompt, {
+      props: { modelValue: 'Hello' },
+      slots: {
+        body: (props: any) => {
+          slotProps.submit = props.submit
+          slotProps.close = props.close
+          return h('div', 'body')
+        }
+      }
+    })
+
+    slotProps.submit?.()
+    expect(wrapper.emitted('submit')).toHaveLength(1)
+
+    slotProps.close?.()
+    expect(wrapper.emitted('close')).toHaveLength(1)
+  })
+
+  it('does not emit submit from the body slot when the value is empty', async () => {
+    const slotProps: { submit?: () => void } = {}
+    const wrapper = await mountSuspended(ChatPrompt, {
+      props: { modelValue: '  ' },
+      slots: {
+        body: (props: any) => {
+          slotProps.submit = props.submit
+          return h('div', 'body')
+        }
+      }
+    })
+
+    slotProps.submit?.()
+
+    expect(wrapper.emitted('submit')).toBeUndefined()
   })
 
   it('passes accessibility tests', async () => {

--- a/test/components/__snapshots__/ChatPrompt-vue.spec.ts.snap
+++ b/test/components/__snapshots__/ChatPrompt-vue.spec.ts.snap
@@ -24,6 +24,12 @@ exports[`ChatPrompt > renders with b24ui correctly 1`] = `
 </form>"
 `;
 
+exports[`ChatPrompt > renders with body slot correctly 1`] = `
+"<form data-slot="root" class="relative flex flex-col items-stretch gap-[2px] ps-[12px] pe-2 py-2 w-full rounded-lg bg-(--ui-color-design-outline-bg) ring-(--ui-color-design-outline-stroke) ring-1 text-(--ui-color-design-outline-content)">
+  <!--v-if-->Body slot<div data-slot="footer" class="flex items-center justify-end gap-2"></div>
+</form>"
+`;
+
 exports[`ChatPrompt > renders with class correctly 1`] = `
 "<form data-slot="root" class="relative flex flex-col items-stretch gap-[2px] w-full rounded-lg bg-(--ui-color-design-outline-bg) ring-(--ui-color-design-outline-stroke) ring-1 text-(--ui-color-design-outline-content) p-5">
   <!--v-if-->

--- a/test/components/__snapshots__/ChatPrompt.spec.ts.snap
+++ b/test/components/__snapshots__/ChatPrompt.spec.ts.snap
@@ -24,6 +24,12 @@ exports[`ChatPrompt > renders with b24ui correctly 1`] = `
 </form>"
 `;
 
+exports[`ChatPrompt > renders with body slot correctly 1`] = `
+"<form data-slot="root" class="relative flex flex-col items-stretch gap-[2px] ps-[12px] pe-2 py-2 w-full rounded-lg bg-(--ui-color-design-outline-bg) ring-(--ui-color-design-outline-stroke) ring-1 text-(--ui-color-design-outline-content)">
+  <!--v-if-->Body slot<div data-slot="footer" class="flex items-center justify-end gap-2"></div>
+</form>"
+`;
+
 exports[`ChatPrompt > renders with class correctly 1`] = `
 "<form data-slot="root" class="relative flex flex-col items-stretch gap-[2px] w-full rounded-lg bg-(--ui-color-design-outline-bg) ring-(--ui-color-design-outline-stroke) ring-1 text-(--ui-color-design-outline-content) p-5">
   <!--v-if-->


### PR DESCRIPTION
Syncs upstream nuxt/ui commit [`123184b`](https://github.com/nuxt/ui/commit/123184b5c72fd3f7d4b6c032a6dd4b52a5046e6e) — *feat(ChatPrompt): add body slot and focus highlight (#6709)*.

## What (ported)
The **`body` slot** replaces the internal textarea — e.g. to render an [Editor](/docs/components/editor/) with mentions — and exposes `submit` / `close` / `placeholder` / `disabled` / `b24ui`. `submit` and `close` become event-optional (`e ?? new Event(...)`) so a custom body can call them without a DOM event.

b24ui's `ChatPrompt.vue` matched the pre-fix textarea structure, so the slot ported cleanly, adapted to b24ui (`B24Textarea`, the `b24ui` prop instead of `ui`; the template wraps `B24Textarea` as the slot's default content). Ported the 3 upstream body-slot tests + the `with body slot` render case.

## Deferred — `color` prop + focus highlight
b24ui's `chat-prompt.ts` theme is a **static** object using the fork's own air `variant` set (`outline`/`tinted`/`filled`/`plain`, `--ui-color-design-*` tokens) — it has no `color` variant and does not use upstream's `options.theme.colors` palette. Upstream's `color` prop, the theme's function conversion, and the `focusHighlight` compound variants (`ring-${color}` / `outline-${color}` / `inverted`) are all tied to that absent color system, so they're deferred to a dedicated b24ui ChatPrompt design pass. (Same split as the ChatTool `actions` port vs its v7-entangled flow.)

## Verify (`CI=true`)
`dev:prepare` · `lint` · `typecheck` · `test` · `build` — all green. The `with body slot` render case wrote **2 new snapshots** and updated **0** existing ones — a slot with default content renders the same DOM when unused, so there's no churn. Suite **5485 passed / 6 skipped** (+8 body-slot tests across the two projects).

Ledger: cursor advanced to `123184b`; previous entry `76d613c` reconciled to PR #271.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JS8ypVfQSFzYVZzkTHhURb)_