### PR TITLE
feat(Empty): add loading and loadingIcon props

### DIFF
--- a/.sync/log/86cd25c5cadacfbbe63d04195a4fb05fec9702d9.md
+++ b/.sync/log/86cd25c5cadacfbbe63d04195a4fb05fec9702d9.md
@@ -1,0 +1,45 @@
+# Port: feat(Empty): add `loading` and `loadingIcon` props (#6707)
+
+**Upstream:** `86cd25c5cadacfbbe63d04195a4fb05fec9702d9` (nuxt/ui)
+**Decision:** port — adapted (b24ui icon system + structure)
+
+## Upstream change
+`Empty` gains `loading?: boolean` + `loadingIcon?` props. When `loading`, an
+`iconName` computed swaps the icon for the loading icon (default
+`appConfig.ui.icons.loading`), `aria-busy="true"` is set on the root, and a theme
+`loading.true` variant spins the avatar's icon (`animate-spin`). Adds docs,
+playground toggle, spec render cases + snapshots.
+
+## b24ui port
+b24ui's `Empty` diverges (icons are `IconComponent`s rendered via
+`<Component :is>` inside an `indicator > icon` structure — no `avatar`; extra
+`color`/`inverted`/`actions` props). Ported adapted:
+- **`Empty.vue`** — added `loading?: boolean` + `loadingIcon?: IconComponent`;
+  `iconName` computed `props.loading ? (props.loadingIcon || icons.loading) : props.icon`
+  (imports `icons` from `dictionary/icons`; b24ui's `icons.loading` = `LoaderWaitIcon`);
+  `loading: props.loading` in `tv()`; template gains `:aria-busy` and uses
+  `iconName` for the `v-if`/`Component :is`.
+- **`theme/empty.ts`** — added `loading: { true: { icon: 'animate-spin' } }`
+  variant. b24ui spins the `icon` slot directly (its structure is `indicator > icon`,
+  not upstream's `avatar > [data-slot=icon]`).
+- **docs `empty.md`** — added "Loading" + "Loading Icon" sections (b24ui icon-cast
+  convention; `loadingIcon` example casts `LoaderClockIcon`, which is registered in
+  `docs/nuxt.config.ts`). Dropped upstream's `ui.icons.loading` app-config
+  `::framework-only` tip (b24ui customizes the loading icon differently).
+- **playgrounds `{nuxt,demo}`** — added a `Loading` `B24Switch` toggle wiring
+  `:loading` + loading-aware title/description/actions (kept in parity).
+
+### Not ported — tests
+b24ui has **no `Empty.spec.ts`** (only pre-existing orphaned/obsolete
+`Empty*.spec.ts.snap` files — a spec that no longer exists). There is no test file
+to add the upstream render cases to, and the obsolete snapshots aren't run, so the
+upstream test + snapshot changes have no target. Left untouched. Default behavior
+is unchanged (`iconName === props.icon` when not loading), so no other component's
+snapshot churns.
+
+## Tests
+No applicable test target. Suite unchanged: 5485 passed / 6 skipped. Typecheck
+(incl. both playgrounds) green.
+
+## Verify (CI=true)
+`dev:prepare` · `lint` · `typecheck` · `test` · `build` — all green.

--- a/.sync/nuxt-ui.json
+++ b/.sync/nuxt-ui.json
@@ -2,7 +2,7 @@
   "upstream": "nuxt/ui",
   "branch": "v4",
   "sync_enabled": false,
-  "cursor": "9df067a6209da2a402a3e24e1f9ed2e897b368a9",
+  "cursor": "86cd25c5cadacfbbe63d04195a4fb05fec9702d9",
   "_cursor_note": "cursor = last upstream commit ported into b24ui (oldest-first, manual cadence). sync_enabled stays false until Phase 2 (porter workflow #67 + CLAUDE_CODE_OAUTH_TOKEN) is wired and trusted. `processed` is maintained per port from now on (backfilled #68-#72 on 2026-06-09).",
   "stats": {
     "queue_depth": 0,
@@ -1043,10 +1043,16 @@
       "summary": "feat(ChatPrompt): add body slot and focus highlight (#6709) — PARTIAL. Ported the body slot (replaces internal textarea; exposes submit/close/placeholder/disabled/b24ui; submit/blur event-optional via e ?? new Event) adapted to b24ui (B24Textarea, b24ui prop). +3 body-slot tests + render case; 2 snapshots written, no existing churn. DEFERRED the color prop + focus-highlight theme: b24ui chat-prompt.ts is a static theme with air variant set (outline/tinted/filled/plain, --ui-color-design-* tokens), no color variant / options.theme.colors, so the color variant + function conversion + focusHighlight compoundVariants are entangled with an absent color system. Tests 5485."
     },
     "9df067a6209da2a402a3e24e1f9ed2e897b368a9": {
+      "pr": 274,
+      "b24ui_sha": "ceed3c8d9c82839089090fabcd239c28e7890467",
+      "decision": "port",
+      "summary": "chore(deps): update tiptap to ^3.27.3 (#6719) — §2 manifest bump. Bumped all b24ui @tiptap/* pins ^3.27.1 -> ^3.27.3 (root 17-pkg set, docs/playgrounds extension-emoji + extension-text-align, pnpm-workspace @tiptap/pm override). Regenerated pnpm-lock.yaml (pnpm 11.10.0); net -425 lines from collapsing duplicate tiptap/prosemirror trees (prosemirror-view@1.41.8/model@1.25.8) into one resolution. Dep-only, typecheck confirms no dup-prosemirror-view regression. Tests 5485."
+    },
+    "86cd25c5cadacfbbe63d04195a4fb05fec9702d9": {
       "pr": null,
       "b24ui_sha": "pending-merge",
       "decision": "port",
-      "summary": "chore(deps): update tiptap to ^3.27.3 (#6719) — §2 manifest bump. Bumped all b24ui @tiptap/* pins ^3.27.1 -> ^3.27.3 (root 17-pkg set, docs/playgrounds extension-emoji + extension-text-align, pnpm-workspace @tiptap/pm override). Regenerated pnpm-lock.yaml (pnpm 11.10.0); net -425 lines from collapsing duplicate tiptap/prosemirror trees (prosemirror-view@1.41.8/model@1.25.8) into one resolution. Dep-only, typecheck confirms no dup-prosemirror-view regression. Tests 5485."
+      "summary": "feat(Empty): add loading and loadingIcon props (#6707) — loading?: boolean + loadingIcon?: IconComponent; iconName swaps to icons.loading (LoaderWaitIcon) when loading; aria-busy on root; theme loading.true.icon animate-spin (b24ui structure indicator>icon). Adapted to b24ui IconComponent + Component:is. Docs: Loading/Loading Icon sections (LoaderClockIcon cast). Playgrounds nuxt+demo: Loading toggle. NOT ported: tests — b24ui has no Empty.spec.ts (only orphaned obsolete snapshots), no target. Default behavior unchanged, no snapshot churn. Tests 5485."
     }
   }
 }

