### PR TITLE
perf(vue): skip rewriting unchanged templates (14b6001)

### DIFF
--- a/.sync/log/14b60013ddc094c8e7cee5a3633a57d26c5842e6.md
+++ b/.sync/log/14b60013ddc094c8e7cee5a3633a57d26c5842e6.md
@@ -1,0 +1,25 @@
+# Port: perf(vue): skip rewriting unchanged templates
+
+**Upstream:** `14b60013ddc094c8e7cee5a3633a57d26c5842e6` (nuxt/ui, #6730)
+**Decision:** port — build plugin (verbatim, adapted dir name)
+
+## Upstream change
+Optimizes the template-writing plugin (`src/plugins/templates.ts`): before
+writing each generated virtual template to `node_modules/.nuxt-ui`, read the
+existing file and skip the write if the contents are identical — avoiding mtime
+churn that needlessly invalidates watchers and Tailwind's source scan. Also
+tracks already-created directories in a `Set` to skip redundant `existsSync`.
+
+## b24ui port
+- **`src/plugins/templates.ts`** — b24ui's plugin is structurally identical
+  (writes to `node_modules/.b24ui-nuxt`). Applied the same change verbatim:
+  - `createdDirs` `Set<string>` guards `mkdirSync` per directory;
+  - compute `contents` once, read `existing` (swallowing `ENOENT`), and only
+    `writeFileSync` when `existing !== contents`.
+
+## Tests
+Build-plugin behavior only — no runtime/theme/snapshot impact. Suite unchanged:
+5557 passed / 6 skipped.
+
+## Verify (CI=true)
+`dev:prepare` · `lint` · `typecheck` · `test` · `build` — all green.

--- a/.sync/nuxt-ui.json
+++ b/.sync/nuxt-ui.json
@@ -2,7 +2,7 @@
   "upstream": "nuxt/ui",
   "branch": "v4",
   "sync_enabled": false,
-  "cursor": "317901253dfd02a857ebdba632816445ba45afef",
+  "cursor": "14b60013ddc094c8e7cee5a3633a57d26c5842e6",
   "_cursor_note": "cursor = last upstream commit ported into b24ui (oldest-first, manual cadence). sync_enabled stays false until Phase 2 (porter workflow #67 + CLAUDE_CODE_OAUTH_TOKEN) is wired and trusted. `processed` is maintained per port from now on (backfilled #68-#72 on 2026-06-09).",
   "stats": {
     "queue_depth": 0,
@@ -1091,10 +1091,16 @@
       "summary": "chore(deps): update all non-major dependencies — §2 manifest mirroring of the subset where b24ui shares upstream's old range. Bumped: packageManager pnpm@11.10.0->11.13.0, @floating-ui/dom ^1.7.6->^1.8.0, @tanstack/vue-virtual ^3.13.31->^3.13.32, fuse.js ^7.4.2->^7.5.0, vue-component-type-helpers/vue-component-meta/vue-tsc ^3.3.6->^3.3.7 (root+docs+nuxt+vue+demo), eslint ^10.6.0->^10.7.0, vitest ^4.1.9->^4.1.10, @nuxtjs/mcp-toolkit + nuxt-component-meta ^0.17.2->^0.18.0. SKIPPED (b24ui diverges): ai (v6 line, deferred v7), @ai-sdk/vue (v3), @ai-sdk/mcp (v1), @ai-sdk/anthropic/gateway (absent, uses deepseek), @iconify-json/* (uses b24icons), prettier (already behind at ^3.8.4). Lockfile regen w/ pnpm 11.13.0; AI-SDK v6/v3/v1 lines untouched. No overrides match. Tests 5485."
     },
     "317901253dfd02a857ebdba632816445ba45afef": {
+      "pr": 284,
+      "b24ui_sha": "d44574c0d6db1bf05851aacc3a921d22a6a0fabd",
+      "decision": "port",
+      "summary": "fix(theme): use logical properties for RTL — convert physical directional utilities to logical across theme files (left→start, right→end, text-left/right→text-start/end, transition-[left,right]→inset-inline-*, + rtl: counterparts for translate-x/cursor-resize). b24ui has 9/16 touched files; applied to 8 (navigation-menu viewportWrapper, prose/callout+card externalIcon, prose/pre copy, prose/td+th align, sidebar 6 hunks, table th+separator). prose/tr empty stub. SKIPPED absent: blog-post/content-navigation/content-surround/pricing-plan/pricing-table/prose-code-tree. Contributor-doc RTL guidance (theme-structure.md/AGENTS.md) deferred (docs-only, diverged). Snapshots regen."
+    },
+    "14b60013ddc094c8e7cee5a3633a57d26c5842e6": {
       "pr": null,
       "b24ui_sha": "pending-merge",
       "decision": "port",
-      "summary": "fix(theme): use logical properties for RTL — convert physical directional utilities to logical across theme files (left→start, right→end, text-left/right→text-start/end, transition-[left,right]→inset-inline-*, + rtl: counterparts for translate-x/cursor-resize). b24ui has 9/16 touched files; applied to 8 (navigation-menu viewportWrapper, prose/callout+card externalIcon, prose/pre copy, prose/td+th align, sidebar 6 hunks, table th+separator). prose/tr empty stub. SKIPPED absent: blog-post/content-navigation/content-surround/pricing-plan/pricing-table/prose-code-tree. Contributor-doc RTL guidance (theme-structure.md/AGENTS.md) deferred (docs-only, diverged). Snapshots regen."
+      "summary": "perf(vue): skip rewriting unchanged templates — in src/plugins/templates.ts, read existing generated template file and skip writeFileSync when contents are identical (avoids mtime churn → watcher/Tailwind reinvalidation); track created dirs in a Set to skip redundant existsSync. b24ui plugin structurally identical (writes .b24ui-nuxt); applied verbatim. Build-plugin only, no runtime/snapshot impact. Tests 5557."
     }
   }
 }

