### PR TITLE
feat(prose): configurable heading anchors and copy button (f419731)

### DIFF
--- a/.sync/log/f419731d9b570892e21b990f13985f3f4ad4a56c.md
+++ b/.sync/log/f419731d9b570892e21b990f13985f3f4ad4a56c.md
@@ -1,0 +1,46 @@
+# Port: feat(prose): configurable heading anchors and copy button
+
+**Upstream:** `f419731d9b570892e21b990f13985f3f4ad4a56c` (nuxt/ui, #6735)
+**Decision:** port — feature (adapted; Chat.vue N/A)
+
+## Upstream change
+- Prose `H1`–`H4` gain an `anchor?: boolean` prop that decides whether the
+  heading is wrapped in an anchor link when it has an `id`, taking precedence
+  over the now-deprecated `mdc.headings.anchorLinks` config fallback.
+- Prose `Pre` gains a `copy?: boolean | Omit<ButtonProps, LinkPropsKeys>` prop
+  (default `true`) to hide/customize the code-copy button.
+- `ThemeDefaults` gains a `prose` namespace so `<Theme :props>` can set
+  per-element prose defaults; `prose` is dropped from the test's non-proxy list.
+- Docs updated for both features; `Chat.vue` disables heading anchors via Theme.
+
+## b24ui port
+- **`prose/H1.vue`–`H4.vue`** — added `anchor?: boolean` and rewrote `generate`
+  to `props.id && (props.anchor ?? (typeof anchorLinks === 'boolean' ?
+  anchorLinks : anchorLinks?.hN) ?? false)`. H2–H4 carry the upstream note that
+  `@nuxt/content`/`@nuxtjs/mdc` enable anchors for them by default.
+- **`prose/Pre.vue`** — added `copy` prop (`withDefaults(..., { copy: true })`),
+  gated the copy `B24Button` behind `v-if="props.copy"` with
+  `v-bind="(typeof props.copy === 'object' ? props.copy : {})"`. Imported
+  `ButtonProps` (Button.vue) + `LinkPropsKeys` (Link.vue). Renamed the
+  `useClipboard` `copy` binding to `copyToClipboard` to avoid a `vue/no-dupe-keys`
+  collision with the new prop.
+- **`types/theme.ts`** — added the `prose` namespace to `ThemeDefaults`
+  (a/accordion/callout/card/code/codeCollapse/codeGroup/collapsible/field/
+  fieldGroup/h1–h4/img/pre/prompt/steps/tabs/td/th). Dropped upstream's
+  `codeTree` entry (b24ui has no CodeTree).
+- **`useComponentProps.spec.ts`** — removed `prose` from `NonProxyComponents`
+  (kept the drift catcher balanced: `prose` now lives in both `Expected` and
+  `ThemeDefaults`) and trimmed the now-stale prose bullet in its doc comment.
+- **Docs** — `headers-and-text.md` gains the `anchor`/`B24Theme` example and the
+  reworded `@nuxt/content` note; `code.md` documents the `copy` prop.
+- **`Chat.vue` — N/A.** b24ui has no Chat component, so the upstream Theme-based
+  anchor-disable hunk was skipped.
+
+## Tests
+Prop additions with backward-compatible defaults (anchor still resolves to the
+same off state in the test env; copy defaults true → button still renders), so
+no snapshot churn. `useComponentProps` drift catcher stays green. Suite:
+5557 passed / 6 skipped.
+
+## Verify (CI=true)
+`dev:prepare` · `lint` · `typecheck` · `test` · `build` — all green.

--- a/.sync/nuxt-ui.json
+++ b/.sync/nuxt-ui.json
@@ -2,7 +2,7 @@
   "upstream": "nuxt/ui",
   "branch": "v4",
   "sync_enabled": false,
-  "cursor": "f546b2c9008044a48e4e9a1d08e9082d5012b200",
+  "cursor": "f419731d9b570892e21b990f13985f3f4ad4a56c",
   "_cursor_note": "cursor = last upstream commit ported into b24ui (oldest-first, manual cadence). sync_enabled stays false until Phase 2 (porter workflow #67 + CLAUDE_CODE_OAUTH_TOKEN) is wired and trusted. `processed` is maintained per port from now on (backfilled #68-#72 on 2026-06-09).",
   "stats": {
     "queue_depth": 0,
@@ -1103,10 +1103,16 @@
       "summary": "perf(vue): skip rewriting unchanged templates — in src/plugins/templates.ts, read existing generated template file and skip writeFileSync when contents are identical (avoids mtime churn → watcher/Tailwind reinvalidation); track created dirs in a Set to skip redundant existsSync. b24ui plugin structurally identical (writes .b24ui-nuxt); applied verbatim. Build-plugin only, no runtime/snapshot impact. Tests 5557."
     },
     "f546b2c9008044a48e4e9a1d08e9082d5012b200": {
+      "pr": 286,
+      "b24ui_sha": "0d77ae456c01e34ff59000eb0c0fdb6656c70ebe",
+      "decision": "port",
+      "summary": "test: add benchmarks — Vitest bench suite (test/bench/components.bench.ts + tv.bench.ts) wired into the vue project (benchmark.include), excluded from nuxt, + pnpm bench script. Adapted to b24ui: components.bench maps 1:1 (Button label/loading, Table data/columns/TableColumn, mountSuspended); tv.bench imports #build/b24ui/* and uses b24ui Button/Table tv() prop shapes (air colors, depth/useLabel/rounded/isAir, loadingColor/loadingAnimation/virtualize, pinned slot). pnpm bench verified — 8 groups green. Not in CI gate. Tests 5557."
+    },
+    "f419731d9b570892e21b990f13985f3f4ad4a56c": {
       "pr": null,
       "b24ui_sha": "pending-merge",
       "decision": "port",
-      "summary": "test: add benchmarks — Vitest bench suite (test/bench/components.bench.ts + tv.bench.ts) wired into the vue project (benchmark.include), excluded from nuxt, + pnpm bench script. Adapted to b24ui: components.bench maps 1:1 (Button label/loading, Table data/columns/TableColumn, mountSuspended); tv.bench imports #build/b24ui/* and uses b24ui Button/Table tv() prop shapes (air colors, depth/useLabel/rounded/isAir, loadingColor/loadingAnimation/virtualize, pinned slot). pnpm bench verified — 8 groups green. Not in CI gate. Tests 5557."
+      "summary": "feat(prose): configurable heading anchors and copy button — prose H1-H4 gain anchor?:boolean (precedence over deprecated mdc.headings.anchorLinks fallback), prose Pre gains copy?:boolean|Omit<ButtonProps,LinkPropsKeys> (default true, v-if-gated button + v-bind customize), ThemeDefaults gains prose namespace (dropped codeTree — absent), spec drops prose from NonProxyComponents (drift catcher balanced). Renamed Pre useClipboard copy→copyToClipboard (dupe-key). Docs: headers-and-text (anchor/B24Theme example) + code (copy prop). Chat.vue N/A (b24ui has no Chat). Backward-compatible defaults → no snapshot churn. Tests 5557."
     }
   }
 }