--- a/docs/content/docs/2.components/empty.md
+++ b/docs/content/docs/2.components/empty.md
@@ -66,6 +66,45 @@ props:
 ---
 ::
 
+### Loading
+
+Use the `loading` prop to show a loading icon in place of the icon. The layout stays identical, so you can toggle between loading and empty states without layout shifts.
+
+::component-code
+---
+prettier: true
+ignore:
+  - title
+  - description
+props:
+  loading: true
+  title: Loading projects
+  description: Please wait while we fetch your projects.
+---
+::
+
+### Loading Icon
+
+Use the `loading-icon` prop to customize the loading icon. Defaults to `icons.loading`.
+
+::component-code
+---
+prettier: true
+ignore:
+  - title
+  - description
+  - loading
+  - loadingIcon
+cast:
+  loadingIcon: 'LoaderClockIcon'
+props:
+  loading: true
+  loadingIcon: 'LoaderClockIcon'
+  title: Loading projects
+  description: Please wait while we fetch your projects.
+---
+::
+
 ### Actions
 
 Use the `actions` prop to add some [Button](/docs/components/button/) actions to the empty state.

--- a/playgrounds/demo/app/pages/components/empty.vue
+++ b/playgrounds/demo/app/pages/components/empty.vue
@@ -19,6 +19,7 @@ const attrs = reactive({
 })
 
 const inverted = ref(false)
