### PR TITLE
chore(sync): no-op upstream docs badge update (f8c0850)

### DIFF
--- a/.sync/log/f8c0850eb68a6d49fd995c94c74951263c4f13f4.md
+++ b/.sync/log/f8c0850eb68a6d49fd995c94c74951263c4f13f4.md
@@ -1,0 +1,29 @@
+# Port: docs: update badges
+
+**Upstream:** `f8c0850eb68a6d49fd995c94c74951263c4f13f4` (nuxt/ui)
+**Decision:** no-op
+
+## Upstream change
+Docs-only relabeling of availability badges now that the features shipped in
+v4.10.0: `:badge{label="Soon"}` → `:badge{label="4.10+"}` across chat-prompt /
+chat-tool / drawer / empty / modal / scroll-area / slideover / table docs;
+input-rating `navigation.badge: Soon` → `New`; use-tour drops its `New` badge.
+
+## b24ui port
+**Not applicable.** The relabeling targets upstream's version string (`4.10+`),
+which doesn't map to b24ui's independent versioning. b24ui already uses a
+`New`-style availability convention, and the affected docs are already in the
+correct state:
+
+- **scroll-area.md / table.md** ("With external scroll element") and
+  **input-rating.md** — already carry `label="New"` / `navigation.badge: New`
+  in b24ui (features shipped here), so there is nothing to relabel.
+- **chat-prompt.md / chat-tool.md / drawer.md / empty.md / modal.md /
+  slideover.md** — carry no `:badge{label=…}` availability marker in b24ui at
+  all, so upstream's "Soon"→version swap has no target.
+- **use-tour** — no `navigation.badge` entry in b24ui.
+
+No-op — cursor advanced only.
+
+## Tests
+Docs-content only, no change. Suite unchanged: 5557 passed / 6 skipped.

--- a/.sync/nuxt-ui.json
+++ b/.sync/nuxt-ui.json
@@ -2,7 +2,7 @@
   "upstream": "nuxt/ui",
   "branch": "v4",
   "sync_enabled": false,
-  "cursor": "ada15803684c4a8eeced1a305d5d930484ccf82d",
+  "cursor": "f8c0850eb68a6d49fd995c94c74951263c4f13f4",
   "_cursor_note": "cursor = last upstream commit ported into b24ui (oldest-first, manual cadence). sync_enabled stays false until Phase 2 (porter workflow #67 + CLAUDE_CODE_OAUTH_TOKEN) is wired and trusted. `processed` is maintained per port from now on (backfilled #68-#72 on 2026-06-09).",
   "stats": {
     "queue_depth": 0,
@@ -1115,10 +1115,16 @@
       "summary": "feat(prose): configurable heading anchors and copy button — prose H1-H4 gain anchor?:boolean (precedence over deprecated mdc.headings.anchorLinks fallback), prose Pre gains copy?:boolean|Omit<ButtonProps,LinkPropsKeys> (default true, v-if-gated button + v-bind customize), ThemeDefaults gains prose namespace (dropped codeTree — absent), spec drops prose from NonProxyComponents (drift catcher balanced). Renamed Pre useClipboard copy→copyToClipboard (dupe-key). Docs: headers-and-text (anchor/B24Theme example) + code (copy prop). Chat.vue N/A (b24ui has no Chat). Backward-compatible defaults → no snapshot churn. Tests 5557."
     },
     "ada15803684c4a8eeced1a305d5d930484ccf82d": {
+      "pr": 288,
+      "b24ui_sha": "0aaabd5a2a2bbd4988ca9efa7114867ff613b32b",
+      "decision": "no-op",
+      "summary": "chore(release): v4.10.0 — pure release commit (package.json 4.9.0->4.10.0 + CHANGELOG.md regen). NOT APPLICABLE: b24ui is independently versioned (2.9.0) with its own changelog. No-op."
+    },
+    "f8c0850eb68a6d49fd995c94c74951263c4f13f4": {
       "pr": null,
       "b24ui_sha": "pending-merge",
       "decision": "no-op",
-      "summary": "chore(release): v4.10.0 — pure release commit (package.json 4.9.0->4.10.0 + CHANGELOG.md regen). NOT APPLICABLE: b24ui is independently versioned (2.9.0) with its own changelog. No-op."
+      "summary": "docs: update badges — relabel :badge{label=Soon}->4.10+ across chat-prompt/chat-tool/drawer/empty/modal/scroll-area/slideover/table + input-rating Soon->New + use-tour drops New. NOT APPLICABLE: targets upstream version string (4.10+) vs b24ui independent versioning; b24ui uses New-style badges and affected docs already correct (scroll-area/table/input-rating already label=New; drawer/empty/modal/slideover/chat-* carry no availability badge). No-op."
     }
   }
 }


### PR DESCRIPTION
Syncs upstream nuxt/ui commit [`f8c0850`](https://github.com/nuxt/ui/commit/f8c0850eb68a6d49fd995c94c74951263c4f13f4) — *docs: update badges*.

## Decision: no-op
Docs-only relabeling of availability badges now that features shipped in v4.10.0: `:badge{label="Soon"}` → `:badge{label="4.10+"}` (chat-prompt/chat-tool/drawer/empty/modal/scroll-area/slideover/table), input-rating `Soon`→`New`, use-tour drops `New`.

**Not applicable to b24ui:** the relabeling targets upstream's version string (`4.10+`), which doesn't map to b24ui's independent versioning. b24ui uses a `New`-style availability convention and the affected docs are already in the correct state:
- **scroll-area.md / table.md / input-rating.md** already carry `label="New"` / `navigation.badge: New` (features shipped here).
- **chat-prompt / chat-tool / drawer / empty / modal / slideover** carry no availability badge in b24ui at all — nothing to relabel.

Ledger-only: cursor advanced to `f8c0850`; previous entry `ada1580` reconciled to PR #288.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JS8ypVfQSFzYVZzkTHhURb)_