### PR TITLE
chore(sync): no-op upstream BlogPost/ChangelogVersion UTC date fix

### DIFF
--- a/.sync/log/fe5bb2388b32fd13a4fe677b1d82328312ca501b.md
+++ b/.sync/log/fe5bb2388b32fd13a4fe677b1d82328312ca501b.md
@@ -1,0 +1,17 @@
+# No-op: fix(BlogPost/ChangelogVersion): format date in UTC to prevent hydration mismatch
+
+**Upstream:** `fe5bb2388b32fd13a4fe677b1d82328312ca501b` (nuxt/ui)
+**Decision:** no-op (not applicable to b24ui)
+
+## Upstream change
+Adds `timeZone: 'UTC'` to the date formatter in `BlogPost.vue` and
+`ChangelogVersion.vue` so the server- and client-rendered dates match (fixes a
+hydration mismatch).
+
+## Why no-op for b24ui
+b24ui has **neither `BlogPost` nor `ChangelogVersion`** — `src/**/*blog*`,
+`src/**/*changelog*` (and the docs equivalents) are all empty; the fork never
+ported these two components. Nothing to edit.
+
+## Verify
+No code change (ledger/log only). Cursor advanced past `fe5bb23`.

--- a/.sync/nuxt-ui.json
+++ b/.sync/nuxt-ui.json
@@ -2,7 +2,7 @@
   "upstream": "nuxt/ui",
   "branch": "v4",
   "sync_enabled": false,
-  "cursor": "f41d11e2e330213385a807fccece1c3a3d3bb936",
+  "cursor": "fe5bb2388b32fd13a4fe677b1d82328312ca501b",
   "_cursor_note": "cursor = last upstream commit ported into b24ui (oldest-first, manual cadence). sync_enabled stays false until Phase 2 (porter workflow #67 + CLAUDE_CODE_OAUTH_TOKEN) is wired and trusted. `processed` is maintained per port from now on (backfilled #68-#72 on 2026-06-09).",
   "stats": {
     "queue_depth": 0,
@@ -1055,10 +1055,16 @@
       "summary": "feat(Empty): add loading and loadingIcon props (#6707) — loading?: boolean + loadingIcon?: IconComponent; iconName swaps to icons.loading (LoaderWaitIcon) when loading; aria-busy on root; theme loading.true.icon animate-spin (b24ui structure indicator>icon). Adapted to b24ui IconComponent + Component:is. Docs: Loading/Loading Icon sections (LoaderClockIcon cast). Playgrounds nuxt+demo: Loading toggle. NOT ported: tests — b24ui has no Empty.spec.ts (only orphaned obsolete snapshots), no target. Default behavior unchanged, no snapshot churn. Tests 5485."
     },
     "f41d11e2e330213385a807fccece1c3a3d3bb936": {
+      "pr": 276,
+      "b24ui_sha": "202b114defac5ab1a2f73978fe1be30eaf670e59",
+      "decision": "no-op",
+      "summary": "fix(Carousel): prevent reset when plugin props use inline objects — watcher no longer calls emblaApi.reInit, relies on useEmblaCarousel arePluginsEqual guard so inline-object plugin props don't reset carousel. NOT APPLICABLE: b24ui has no Carousel component (no src or docs carousel files). No-op."
+    },
+    "fe5bb2388b32fd13a4fe677b1d82328312ca501b": {
       "pr": null,
       "b24ui_sha": "pending-merge",
       "decision": "no-op",
-      "summary": "fix(Carousel): prevent reset when plugin props use inline objects — watcher no longer calls emblaApi.reInit, relies on useEmblaCarousel arePluginsEqual guard so inline-object plugin props don't reset carousel. NOT APPLICABLE: b24ui has no Carousel component (no src or docs carousel files). No-op."
+      "summary": "fix(BlogPost/ChangelogVersion): format date in UTC to prevent hydration mismatch — adds timeZone: 'UTC' to date formatter in BlogPost.vue + ChangelogVersion.vue. NOT APPLICABLE: b24ui has neither component (no blog/changelog files in src or docs). No-op."
     }
   }
 }


### PR DESCRIPTION
Records upstream nuxt/ui commit [`fe5bb23`](https://github.com/nuxt/ui/commit/fe5bb2388b32fd13a4fe677b1d82328312ca501b) — *fix(BlogPost/ChangelogVersion): format date in UTC to prevent hydration mismatch* — as a **no-op** for b24ui.

## Why no-op
Upstream adds `timeZone: 'UTC'` to the date formatter in `BlogPost.vue` and `ChangelogVersion.vue` so server- and client-rendered dates match. b24ui has **neither `BlogPost` nor `ChangelogVersion`** — those components were never ported to the fork (no blog/changelog files in `src` or `docs`). There's nothing to edit.

Ledger/log only — no code change. Cursor advanced to `fe5bb23`; previous entry `f41d11e` reconciled to PR #276.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JS8ypVfQSFzYVZzkTHhURb)_