### PR TITLE
fix(docs): register loadingIcon cast so the Empty page prerenders (unbreak Pages deploy)

### DIFF
--- a/docs/app/components/content/ComponentCode.vue
+++ b/docs/app/components/content/ComponentCode.vue
@@ -27,7 +27,7 @@ type CastDateValue = [number, number, number]
 type CastTimeValue = [number, number, number]
 type CastTimeRangeValue = { start: CastTimeValue, end: CastTimeValue }
 
-const iconsTypeList = ['icon', 'trailingIcon', 'deleteIcon', 'selectedIcon', 'incrementIcon', 'decrementIcon', 'checkedIcon', 'uncheckedIcon', 'separatorIcon', 'closeIcon', 'backIcon', 'prevIcon', 'nextIcon']
+const iconsTypeList = ['icon', 'loadingIcon', 'trailingIcon', 'deleteIcon', 'selectedIcon', 'incrementIcon', 'decrementIcon', 'checkedIcon', 'uncheckedIcon', 'separatorIcon', 'closeIcon', 'backIcon', 'prevIcon', 'nextIcon']
 const convertIcon = (key: string): null | string => {
   if (!iconsTypeList.includes(key)) {
     return null
@@ -35,6 +35,8 @@ const convertIcon = (key: string): null | string => {
 
   if (key === 'icon') {
     return `:icon="RocketIcon"`
+  } else if (key === 'loadingIcon') {
+    return `:loading-icon="RocketIcon"`
   } else if (key === 'trailingIcon') {
     return `:trailing-icon="RocketIcon"`
   } else if (key === 'deleteIcon') {

--- a/docs/content/docs/2.components/empty.md
+++ b/docs/content/docs/2.components/empty.md
@@ -96,10 +96,10 @@ ignore:
   - loading
   - loadingIcon
 cast:
-  loadingIcon: 'LoaderClockIcon'
+  loadingIcon: 'RocketIcon'
 props:
   loading: true
-  loadingIcon: 'LoaderClockIcon'
+  loadingIcon: 'RocketIcon'
   title: Loading projects
   description: Please wait while we fetch your projects.
 ---

--- a/docs/server/utils/transformMDC.ts
+++ b/docs/server/utils/transformMDC.ts
@@ -327,7 +327,7 @@ type CastDateValue = [number, number, number]
 type CastTimeValue = [number, number, number]
 type CastTimeRangeValue = { start: CastTimeValue, end: CastTimeValue }
 
-const iconsTypeList = ['icon', 'trailingIcon', 'deleteIcon', 'selectedIcon', 'incrementIcon', 'decrementIcon', 'checkedIcon', 'uncheckedIcon', 'separatorIcon', 'closeIcon', 'backIcon', 'prevIcon', 'nextIcon']
+const iconsTypeList = ['icon', 'loadingIcon', 'trailingIcon', 'deleteIcon', 'selectedIcon', 'incrementIcon', 'decrementIcon', 'checkedIcon', 'uncheckedIcon', 'separatorIcon', 'closeIcon', 'backIcon', 'prevIcon', 'nextIcon']
 const convertIcon = (key: string): null | string => {
   if (!iconsTypeList.includes(key)) {
     return null
@@ -335,6 +335,8 @@ const convertIcon = (key: string): null | string => {
 
   if (key === 'icon') {
     return `:icon="RocketIcon"`
+  } else if (key === 'loadingIcon') {
+    return `:loading-icon="RocketIcon"`
   } else if (key === 'trailingIcon') {
     return `:trailing-icon="RocketIcon"`
   } else if (key === 'deleteIcon') {


### PR DESCRIPTION
## Problem
The **Deploy to Pages** workflow has failed on every run since **#577** (`80ab3e4a`, PR #275 *feat(Empty): add loading and loadingIcon props*). The last green deploy was **#576** (PR #274). CI aborts in the **Generate Docs** step:

```
Errors prerendering:
  ├─ /b24ui/docs/components/empty/ (20839ms)
  │ ├── [500] Server Error
[error] Exiting due to prerender errors.
```

`/docs/components/empty/` is the **only** failing route — every other page prerenders fine (all the "Linked from …" lines are just pages that link to it). My recent sync PRs (#279/#280/#281) merely inherited an already-broken `main`; they didn't cause this.

## Root cause
PR #275's ported "Loading Icon" example uses:
```yaml
cast:
  loadingIcon: 'LoaderClockIcon'
```
but `LoaderClockIcon` was never added to the docs **`castMap`** (in `ComponentCode.vue` and `server/utils/transformMDC.ts`). An unregistered cast hits:
```ts
if (cast && !castMap[cast]) throw new Error(`Unknown cast: ${cast}`)
```
during SSR → Nitro reports `[500]` and exits with prerender errors.

b24ui docs deliberately expose **one** registered demo-icon cast — `RocketIcon` — and every other icon example uses it (`convertIcon` hardcodes it in each branch). `LoaderClockIcon` was an un-adapted leftover from the upstream port.

## Fix
- **`empty.md`** — cast `loadingIcon` via the registered `RocketIcon`.
- **`ComponentCode.vue` + `transformMDC.ts`** — add `loadingIcon` to `iconsTypeList` and `convertIcon`, so the example's displayed code shows `:loading-icon="RocketIcon"`, consistent with the live preview (matching the existing `icon`/`trailing-icon`/… handling).

Audited all docs content: after this change, the only icon cast referenced anywhere is `RocketIcon` (registered) — no other latent unregistered-cast 500s.

## Verification
Local full `nuxt generate docs` can't complete in the sandbox (`ulimit -Hn` is 4096 → `EMFILE` in `@nuxtjs/mdc`), but across runs the prerender reached **774 routes with zero `Unknown cast`/`[500]` errors** — the empty-page crash no longer occurs. The authoritative check is this PR's **Deploy to Pages** run, which has the fd headroom to complete the prerender (pre-fix it finished the full crawl and failed *only* on the empty-page cast).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JS8ypVfQSFzYVZzkTHhURb)_