--- a/docs/content/docs/4.typography/2.headers-and-text.md
+++ b/docs/content/docs/4.typography/2.headers-and-text.md
@@ -11,10 +11,20 @@ links:
 
 Use headings to organize your content and make it easier to read.
 
-H1 to H3 headings get anchor links and show up in the table of contents for easy navigation.
+Headings can be wrapped in an anchor link when they have an `id`, with a hash icon shown on hover for `H2` and `H3` so readers can link directly to a section.
+
+Anchor links are off by default. Use the [`Theme`](/docs/components/theme/) component with the `anchor` prop to toggle them for a section of your app:
+
+```vue
+<template>
+  <B24Theme :props="{ prose: { h2: { anchor: true }, h3: { anchor: true }, h4: { anchor: true } } }">
+    <!-- your rendered markdown -->
+  </B24Theme>
+</template>
+```
 
 ::note
-You can control [anchor links](https://content.nuxt.com/docs/getting-started/configuration#anchorlinks) generation (for example, for AI chat interfaces) in your `nuxt.config.ts`:
+When using `@nuxt/content`, anchor links are enabled for `H2`, `H3` and `H4` by default. You can control their [generation](https://content.nuxt.com/docs/getting-started/configuration#anchorlinks) (for example, to disable them for AI chat interfaces) in your `nuxt.config.ts`:
 
 ```ts [nuxt.config.ts]
 export default defineNuxtConfig({

--- a/docs/content/docs/4.typography/5.code.md
+++ b/docs/content/docs/4.typography/5.code.md
@@ -11,6 +11,8 @@ links:
 
 Code blocks are rendered by the `ProsePre` component of `@nuxtjs/mdc` and [code highlighting](https://content.nuxt.com/docs/files/markdown#code-highlighting) is done underneath by [Shiki](https://github.com/shikijs/shiki).
 
+Set the `copy` prop to `false` to hide the copy button, or pass [Button](/docs/components/button/) props to customize it.
+
 ::tabs{class="gap-0"}
 
 ::code-preview{label="Preview" class="[&>div]:*:my-0 [&>div]:*:w-full"}

--- a/src/runtime/components/prose/H1.vue
+++ b/src/runtime/components/prose/H1.vue
@@ -9,6 +9,11 @@ type ProseH1 = ComponentConfig<typeof theme, AppConfig, 'h1', 'b24ui.prose'>
 export interface ProseH1Props {
   id?: string
   /**
+   * Wrap the heading in an anchor link when an `id` is present.
+   * @defaultValue false
+   */
+  anchor?: boolean
+  /**
    * @defaultValue 'default'
    */
   accent?: ProseH1['variants']['accent']
@@ -43,7 +48,8 @@ const b24ui = computed(() => tv({ extend: theme, ...(appConfig.b24ui?.prose?.h1 
   accent: props.accent
 }))
 
-const generate = computed(() => props.id && typeof headings?.anchorLinks === 'object' && headings.anchorLinks.h1)
+// NOTE: the `mdc.headings.anchorLinks` fallback is deprecated, remove in v5 in favor of the `anchor` prop.
+const generate = computed(() => props.id && (props.anchor ?? (typeof headings?.anchorLinks === 'boolean' ? headings.anchorLinks : headings?.anchorLinks?.h1) ?? false))
 </script>
 
 <template>

--- a/src/runtime/components/prose/H2.vue
+++ b/src/runtime/components/prose/H2.vue
@@ -9,6 +9,12 @@ type ProseH2 = ComponentConfig<typeof theme, AppConfig, 'h2', 'b24ui.prose'>
 export interface ProseH2Props {
   id?: string
   /**
+   * Wrap the heading in an anchor link when an `id` is present.
+   * `@nuxt/content` and `@nuxtjs/mdc` enable this for H2–H4 by default.
+   * @defaultValue false
+   */
+  anchor?: boolean
+  /**
    * @defaultValue 'default'
    */
   accent?: ProseH2['variants']['accent']
@@ -44,7 +50,8 @@ const b24ui = computed(() => tv({ extend: theme, ...(appConfig.b24ui?.prose?.h2 
   accent: props.accent
 }))
 
-const generate = computed(() => props.id && typeof headings?.anchorLinks === 'object' && headings.anchorLinks.h2)
+// NOTE: the `mdc.headings.anchorLinks` fallback is deprecated, remove in v5 in favor of the `anchor` prop.
+const generate = computed(() => props.id && (props.anchor ?? (typeof headings?.anchorLinks === 'boolean' ? headings.anchorLinks : headings?.anchorLinks?.h2) ?? false))
 </script>
 
 <template>

--- a/src/runtime/components/prose/H3.vue
+++ b/src/runtime/components/prose/H3.vue
@@ -9,6 +9,12 @@ type ProseH3 = ComponentConfig<typeof theme, AppConfig, 'h3', 'b24ui.prose'>
 export interface ProseH3Props {
   id?: string
   /**
+   * Wrap the heading in an anchor link when an `id` is present.
+   * `@nuxt/content` and `@nuxtjs/mdc` enable this for H2–H4 by default.
+   * @defaultValue false
+   */
+  anchor?: boolean
+  /**
    * @defaultValue 'default'
    */
   accent?: ProseH3['variants']['accent']
@@ -44,7 +50,8 @@ const b24ui = computed(() => tv({ extend: theme, ...(appConfig.b24ui?.prose?.h3 
   accent: props.accent
 }))
 
-const generate = computed(() => props.id && typeof headings?.anchorLinks === 'object' && headings.anchorLinks.h3)
+// NOTE: the `mdc.headings.anchorLinks` fallback is deprecated, remove in v5 in favor of the `anchor` prop.
+const generate = computed(() => props.id && (props.anchor ?? (typeof headings?.anchorLinks === 'boolean' ? headings.anchorLinks : headings?.anchorLinks?.h3) ?? false))
 </script>
 
 <template>

--- a/src/runtime/components/prose/H4.vue
+++ b/src/runtime/components/prose/H4.vue
@@ -9,6 +9,12 @@ type ProseH4 = ComponentConfig<typeof theme, AppConfig, 'h4', 'b24ui.prose'>
 export interface ProseH4Props {
   id?: string
   /**
+   * Wrap the heading in an anchor link when an `id` is present.
+   * `@nuxt/content` and `@nuxtjs/mdc` enable this for H2–H4 by default.
+   * @defaultValue false
+   */
+  anchor?: boolean
+  /**
    * @defaultValue 'default'
    */
   accent?: ProseH4['variants']['accent']
@@ -44,7 +50,8 @@ const b24ui = computed(() => tv({ extend: theme, ...(appConfig.b24ui?.prose?.h4 
   accent: props.accent
 }))
 
-const generate = computed(() => props.id && typeof headings?.anchorLinks === 'object' && headings.anchorLinks.h4)
+// NOTE: the `mdc.headings.anchorLinks` fallback is deprecated, remove in v5 in favor of the `anchor` prop.
+const generate = computed(() => props.id && (props.anchor ?? (typeof headings?.anchorLinks === 'boolean' ? headings.anchorLinks : headings?.anchorLinks?.h4) ?? false))
 </script>
 
 <template>

--- a/src/runtime/components/prose/Pre.vue
+++ b/src/runtime/components/prose/Pre.vue
@@ -4,6 +4,8 @@ import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/b24ui/prose/pre'
 import type { IconComponent } from '../../types/icons'
 import type { ComponentConfig } from '../../types/tv'
+import type { ButtonProps } from '../Button.vue'
+import type { LinkPropsKeys } from '../Link.vue'
 
 type ProsePre = ComponentConfig<typeof theme, AppConfig, 'pre', 'b24ui.prose'>
 
@@ -15,6 +17,12 @@ export interface ProsePreProps {
   highlights?: number[]
   hideHeader?: boolean
   meta?: string
+  /**
+   * Display a button to copy the code to the clipboard.
+   * `{ size: 'sm', color: 'air-secondary-no-accent' }`{lang="ts-type"}
+   * @defaultValue true
+   */
+  copy?: boolean | Omit<ButtonProps, LinkPropsKeys>
   class?: any
   style?: any
   b24ui?: ProsePre['slots']
@@ -36,14 +44,16 @@ import icons from '../../dictionary/icons'
 import B24CodeIcon from './CodeIcon.vue'
 import B24Button from '../Button.vue'
 
-const _props = defineProps<ProsePreProps>()
+const _props = withDefaults(defineProps<ProsePreProps>(), {
+  copy: true
+})
 
 defineSlots<ProsePreSlots>()
 
 const props = useComponentProps('prose.pre', _props)
 
 const { t } = useLocale()
-const { copy, copied } = useClipboard()
+const { copy: copyToClipboard, copied } = useClipboard()
 const appConfig = useAppConfig() as ProsePre['AppConfig']
 
 const baseRef = useTemplateRef('baseRef')
@@ -54,7 +64,7 @@ const b24ui = computed(() => tv({ extend: theme, ...(appConfig.b24ui?.prose?.pre
 function copyCode() {
   const code = props.code ?? baseRef.value?.textContent ?? ''
 
-  copy(code)
+  copyToClipboard(code)
 }
 </script>
 
@@ -67,6 +77,7 @@ function copyCode() {
     </div>
 
     <B24Button
+      v-if="props.copy"
       color="air-secondary-no-accent"
       size="sm"
       :aria-label="t('prose.pre.copy')"
@@ -75,6 +86,7 @@ function copyCode() {
       tabindex="-1"
       :icon="copied ? icons.copyCheck : icons.copy"
       :b24ui="{ leadingIcon: [copied ? 'text-(--ui-color-accent-main-success)' : 'text-(--ui-btn-color)'] }"
+      v-bind="(typeof props.copy === 'object' ? props.copy : {})"
       @click="copyCode"
     />
 

--- a/src/runtime/types/theme.ts
+++ b/src/runtime/types/theme.ts
@@ -127,6 +127,36 @@ export interface ThemeDefaults {
   // pricingPlans?: Partial<ComponentTypes.PricingPlansProps>
   // pricingTable?: Partial<ComponentTypes.PricingTableProps>
   progress?: Partial<ComponentTypes.ProgressProps>
+  /**
+   * Prose components that expose overridable props, under a `prose` namespace
+   * (mirrors `app.config.b24ui.prose` and `useComponentProps('prose.<tag>', …)`).
+   * Set prop defaults per element to scope behavior for a subtree, e.g.
+   * `{ prose: { h2: { anchor: true }, pre: { copy: false } } }`. Class-only
+   * elements (`p`, `li`, `table`, `em`, …) are omitted — restyle them via `:b24ui`.
+   */
+  prose?: {
+    a?: Partial<ComponentTypes.ProseAProps>
+    accordion?: Partial<ComponentTypes.ProseAccordionProps>
+    callout?: Partial<ComponentTypes.ProseCalloutProps>
+    card?: Partial<ComponentTypes.ProseCardProps>
+    code?: Partial<ComponentTypes.ProseCodeProps>
+    codeCollapse?: Partial<ComponentTypes.ProseCodeCollapseProps>
+    codeGroup?: Partial<ComponentTypes.ProseCodeGroupProps>
+    collapsible?: Partial<ComponentTypes.ProseCollapsibleProps>
+    field?: Partial<ComponentTypes.ProseFieldProps>
+    fieldGroup?: Partial<ComponentTypes.ProseFieldGroupProps>
+    h1?: Partial<ComponentTypes.ProseH1Props>
+    h2?: Partial<ComponentTypes.ProseH2Props>
+    h3?: Partial<ComponentTypes.ProseH3Props>
+    h4?: Partial<ComponentTypes.ProseH4Props>
+    img?: Partial<ComponentTypes.ProseImgProps>
+    pre?: Partial<ComponentTypes.ProsePreProps>
+    prompt?: Partial<ComponentTypes.ProsePromptProps>
+    steps?: Partial<ComponentTypes.ProseStepsProps>
+    tabs?: Partial<ComponentTypes.ProseTabsProps>
+    td?: Partial<ComponentTypes.ProseTdProps>
+    th?: Partial<ComponentTypes.ProseThProps>
+  }
   radioGroup?: Partial<ComponentTypes.RadioGroupProps>
   range?: Partial<ComponentTypes.RangeProps> // this is slider
   scrollArea?: Partial<ComponentTypes.ScrollAreaProps>

--- a/test/composables/useComponentProps.spec.ts
+++ b/test/composables/useComponentProps.spec.ts
@@ -7,18 +7,15 @@ import type { ThemeDefaults } from '../../src/runtime/types/theme'
 
 /**
  * Hand-maintained list of `#build/b24ui` exports that intentionally don't
- * participate in `<B24Theme :props>` overrides. Two reasons land here:
+ * participate in `<B24Theme :props>` overrides:
  *
- *   - `prose` is a namespace, not a single component (its children live
- *     under `prose.<tag>` and are read via `useComponentProps('prose.p', …)`).
  *   - The matching Vue file doesn't run `useComponentProps`, so a `:props`
  *     entry would types-check but no-op at runtime. If a key stays here
  *     long-term, consider migrating the component to `useComponentProps`
  *     and removing it from this list.
  */
 type NonProxyComponents
-  = | 'prose'
-    | 'link'
+  = | 'link'
     | 'editorEmojiMenu'
     | 'editorMentionMenu'
     | 'editorSuggestionMenu'


### PR DESCRIPTION
Syncs upstream nuxt/ui commit [`f419731`](https://github.com/nuxt/ui/commit/f419731d9b570892e21b990f13985f3f4ad4a56c) — *feat(prose): configurable heading anchors and copy button* (#6735).

## b24ui port
- **`prose/H1.vue`–`H4.vue`** — add `anchor?: boolean` and rewrite `generate` to `props.id && (props.anchor ?? (typeof anchorLinks === 'boolean' ? anchorLinks : anchorLinks?.hN) ?? false)`, giving the prop precedence over the now-deprecated `mdc.headings.anchorLinks` fallback.
- **`prose/Pre.vue`** — add `copy?: boolean | Omit<ButtonProps, LinkPropsKeys>` (default `true`); gate the copy `B24Button` behind `v-if="props.copy"` with `v-bind` customization. Renamed the `useClipboard` `copy` binding to `copyToClipboard` to avoid a `vue/no-dupe-keys` collision with the new prop.
- **`types/theme.ts`** — add a `prose` namespace to `ThemeDefaults` so `<Theme :props>` can set per-element prose defaults. Dropped upstream's `codeTree` entry (b24ui has no CodeTree).
- **`useComponentProps.spec.ts`** — remove `prose` from `NonProxyComponents`, keeping the type-level drift catcher balanced (`prose` now lives in both `Expected` and `ThemeDefaults`).
- **Docs** — `headers-and-text.md` documents the `anchor` prop with a `B24Theme :props` example; `code.md` documents the `copy` prop.
- **`Chat.vue` — N/A** (b24ui has no Chat component, so the upstream Theme-based anchor-disable hunk is skipped).

## Tests
Prop additions with backward-compatible defaults (anchor resolves to the same off-state in the test env; copy defaults `true` → button still renders) → **no snapshot churn**. The `useComponentProps` drift catcher stays green. Suite **5557 passed / 6 skipped**.

## Verify (`CI=true`)
`dev:prepare` · `lint` · `typecheck` · `test` · `build` — all green.

Ledger: cursor advanced to `f419731`; previous entry `f546b2c` reconciled to PR #286.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JS8ypVfQSFzYVZzkTHhURb)_