### PR TITLE
chore(sync): no-op upstream v4.10.0 release (ada1580)

### DIFF
--- a/.sync/log/ada15803684c4a8eeced1a305d5d930484ccf82d.md
+++ b/.sync/log/ada15803684c4a8eeced1a305d5d930484ccf82d.md
@@ -1,0 +1,16 @@
+# Port: chore(release): v4.10.0
+
+**Upstream:** `ada15803684c4a8eeced1a305d5d930484ccf82d` (nuxt/ui)
+**Decision:** no-op
+
+## Upstream change
+Pure release commit — bumps `package.json` version `4.9.0` → `4.10.0` and
+regenerates `CHANGELOG.md`. No source/component/theme changes.
+
+## b24ui port
+**Not applicable.** b24ui is an independently-versioned fork (currently
+`2.9.0`) with its own `CHANGELOG.md`; upstream's version number and changelog
+do not transfer. No-op — cursor advanced only.
+
+## Tests
+No change. Suite unchanged: 5557 passed / 6 skipped.

--- a/.sync/nuxt-ui.json
+++ b/.sync/nuxt-ui.json
@@ -2,7 +2,7 @@
   "upstream": "nuxt/ui",
   "branch": "v4",
   "sync_enabled": false,
-  "cursor": "f419731d9b570892e21b990f13985f3f4ad4a56c",
+  "cursor": "ada15803684c4a8eeced1a305d5d930484ccf82d",
   "_cursor_note": "cursor = last upstream commit ported into b24ui (oldest-first, manual cadence). sync_enabled stays false until Phase 2 (porter workflow #67 + CLAUDE_CODE_OAUTH_TOKEN) is wired and trusted. `processed` is maintained per port from now on (backfilled #68-#72 on 2026-06-09).",
   "stats": {
     "queue_depth": 0,
@@ -1109,10 +1109,16 @@
       "summary": "test: add benchmarks — Vitest bench suite (test/bench/components.bench.ts + tv.bench.ts) wired into the vue project (benchmark.include), excluded from nuxt, + pnpm bench script. Adapted to b24ui: components.bench maps 1:1 (Button label/loading, Table data/columns/TableColumn, mountSuspended); tv.bench imports #build/b24ui/* and uses b24ui Button/Table tv() prop shapes (air colors, depth/useLabel/rounded/isAir, loadingColor/loadingAnimation/virtualize, pinned slot). pnpm bench verified — 8 groups green. Not in CI gate. Tests 5557."
     },
     "f419731d9b570892e21b990f13985f3f4ad4a56c": {
-      "pr": null,
-      "b24ui_sha": "pending-merge",
+      "pr": 287,
+      "b24ui_sha": "b12036d46145675052e42bb5fc6a14b7402906a2",
       "decision": "port",
       "summary": "feat(prose): configurable heading anchors and copy button — prose H1-H4 gain anchor?:boolean (precedence over deprecated mdc.headings.anchorLinks fallback), prose Pre gains copy?:boolean|Omit<ButtonProps,LinkPropsKeys> (default true, v-if-gated button + v-bind customize), ThemeDefaults gains prose namespace (dropped codeTree — absent), spec drops prose from NonProxyComponents (drift catcher balanced). Renamed Pre useClipboard copy→copyToClipboard (dupe-key). Docs: headers-and-text (anchor/B24Theme example) + code (copy prop). Chat.vue N/A (b24ui has no Chat). Backward-compatible defaults → no snapshot churn. Tests 5557."
+    },
+    "ada15803684c4a8eeced1a305d5d930484ccf82d": {
+      "pr": null,
+      "b24ui_sha": "pending-merge",
+      "decision": "no-op",
+      "summary": "chore(release): v4.10.0 — pure release commit (package.json 4.9.0->4.10.0 + CHANGELOG.md regen). NOT APPLICABLE: b24ui is independently versioned (2.9.0) with its own changelog. No-op."
     }
   }
 }


### PR DESCRIPTION
Syncs upstream nuxt/ui commit [`ada1580`](https://github.com/nuxt/ui/commit/ada15803684c4a8eeced1a305d5d930484ccf82d) — *chore(release): v4.10.0*.

## Decision: no-op
Pure release commit — bumps `package.json` `4.9.0` → `4.10.0` and regenerates `CHANGELOG.md`, with **no source/component/theme changes**.

**Not applicable to b24ui:** the fork is independently versioned (currently `2.9.0`) and keeps its own `CHANGELOG.md`; upstream's version number and changelog do not transfer.

Ledger-only: cursor advanced to `ada1580`; previous entry `f419731` reconciled to PR #287.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JS8ypVfQSFzYVZzkTHhURb)_