### PR TITLE
test: add benchmarks (f546b2c)

### DIFF
--- a/.sync/log/f546b2c9008044a48e4e9a1d08e9082d5012b200.md
+++ b/.sync/log/f546b2c9008044a48e4e9a1d08e9082d5012b200.md
@@ -1,0 +1,35 @@
+# Port: test: add benchmarks
+
+**Upstream:** `f546b2c9008044a48e4e9a1d08e9082d5012b200` (nuxt/ui, #6728)
+**Decision:** port — test-infra (adapted to b24ui API)
+
+## Upstream change
+Adds a Vitest benchmark suite (`test/bench/components.bench.ts`,
+`test/bench/tv.bench.ts`), wires it into the `vue` project only (happy-dom,
+excluded from `nuxt`), and adds a `pnpm bench` script. Benchmarks profile
+component mount/re-render cost and the `tv` factory build/invoke/slot cost.
+
+## b24ui port
+- **`test/bench/components.bench.ts`** — ported; Button/Table import paths are
+  identical, `mountSuspended` resolves to b24ui's `test/utils/mount.ts` in the
+  vue project. Renamed the local `UButton` registration to `B24Button`; b24ui's
+  Button (`label`/`loading`) and Table (`data`/`columns`/`TableColumn`) APIs
+  match 1:1.
+- **`test/bench/tv.bench.ts`** — ported with b24ui adaptation:
+  - imports `#build/b24ui/{button,navigation-menu,table}` (was `#build/ui/*`);
+  - `buttonProps` / `tableProps` rewritten to mirror b24ui's actual
+    `Button.vue` / `Table.vue` `tv(...)(...)` invocation objects (air colors,
+    `depth`/`useLabel`/`rounded`/`isAir` for button; `loadingColor: air-primary`,
+    `loadingAnimation: carousel`, `virtualize` for table);
+  - `td` slot invocation uses b24ui's `pinned` variant (unchanged).
+- **`vitest.config.ts`** — `benchmark: { include: [] }` on the nuxt project;
+  `benchmark: { include: ['bench/**/*.bench.ts'] }` on the vue project.
+- **`package.json`** — added `"bench": "vitest bench --project vue"`.
+
+## Tests
+Additive test-infra; not part of the `ci` gate. `pnpm bench` verified locally —
+all 8 benchmark groups run green against b24ui's components/themes. Normal suite
+unchanged (benchmarks excluded from `.spec.ts` runs): 5557 passed / 6 skipped.
+
+## Verify (CI=true)
+`dev:prepare` · `lint` · `typecheck` · `test` · `build` (+ `bench`) — all green.

--- a/.sync/nuxt-ui.json
+++ b/.sync/nuxt-ui.json
@@ -2,7 +2,7 @@
   "upstream": "nuxt/ui",
   "branch": "v4",
   "sync_enabled": false,
-  "cursor": "14b60013ddc094c8e7cee5a3633a57d26c5842e6",
+  "cursor": "f546b2c9008044a48e4e9a1d08e9082d5012b200",
   "_cursor_note": "cursor = last upstream commit ported into b24ui (oldest-first, manual cadence). sync_enabled stays false until Phase 2 (porter workflow #67 + CLAUDE_CODE_OAUTH_TOKEN) is wired and trusted. `processed` is maintained per port from now on (backfilled #68-#72 on 2026-06-09).",
   "stats": {
     "queue_depth": 0,
@@ -1097,10 +1097,16 @@
       "summary": "fix(theme): use logical properties for RTL — convert physical directional utilities to logical across theme files (left→start, right→end, text-left/right→text-start/end, transition-[left,right]→inset-inline-*, + rtl: counterparts for translate-x/cursor-resize). b24ui has 9/16 touched files; applied to 8 (navigation-menu viewportWrapper, prose/callout+card externalIcon, prose/pre copy, prose/td+th align, sidebar 6 hunks, table th+separator). prose/tr empty stub. SKIPPED absent: blog-post/content-navigation/content-surround/pricing-plan/pricing-table/prose-code-tree. Contributor-doc RTL guidance (theme-structure.md/AGENTS.md) deferred (docs-only, diverged). Snapshots regen."
     },
     "14b60013ddc094c8e7cee5a3633a57d26c5842e6": {
+      "pr": 285,
+      "b24ui_sha": "ebeee29ad94a3749229f4d2df231929e7255a486",
+      "decision": "port",
+      "summary": "perf(vue): skip rewriting unchanged templates — in src/plugins/templates.ts, read existing generated template file and skip writeFileSync when contents are identical (avoids mtime churn → watcher/Tailwind reinvalidation); track created dirs in a Set to skip redundant existsSync. b24ui plugin structurally identical (writes .b24ui-nuxt); applied verbatim. Build-plugin only, no runtime/snapshot impact. Tests 5557."
+    },
+    "f546b2c9008044a48e4e9a1d08e9082d5012b200": {
       "pr": null,
       "b24ui_sha": "pending-merge",
       "decision": "port",
-      "summary": "perf(vue): skip rewriting unchanged templates — in src/plugins/templates.ts, read existing generated template file and skip writeFileSync when contents are identical (avoids mtime churn → watcher/Tailwind reinvalidation); track created dirs in a Set to skip redundant existsSync. b24ui plugin structurally identical (writes .b24ui-nuxt); applied verbatim. Build-plugin only, no runtime/snapshot impact. Tests 5557."
+      "summary": "test: add benchmarks — Vitest bench suite (test/bench/components.bench.ts + tv.bench.ts) wired into the vue project (benchmark.include), excluded from nuxt, + pnpm bench script. Adapted to b24ui: components.bench maps 1:1 (Button label/loading, Table data/columns/TableColumn, mountSuspended); tv.bench imports #build/b24ui/* and uses b24ui Button/Table tv() prop shapes (air colors, depth/useLabel/rounded/isAir, loadingColor/loadingAnimation/virtualize, pinned slot). pnpm bench verified — 8 groups green. Not in CI gate. Tests 5557."
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -137,7 +137,8 @@
     "typecheck": "vue-tsc --noEmit && nuxt typecheck playgrounds/nuxt && nuxt typecheck playgrounds/demo && nuxt typecheck docs && cd playgrounds/vue && vue-tsc --noEmit",
     "test": "vitest",
     "test:vue": "vitest --project vue",
-    "test:nuxt": "vitest --project nuxt"
+    "test:nuxt": "vitest --project nuxt",
+    "bench": "vitest bench --project vue"
   },
   "dependencies": {
     "@floating-ui/dom": "^1.8.0",

--- a/test/bench/components.bench.ts
+++ b/test/bench/components.bench.ts
@@ -1,0 +1,88 @@
+import { bench, describe } from 'vitest'
+import { mountSuspended } from '@nuxt/test-utils/runtime'
+import Button from '../../src/runtime/components/Button.vue'
+import Table from '../../src/runtime/components/Table.vue'
+import type { TableColumn } from '../../src/runtime/components/Table.vue'
+
+// A toolbar of many buttons (the #6293 shape): each Button builds its own tv
+// factory on mount, and re-renders on every editor transaction. Labels only —
+// icons resolve via an async fetch that's orthogonal to the tv cost measured here.
+const Toolbar = {
+  components: { B24Button: Button },
+  template: `<div><B24Button v-for="i in 25" :key="i" :label="'B' + i" /></div>`
+}
+
+describe('Button mount', () => {
+  bench('toolbar of 25', async () => {
+    const wrapper = await mountSuspended(Toolbar)
+    wrapper.unmount()
+  })
+})
+
+// Toggling a variant prop re-runs the component's `b24ui` computed and re-renders
+// its subtree. Each iteration performs a full on/off cycle so the work measured
+// is deterministic and always ends back in the initial `false` state.
+describe('Button re-render (variant prop change)', () => {
+  let wrapper: Awaited<ReturnType<typeof mountSuspended>>
+
+  bench('toggle loading', async () => {
+    await wrapper.setProps({ loading: true })
+    await wrapper.setProps({ loading: false })
+  }, {
+    async setup() {
+      wrapper = await mountSuspended(Button, { props: { label: 'Button' } })
+    },
+    teardown() {
+      wrapper?.unmount()
+    }
+  })
+})
+
+type Row = { id: number, name: string, email: string, amount: number, status: string }
+
+function makeData(n: number): Row[] {
+  return Array.from({ length: n }, (_, i) => ({
+    id: i,
+    name: `Name ${i}`,
+    email: `user${i}@example.com`,
+    amount: i * 3,
+    status: i % 2 ? 'success' : 'failed'
+  }))
+}
+
+const columns: TableColumn<Row>[] = [
+  { accessorKey: 'id', header: '#' },
+  { accessorKey: 'name', header: 'Name' },
+  { accessorKey: 'email', header: 'Email' },
+  { accessorKey: 'amount', header: 'Amount' },
+  { accessorKey: 'status', header: 'Status' }
+]
+
+// `mountSuspended` doesn't infer the Table's row generic, so the mounted prop
+// expects `TableColumn<unknown, unknown>[]` — cast the checked columns at use.
+const tableProps = (data: Row[]) => ({ data, columns: columns as unknown as TableColumn<unknown, unknown>[] })
+
+// The per-cell `b24ui.td()` path at scale (200 rows x 5 columns = 1000 cells).
+describe('Table mount (200 x 5)', () => {
+  const data = makeData(200)
+
+  bench('mount', async () => {
+    const wrapper = await mountSuspended(Table, { props: tableProps(data) })
+    wrapper.unmount()
+  })
+})
+
+describe('Table re-render (new data identity)', () => {
+  let wrapper: Awaited<ReturnType<typeof mountSuspended>>
+
+  bench('set data', async () => {
+    await wrapper.setProps({ data: makeData(200) })
+  }, {
+    async setup() {
+      wrapper = await mountSuspended(Table, { props: tableProps(makeData(200)) })
+    },
+    teardown() {
+      wrapper?.unmount()
+    }
+  })
+})

--- a/test/bench/tv.bench.ts
+++ b/test/bench/tv.bench.ts
@@ -1,0 +1,96 @@
+import { bench, describe } from 'vitest'
+import { tv } from '../../src/runtime/utils/tv'
+import buttonTheme from '#build/b24ui/button'
+import navigationMenuTheme from '#build/b24ui/navigation-menu'
+import tableTheme from '#build/b24ui/table'
+
+// Representative invocation props for each component (mirrors the objects the
+// components pass to `tv(...)(...)` at runtime — see Button.vue / Table.vue).
+const buttonProps = {
+  color: 'air-primary',
+  depth: 'normal',
+  size: 'md',
+  noSplit: false,
+  loading: false,
+  useLabel: true,
+  block: false,
+  normalCase: false,
+  rounded: false,
+  useDropdown: false,
+  useWait: false,
+  useClock: false,
+  leading: false,
+  isAir: true
+} as const
+const tableProps = {
+  sticky: false,
+  loading: false,
+  loadingColor: 'air-primary',
+  loadingAnimation: 'carousel',
+  virtualize: false,
+  externalScroll: false
+} as const
+
+// Building the factory is the expensive step (deep-merges the whole variant
+// matrix, joins every slot, flattens compound variants). Today it happens inside
+// each component's `computed`, so every variant-prop change re-runs it.
+describe('factory build', () => {
+  bench('button', () => {
+    tv({ extend: buttonTheme })
+  })
+
+  bench('table', () => {
+    tv({ extend: tableTheme })
+  })
+
+  bench('navigation-menu', () => {
+    tv({ extend: navigationMenuTheme })
+  })
+})
+
+// Invoking a prebuilt factory is the cheap step — this is all a variant-prop
+// change should cost once the build is hoisted out of the invocation computed.
+describe('invocation (prebuilt factory)', () => {
+  const buttonFactory = tv({ extend: buttonTheme })
+  const tableFactory = tv({ extend: tableTheme })
+
+  bench('button', () => {
+    buttonFactory(buttonProps)
+  })
+
+  bench('table', () => {
+    tableFactory(tableProps)
+  })
+})
+
+// Build and invoke fused in one call, as every component does today. The gap
+// between this and "invocation (prebuilt factory)" is the overhead saved by
+// hoisting factory construction out of the per-variant-prop recomputation.
+describe('build + invoke (current fused pattern)', () => {
+  bench('button', () => {
+    tv({ extend: buttonTheme })(buttonProps)
+  })
+
+  bench('table', () => {
+    tv({ extend: tableTheme })(tableProps)
+  })
+})
+
+// Table renders call `b24ui.td(...)` once per cell through the `wrapSlots` proxy.
+// This models a 100-cell render, exercising the per-access wrapper-closure
+// allocation and the replacer scan on every slot call.
+describe('slot invocation', () => {
+  const tableUi = tv({ extend: tableTheme })(tableProps)
+
+  bench('td x100 (string class)', () => {
+    for (let i = 0; i < 100; i++) {
+      tableUi.td({ class: 'p-2', pinned: false })
+    }
+  })
+
+  bench('td x100 (array class)', () => {
+    for (let i = 0; i < 100; i++) {
+      tableUi.td({ class: [undefined, 'p-2'], pinned: false })
+    }
+  })
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -32,6 +32,9 @@ export default defineConfig({
             'composables/**.spec.ts',
             'utils/**/**.spec.ts'
           ],
+          // Benchmarks run in the `vue` project only (happy-dom, faster); keep them
+          // out of the nuxt project so a bare `vitest bench` doesn't double-run them.
+          benchmark: { include: [] },
           environment: 'nuxt',
           environmentOptions: {
             nuxt: {
@@ -52,6 +55,7 @@ export default defineConfig({
             'composables/**.spec.ts',
             'utils/**/**.spec.ts'
           ],
+          benchmark: { include: ['bench/**/*.bench.ts'] },
           setupFiles: ['./test/utils/setup.ts']
         },
         plugins: [


### PR DESCRIPTION
Syncs upstream nuxt/ui commit [`f546b2c`](https://github.com/nuxt/ui/commit/f546b2c9008044a48e4e9a1d08e9082d5012b200) — *test: add benchmarks* (#6728).

## What
Adds a Vitest benchmark suite profiling component mount/re-render cost and the `tv` factory build/invoke/slot cost, wired into the `vue` project only (happy-dom, excluded from `nuxt`), exposed via `pnpm bench`.

## b24ui port
- **`test/bench/components.bench.ts`** — Button/Table mount + re-render benchmarks. b24ui APIs map 1:1 (`label`/`loading`, `data`/`columns`/`TableColumn`, `mountSuspended` resolves to b24ui's `test/utils/mount.ts`); local `UButton`→`B24Button`.
- **`test/bench/tv.bench.ts`** — `tv` factory build/invoke/slot benchmarks. Adapted: imports `#build/b24ui/{button,navigation-menu,table}` and uses b24ui's actual `Button.vue`/`Table.vue` `tv(...)(...)` prop shapes (air colors, `depth`/`useLabel`/`rounded`/`isAir`; `loadingColor`/`loadingAnimation`/`virtualize`; `pinned` slot).
- **`vitest.config.ts`** — `benchmark: { include: [] }` on nuxt, `benchmark: { include: ['bench/**/*.bench.ts'] }` on vue.
- **`package.json`** — `"bench": "vitest bench --project vue"`.

## Tests
Additive test-infra; **not part of the `ci` gate**. `pnpm bench` verified locally — all **8 benchmark groups run green** against b24ui's components/themes. Normal suite unchanged (benchmarks excluded from `.spec.ts` runs): **5557 passed / 6 skipped**.

## Verify (`CI=true`)
`dev:prepare` · `lint` · `typecheck` · `test` · `build` (+ `bench`) — all green.

Ledger: cursor advanced to `f546b2c`; previous entry `14b6001` reconciled to PR #285.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JS8ypVfQSFzYVZzkTHhURb)_