### PR TITLE
chore(sync): reconcile ledger entry for ChatPrompt body slot (123184b)

### DIFF
--- a/.sync/nuxt-ui.json
+++ b/.sync/nuxt-ui.json
@@ -1037,8 +1037,8 @@
       "summary": "feat(Editor): allow disabling starter kit for plain text (#6713) — starterKit prop now boolean | Partial<StarterKitOptions> (default true); false gives plain-text editor (plainText override disables all formatting, keeps essential nodes), Code/HorizontalRule gated behind props.starterKit !== false. b24ui Editor.vue matched, applied verbatim; kept b24ui dropcursor token var(--ui-color-accent-main-primary). Docs: added ::tip in editor.md. Default true reproduces prior config -> no snapshot churn. Tests 5477."
     },
     "123184b5c72fd3f7d4b6c032a6dd4b52a5046e6e": {
-      "pr": null,
-      "b24ui_sha": "pending-merge",
+      "pr": 272,
+      "b24ui_sha": "9a13bc9f8ef04ea2f44d36cfa1a6804f8e725404",
       "decision": "port",
       "summary": "feat(ChatPrompt): add body slot and focus highlight (#6709) — PARTIAL. Ported the body slot (replaces internal textarea; exposes submit/close/placeholder/disabled/b24ui; submit/blur event-optional via e ?? new Event) adapted to b24ui (B24Textarea, b24ui prop). +3 body-slot tests + render case; 2 snapshots written, no existing churn. DEFERRED the color prop + focus-highlight theme: b24ui chat-prompt.ts is a static theme with air variant set (outline/tinted/filled/plain, --ui-color-design-* tokens), no color variant / options.theme.colors, so the color variant + function conversion + focusHighlight compoundVariants are entangled with an absent color system. Tests 5485."
     }


### PR DESCRIPTION
Ledger-only follow-up to close out the sync round.

The final commit of the round — `123184b` (ChatPrompt body slot, [PR #272](https://github.com/bitrix24/b24ui/pull/272)) — was left as `pending-merge` in `.sync/nuxt-ui.json` (the normal steady state, reconciled by the next port). This records its merged PR number (`272`) and b24ui merge sha (`9a13bc9f`) so **no ledger entry remains `pending-merge`** and the cursor cleanly reflects the fully-synced state at upstream `v4` HEAD.

No code, test, or snapshot changes — `.sync/nuxt-ui.json` only (2 fields).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JS8ypVfQSFzYVZzkTHhURb)_