### PR TITLE
docs(select-menu/input-menu): use grouped items in items type example

### DIFF
--- a/.sync/log/17196ecc3057a18d540f8b9a77f857fbbe8969c0.md
+++ b/.sync/log/17196ecc3057a18d540f8b9a77f857fbbe8969c0.md
@@ -1,0 +1,26 @@
+# Port: docs(select-menu/input-menu): use grouped items in items type example
+
+**Upstream:** `17196ecc3057a18d540f8b9a77f857fbbe8969c0` (nuxt/ui)
+**Decision:** port — docs-only (adapted to b24ui examples)
+
+## Upstream change
+In the `items` type example of `input-menu.md` / `select-menu.md`, restructures
+the flat items list into an **array of arrays** (one sub-array per label group),
+and adds a `::note` to all three of `input-menu.md` / `listbox.md` /
+`select-menu.md`: "When using `label` items as group headings, pass an array of
+arrays so a label gets filtered out together with its group when searching."
+
+## b24ui port
+- **`input-menu.md` / `select-menu.md`** — grouped the `Fruits` / `Vegetables`
+  label headings into sub-arrays (array of arrays). b24ui's examples carry an
+  extra intra-`Fruits` `type: 'separator'` (a fork demo detail) which was
+  preserved inside the `Fruits` sub-array. Added the `::note`.
+- **`listbox.md`** — b24ui's listbox items example **already** uses the grouped
+  (array-of-arrays) format, so only the `::note` was added.
+
+## Tests
+Docs-content (Markdown) only — no runtime/theme/test/snapshot impact. Suite
+unchanged: 5485 passed / 6 skipped.
+
+## Verify (CI=true)
+`dev:prepare` · `lint` · `typecheck` · `test` · `build` — all green.

--- a/.sync/nuxt-ui.json
+++ b/.sync/nuxt-ui.json
@@ -2,7 +2,7 @@
   "upstream": "nuxt/ui",
   "branch": "v4",
   "sync_enabled": false,
-  "cursor": "fe5bb2388b32fd13a4fe677b1d82328312ca501b",
+  "cursor": "17196ecc3057a18d540f8b9a77f857fbbe8969c0",
   "_cursor_note": "cursor = last upstream commit ported into b24ui (oldest-first, manual cadence). sync_enabled stays false until Phase 2 (porter workflow #67 + CLAUDE_CODE_OAUTH_TOKEN) is wired and trusted. `processed` is maintained per port from now on (backfilled #68-#72 on 2026-06-09).",
   "stats": {
     "queue_depth": 0,
@@ -1061,10 +1061,16 @@
       "summary": "fix(Carousel): prevent reset when plugin props use inline objects — watcher no longer calls emblaApi.reInit, relies on useEmblaCarousel arePluginsEqual guard so inline-object plugin props don't reset carousel. NOT APPLICABLE: b24ui has no Carousel component (no src or docs carousel files). No-op."
     },
     "fe5bb2388b32fd13a4fe677b1d82328312ca501b": {
-      "pr": null,
-      "b24ui_sha": "pending-merge",
+      "pr": 277,
+      "b24ui_sha": "50a8be9ce18938689227c08688bc6ae5eb8abb7f",
       "decision": "no-op",
       "summary": "fix(BlogPost/ChangelogVersion): format date in UTC to prevent hydration mismatch — adds timeZone: 'UTC' to date formatter in BlogPost.vue + ChangelogVersion.vue. NOT APPLICABLE: b24ui has neither component (no blog/changelog files in src or docs). No-op."
+    },
+    "17196ecc3057a18d540f8b9a77f857fbbe8969c0": {
+      "pr": null,
+      "b24ui_sha": "pending-merge",
+      "decision": "port",
+      "summary": "docs(select-menu/input-menu): use grouped items in items type example — restructure flat items into array-of-arrays (one sub-array per label group) in input-menu.md/select-menu.md + add ::note to all three (input-menu/listbox/select-menu). b24ui: grouped Fruits/Vegetables, preserved fork intra-Fruits separator inside sub-array; listbox already grouped so note-only. Docs-content only. Tests 5485."
     }
   }
 }

