### PR TITLE
chore(sync): no-op upstream Carousel inline-plugin-props fix

### DIFF
--- a/.sync/log/f41d11e2e330213385a807fccece1c3a3d3bb936.md
+++ b/.sync/log/f41d11e2e330213385a807fccece1c3a3d3bb936.md
@@ -1,0 +1,19 @@
+# No-op: fix(Carousel): prevent reset when plugin props use inline objects
+
+**Upstream:** `f41d11e2e330213385a807fccece1c3a3d3bb936` (nuxt/ui)
+**Decision:** no-op (not applicable to b24ui)
+
+## Upstream change
+`Carousel.vue`'s plugin-prop watcher stopped calling `emblaApi.reInit(...)`
+itself (now just rebuilds the plugins array via `loadPlugins`), letting
+`useEmblaCarousel`'s own `arePluginsEqual` guard handle reinit — so inline-object
+plugin props (`:autoplay="{ delay: 5000 }"`) that get a new reference each render
+no longer reset the carousel to the first slide.
+
+## Why no-op for b24ui
+b24ui has **no `Carousel` component** (`src/**/*carousel*` and
+`docs/content/**/*carousel*` both empty) — the fork never ported Carousel. Nothing
+to edit.
+
+## Verify
+No code change (ledger/log only). Cursor advanced past `f41d11e`.

--- a/.sync/nuxt-ui.json
+++ b/.sync/nuxt-ui.json
@@ -2,7 +2,7 @@
   "upstream": "nuxt/ui",
   "branch": "v4",
   "sync_enabled": false,
-  "cursor": "86cd25c5cadacfbbe63d04195a4fb05fec9702d9",
+  "cursor": "f41d11e2e330213385a807fccece1c3a3d3bb936",
   "_cursor_note": "cursor = last upstream commit ported into b24ui (oldest-first, manual cadence). sync_enabled stays false until Phase 2 (porter workflow #67 + CLAUDE_CODE_OAUTH_TOKEN) is wired and trusted. `processed` is maintained per port from now on (backfilled #68-#72 on 2026-06-09).",
   "stats": {
     "queue_depth": 0,
@@ -1049,10 +1049,16 @@
       "summary": "chore(deps): update tiptap to ^3.27.3 (#6719) — §2 manifest bump. Bumped all b24ui @tiptap/* pins ^3.27.1 -> ^3.27.3 (root 17-pkg set, docs/playgrounds extension-emoji + extension-text-align, pnpm-workspace @tiptap/pm override). Regenerated pnpm-lock.yaml (pnpm 11.10.0); net -425 lines from collapsing duplicate tiptap/prosemirror trees (prosemirror-view@1.41.8/model@1.25.8) into one resolution. Dep-only, typecheck confirms no dup-prosemirror-view regression. Tests 5485."
     },
     "86cd25c5cadacfbbe63d04195a4fb05fec9702d9": {
-      "pr": null,
-      "b24ui_sha": "pending-merge",
+      "pr": 275,
+      "b24ui_sha": "80ab3e4aac78b55dfd6e4b4130d57701eecfeaff",
       "decision": "port",
       "summary": "feat(Empty): add loading and loadingIcon props (#6707) — loading?: boolean + loadingIcon?: IconComponent; iconName swaps to icons.loading (LoaderWaitIcon) when loading; aria-busy on root; theme loading.true.icon animate-spin (b24ui structure indicator>icon). Adapted to b24ui IconComponent + Component:is. Docs: Loading/Loading Icon sections (LoaderClockIcon cast). Playgrounds nuxt+demo: Loading toggle. NOT ported: tests — b24ui has no Empty.spec.ts (only orphaned obsolete snapshots), no target. Default behavior unchanged, no snapshot churn. Tests 5485."
+    },
+    "f41d11e2e330213385a807fccece1c3a3d3bb936": {
+      "pr": null,
+      "b24ui_sha": "pending-merge",
+      "decision": "no-op",
+      "summary": "fix(Carousel): prevent reset when plugin props use inline objects — watcher no longer calls emblaApi.reInit, relies on useEmblaCarousel arePluginsEqual guard so inline-object plugin props don't reset carousel. NOT APPLICABLE: b24ui has no Carousel component (no src or docs carousel files). No-op."
     }
   }
 }


### PR DESCRIPTION
Records upstream nuxt/ui commit [`f41d11e`](https://github.com/nuxt/ui/commit/f41d11e2e330213385a807fccece1c3a3d3bb936) — *fix(Carousel): prevent reset when plugin props use inline objects* — as a **no-op** for b24ui.

## Why no-op
Upstream stops `Carousel.vue`'s plugin-prop watcher from calling `emblaApi.reInit(...)` itself (it now just rebuilds the plugins array), relying on `useEmblaCarousel`'s own `arePluginsEqual` guard — so inline-object plugin props like `:autoplay="{ delay: 5000 }"` (new reference each render) no longer reset the carousel to the first slide.

b24ui has **no `Carousel` component** — `src/**/*carousel*` and `docs/content/**/*carousel*` are both empty; the fork never ported Carousel. There's nothing to edit.

Ledger/log only — no code change. Cursor advanced to `f41d11e`; previous entry `86cd25c` reconciled to PR #275.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JS8ypVfQSFzYVZzkTHhURb)_