--- a/src/plugins/templates.ts
+++ b/src/plugins/templates.ts
@@ -15,15 +15,34 @@ export default function TemplatePlugin(options: Bitrix24UIOptions, appConfig: Re
   async function writeTemplates(root: string) {
     const map: Record<string, string> = {}
     const dir = path.join(root, 'node_modules', '.b24ui-nuxt')
+    const createdDirs = new Set<string>()
     for (const template of templates) {
       if (!template.write || !template.filename) {
         continue
       }
       const filePath = path.join(dir, template.filename)
-      if (!fs.existsSync(path.dirname(filePath))) {
-        fs.mkdirSync(path.dirname(filePath), { recursive: true })
+      const fileDir = path.dirname(filePath)
+      if (!createdDirs.has(fileDir)) {
+        if (!fs.existsSync(fileDir)) {
+          fs.mkdirSync(fileDir, { recursive: true })
+        }
+        createdDirs.add(fileDir)
       }
-      fs.writeFileSync(filePath, await template.getContents!({} as any))
+
+      const contents = await template.getContents!({} as any)
+      // Skip rewriting identical files so we don't churn mtimes on every config
+      // resolve, which needlessly invalidates watchers and Tailwind's source scan.
+      let existing: string | null = null
+      try {
+        existing = fs.readFileSync(filePath, 'utf8')
+      } catch (error: any) {
+        if (error.code !== 'ENOENT') {
+          throw error
+        }
+      }
+      if (existing !== contents) {
+        fs.writeFileSync(filePath, contents)
+      }
 
       map[`#build/${template.filename}`] = filePath
     }


### PR DESCRIPTION
Syncs upstream nuxt/ui commit [`14b6001`](https://github.com/nuxt/ui/commit/14b60013ddc094c8e7cee5a3633a57d26c5842e6) — *perf(vue): skip rewriting unchanged templates* (#6730).

## What
In the template-writing plugin, read the existing generated file and skip `writeFileSync` when the contents are identical — avoiding mtime churn that needlessly invalidates watchers and Tailwind's source scan on every config resolve. Also tracks already-created directories in a `Set` to skip redundant `existsSync` calls.

## b24ui port
- **`src/plugins/templates.ts`** — b24ui's plugin is structurally identical (writes generated virtual templates to `node_modules/.b24ui-nuxt`); the change was applied verbatim: `createdDirs` Set guards `mkdirSync`, and a read-before-write comparison (swallowing `ENOENT`) skips the write when `existing === contents`.

## Tests
Build-plugin behavior only — no runtime/theme/snapshot impact. Suite **5557 passed / 6 skipped** (unchanged).

## Verify (`CI=true`)
`dev:prepare` · `lint` · `typecheck` · `test` · `build` — all green (typecheck & build isolated).

Ledger: cursor advanced to `14b6001`; previous entry `3179012` reconciled to PR #284.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JS8ypVfQSFzYVZzkTHhURb)_