--- a/docs/content/docs/2.components/input-menu.md
+++ b/docs/content/docs/2.components/input-menu.md
@@ -791,22 +791,26 @@ externalTypes:
 props:
   modelValue: 'Apple'
   items:
-    - type: 'label'
-      label: 'Fruits'
-    - Apple
-    - Banana
-    - type: 'separator'
-    - Blueberry
-    - Grapes
-    - Pineapple
-    - type: 'label'
-      label: 'Vegetables'
-    - Aubergine
-    - Broccoli
-    - Carrot
-    - Courgette
-    - Leek
+    - - type: 'label'
+        label: 'Fruits'
+      - Apple
+      - Banana
+      - type: 'separator'
+      - Blueberry
+      - Grapes
+      - Pineapple
+    - - type: 'label'
+        label: 'Vegetables'
+      - Aubergine
+      - Broccoli
+      - Carrot
+      - Courgette
+      - Leek
 ---
+::
+
+::note
+When using `label` items as group headings, pass an array of arrays so a label gets filtered out together with its group when searching.
 ::
 
 ### With colors items

--- a/docs/content/docs/2.components/listbox.md
+++ b/docs/content/docs/2.components/listbox.md
@@ -393,6 +393,10 @@ props:
 ---
 ::
 
+::note
+When using `label` items as group headings, pass an array of arrays so a label gets filtered out together with its group when searching.
+::
+
 ### With icon in items
 
 You can use the `icon` property to display an [Icon](https://bitrix24.github.io/b24icons/icons/) inside the items.

--- a/docs/content/docs/2.components/select-menu.md
+++ b/docs/content/docs/2.components/select-menu.md
@@ -858,23 +858,27 @@ externalTypes:
 props:
   modelValue: 'Apple'
   items:
-    - type: 'label'
-      label: 'Fruits'
-    - Apple
-    - Banana
-    - type: 'separator'
-    - Blueberry
-    - Grapes
-    - Pineapple
-    - type: 'label'
-      label: 'Vegetables'
-    - Aubergine
-    - Broccoli
-    - Carrot
-    - Courgette
-    - Leek
+    - - type: 'label'
+        label: 'Fruits'
+      - Apple
+      - Banana
+      - type: 'separator'
+      - Blueberry
+      - Grapes
+      - Pineapple
+    - - type: 'label'
+        label: 'Vegetables'
+      - Aubergine
+      - Broccoli
+      - Carrot
+      - Courgette
+      - Leek
   class: 'w-48'
 ---
+::
+
+::note
+When using `label` items as group headings, pass an array of arrays so a label gets filtered out together with its group when searching.
 ::
 
 ### With colors items


### PR DESCRIPTION
Syncs upstream nuxt/ui commit [`17196ec`](https://github.com/nuxt/ui/commit/17196ecc3057a18d540f8b9a77f857fbbe8969c0) — *docs(select-menu/input-menu): use grouped items in items type example*.

## What
In the `items`-type example, restructures the flat items list into an **array of arrays** (one sub-array per label group), and adds a `::note` to all three docs: *"When using `label` items as group headings, pass an array of arrays so a label gets filtered out together with its group when searching."*

## b24ui port
- **`input-menu.md` / `select-menu.md`** — grouped the `Fruits` / `Vegetables` label headings into sub-arrays. b24ui's examples carry an extra intra-`Fruits` `type: 'separator'` (a fork demo detail), preserved inside the `Fruits` sub-array. Added the note.
- **`listbox.md`** — b24ui's listbox items example **already** uses the grouped (array-of-arrays) format, so it only gains the note.

Docs-content (Markdown) only.

## Verify (`CI=true`)
`dev:prepare` · `lint` · `typecheck` · `test` · `build` — all green. Suite **5485 passed / 6 skipped** (unchanged; docs-content only).

Ledger: cursor advanced to `17196ec`; previous entry `fe5bb23` reconciled to PR #277.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JS8ypVfQSFzYVZzkTHhURb)_