+const loading = ref(false)
 </script>
 
 <template>
@@ -41,14 +42,16 @@ const inverted = ref(false)
         size="xs"
       />
       <B24Switch v-model="inverted" label="Inverted" size="xs" />
+      <B24Switch v-model="loading" label="Loading" size="xs" />
     </template>
 
     <Matrix v-slot="props" :attrs="attrs" :b24ui="{ root: 'max-w-120' }">
       <B24Empty
         :icon="ProductIcon"
-        title="No projects found"
-        description="It looks like you haven't added any projects. Create one to get started."
-        :actions="[
+        :loading="loading"
+        :title="loading ? 'Loading projects' : 'No projects found'"
+        :description="loading ? 'Please wait while we fetch your projects.' : 'It looks like you haven\'t added any projects. Create one to get started.'"
+        :actions="loading ? undefined : [
           {
             label: 'Create new',
             icon: AddProductIcon,

--- a/playgrounds/nuxt/app/pages/components/empty.vue
+++ b/playgrounds/nuxt/app/pages/components/empty.vue
@@ -19,6 +19,7 @@ const attrs = reactive({
 })
 
 const inverted = ref(false)
+const loading = ref(false)
 </script>
 
 <template>
@@ -41,14 +42,16 @@ const inverted = ref(false)
         size="xs"
       />
       <B24Switch v-model="inverted" label="Inverted" size="xs" />
+      <B24Switch v-model="loading" label="Loading" size="xs" />
     </template>
 
     <Matrix v-slot="props" :attrs="attrs" :b24ui="{ root: 'max-w-120' }">
       <B24Empty
         :icon="ProductIcon"
-        title="No projects found"
-        description="It looks like you haven't added any projects. Create one to get started."
-        :actions="[
+        :loading="loading"
+        :title="loading ? 'Loading projects' : 'No projects found'"
+        :description="loading ? 'Please wait while we fetch your projects.' : 'It looks like you haven\'t added any projects. Create one to get started.'"
+        :actions="loading ? undefined : [
           {
             label: 'Create new',
             icon: AddProductIcon,

--- a/src/runtime/components/Empty.vue
+++ b/src/runtime/components/Empty.vue
@@ -19,6 +19,14 @@ export interface EmptyProps {
    * @IconComponent
    */
   icon?: IconComponent
+  /** When `true`, the loading icon will be displayed. */
+  loading?: boolean
+  /**
+   * The icon when the `loading` prop is `true`.
+   * @defaultValue icons.loading
+   * @IconComponent
+   */
+  loadingIcon?: IconComponent
   title?: string
   description?: string
   /**
@@ -60,6 +68,7 @@ import { Primitive } from 'reka-ui'
 import { useAppConfig } from '#imports'
 import { useComponentProps } from '../composables/useComponentProps'
 import { tv } from '../utils/tv'
+import icons from '../dictionary/icons'
 import B24Button from './Button.vue'
 
 const _props = withDefaults(defineProps<EmptyProps>(), {
@@ -71,22 +80,25 @@ const props = useComponentProps('empty', _props)
 
 const appConfig = useAppConfig() as Empty['AppConfig']
 
+const iconName = computed(() => props.loading ? (props.loadingIcon || icons.loading) : props.icon)
+
 // eslint-disable-next-line vue/no-dupe-keys
 const b24ui = computed(() => tv({ extend: theme, ...(appConfig.b24ui?.empty || {}) })({
   color: props.color,
   inverted: Boolean(props.inverted),
-  size: props.size
+  size: props.size,
+  loading: props.loading
 }))
 </script>
 
 <template>
-  <Primitive :as="props.as" data-slot="root" :class="b24ui.root({ class: [props.b24ui?.root, props.class] })">
-    <div v-if="!!slots.header || (props.icon || !!slots.leading) || (props.title || !!slots.title) || (props.description || !!slots.description)" data-slot="header" :class="b24ui.header({ class: props.b24ui?.header })">
+  <Primitive :as="props.as" :aria-busy="props.loading ? 'true' : undefined" data-slot="root" :class="b24ui.root({ class: [props.b24ui?.root, props.class] })">
+    <div v-if="!!slots.header || (iconName || !!slots.leading) || (props.title || !!slots.title) || (props.description || !!slots.description)" data-slot="header" :class="b24ui.header({ class: props.b24ui?.header })">
       <slot name="header">
         <slot name="leading" :b24ui="b24ui">
-          <div v-if="props.icon" data-slot="indicator" :class="b24ui.indicator({ class: props.b24ui?.indicator })">
+          <div v-if="iconName" data-slot="indicator" :class="b24ui.indicator({ class: props.b24ui?.indicator })">
             <Component
-              :is="props.icon"
+              :is="iconName"
               data-slot="icon"
               :class="b24ui.icon({ class: props.b24ui?.icon })"
             />

--- a/src/theme/empty.ts
+++ b/src/theme/empty.ts
@@ -76,6 +76,11 @@ export default {
     inverted: {
       true: '',
       false: ''
+    },
+    loading: {
+      true: {
+        icon: 'animate-spin'
+      }
     }
   },
   compoundVariants: [


### PR DESCRIPTION
Syncs upstream nuxt/ui commit [`86cd25c`](https://github.com/nuxt/ui/commit/86cd25c5cadacfbbe63d04195a4fb05fec9702d9) — *feat(Empty): add `loading` and `loadingIcon` props (#6707)*.

## What
`Empty` gains `loading?: boolean` and `loadingIcon?` props. When `loading`:

- an `iconName` computed swaps the icon for the loading icon (`props.loadingIcon || icons.loading` — b24ui's `icons.loading` is `LoaderWaitIcon`);
- the root gets `aria-busy="true"`;
- a theme `loading.true` variant spins the icon (`animate-spin`).

## Adaptation
b24ui's `Empty` diverges from upstream (icons are `IconComponent`s rendered via `<Component :is>` inside an `indicator > icon` structure — no `avatar`; extra `color`/`inverted`/`actions` props). Ported accordingly: the spin is applied to the `icon` slot directly, and the loading icon comes from `dictionary/icons`.

- **docs `empty.md`** — added "Loading" / "Loading Icon" sections (b24ui icon-cast convention; the custom-icon example casts `LoaderClockIcon`, registered in `docs/nuxt.config.ts`). Dropped upstream's `ui.icons.loading` app-config tip (b24ui customizes it differently).
- **playgrounds `{nuxt,demo}`** — added a `Loading` switch wiring `:loading` + loading-aware title/description/actions (kept in parity).

## Not ported — tests
b24ui has **no `Empty.spec.ts`** — only pre-existing orphaned/obsolete `Empty*.spec.ts.snap` files (a spec that no longer exists). There's no test file to add the upstream render cases to, and the obsolete snapshots aren't run, so the upstream test + snapshot changes have no target and are left untouched. Default behavior is unchanged (`iconName === props.icon` when not loading), so no other component's snapshot churns.

## Verify (`CI=true`)
`dev:prepare` · `lint` · `typecheck` (incl. both playgrounds) · `test` · `build` — all green. Suite **5485 passed / 6 skipped** (unchanged).

Ledger: cursor advanced to `86cd25c`; previous entry `9df067a` reconciled to PR #274.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JS8ypVfQSFzYVZzkTHhURb)_