### PR TITLE
chore(playground): expose all public composables in repl (f400bc6)

### DIFF
--- a/.sync/log/f400bc67670b90837d362bc97c1dd90cddfd786a.md
+++ b/.sync/log/f400bc67670b90837d362bc97c1dd90cddfd786a.md
@@ -1,0 +1,36 @@
+# Port: chore(playground): expose all public composables in repl
+
+**Upstream:** `f400bc67670b90837d362bc97c1dd90cddfd786a` (nuxt/ui)
+**Decision:** port — playground/repl (adapted to b24ui)
+
+## Upstream change
+In the REPL playground (`playgrounds/repl/src/App.vue`), replaces the hardcoded
+composable list in `customCode.importCode` with a list derived from
+`publicComposables` (the auto-import source of truth), and generates the
+`window.<name> = <name>` assignments dynamically — so REPL code can call every
+auto-imported composable without maintaining a hand list.
+
+## b24ui port
+- **`playgrounds/repl/src/App.vue`** —
+  - imported `publicComposables` from `../../../src/imports` (b24ui's own
+    auto-import registry, used by both the Nuxt module and Vite plugin);
+  - `const composables = Object.values(publicComposables).flat()`;
+  - rewrote `importCode` to
+    `import b24Ui, { ${composables.join(', ')} } from '@bitrix24/b24ui-builtin'`
+    plus `${composables.map(name => \`window.${name} = ${name}\`).join('\n')}`
+    (kept b24ui's `b24Ui` default import + `@bitrix24/b24ui-builtin` source).
+- **Behavior delta:** the new list is exactly b24ui's `publicComposables`
+  (defineLocale/extendLocale, defineShortcuts/extractShortcuts, useContentSearch,
+  useFileUpload, useFormField, useKbd, useOverlay, useResizable, useScrollShadow,
+  useScrollspy, useToast, useTour, useLocale, useDevice, useConfetti,
+  useSpeechRecognition). The previously-hardcoded `useColorMode` is dropped —
+  it isn't an official auto-import in b24ui (commented `@todo` in
+  `publicComposables`), so the REPL now matches the real auto-import surface;
+  many composables missing from the old hand list are now exposed.
+
+## Tests
+Playground/repl only — not part of the `ci` gate. Verified with `pnpm
+repl:build` (builds clean). Normal suite unchanged: 5557 passed / 6 skipped.
+
+## Verify (CI=true)
+`dev:prepare` · `lint` · `typecheck` · `test` · `build` (+ `repl:build`) — all green.

--- a/.sync/nuxt-ui.json
+++ b/.sync/nuxt-ui.json
@@ -2,7 +2,7 @@
   "upstream": "nuxt/ui",
   "branch": "v4",
   "sync_enabled": false,
-  "cursor": "f8c0850eb68a6d49fd995c94c74951263c4f13f4",
+  "cursor": "f400bc67670b90837d362bc97c1dd90cddfd786a",
   "_cursor_note": "cursor = last upstream commit ported into b24ui (oldest-first, manual cadence). sync_enabled stays false until Phase 2 (porter workflow #67 + CLAUDE_CODE_OAUTH_TOKEN) is wired and trusted. `processed` is maintained per port from now on (backfilled #68-#72 on 2026-06-09).",
   "stats": {
     "queue_depth": 0,
@@ -1121,10 +1121,16 @@
       "summary": "chore(release): v4.10.0 — pure release commit (package.json 4.9.0->4.10.0 + CHANGELOG.md regen). NOT APPLICABLE: b24ui is independently versioned (2.9.0) with its own changelog. No-op."
     },
     "f8c0850eb68a6d49fd995c94c74951263c4f13f4": {
-      "pr": null,
-      "b24ui_sha": "pending-merge",
+      "pr": 289,
+      "b24ui_sha": "dcd17be69791c8b139fad5d8fc00c31304fa1211",
       "decision": "no-op",
       "summary": "docs: update badges — relabel :badge{label=Soon}->4.10+ across chat-prompt/chat-tool/drawer/empty/modal/scroll-area/slideover/table + input-rating Soon->New + use-tour drops New. NOT APPLICABLE: targets upstream version string (4.10+) vs b24ui independent versioning; b24ui uses New-style badges and affected docs already correct (scroll-area/table/input-rating already label=New; drawer/empty/modal/slideover/chat-* carry no availability badge). No-op."
+    },
+    "f400bc67670b90837d362bc97c1dd90cddfd786a": {
+      "pr": null,
+      "b24ui_sha": "pending-merge",
+      "decision": "port",
+      "summary": "chore(playground): expose all public composables in repl — in playgrounds/repl/src/App.vue, replace hardcoded importCode composable list with Object.values(publicComposables).flat() (imported from ../../../src/imports) + dynamic window.X=X assignments. Adapted: kept b24Ui default import + @bitrix24/b24ui-builtin source. New list = b24ui's real auto-import surface; drops previously-hardcoded useColorMode (not in publicComposables — @todo), adds the many that were missing. Playground/repl only, not in ci gate; verified pnpm repl:build. Tests 5557."
     }
   }
 }

--- a/playgrounds/repl/src/App.vue
+++ b/playgrounds/repl/src/App.vue
@@ -8,6 +8,7 @@ import GraduationCapIcon from '@bitrix24/b24icons-vue/outline/GraduationCapIcon'
 import GitHubIcon from '@bitrix24/b24icons-vue/social/GitHubIcon'
 import ShareIcon from '@bitrix24/b24icons-vue/outline/ShareIcon'
 import CircleCheckIcon from '@bitrix24/b24icons-vue/outline/CircleCheckIcon'
+import { publicComposables } from '../../../src/imports'
 
 // const colorMode = useColorMode()
 // const theme = computed(() => colorMode.preference === 'dark' ? 'dark' : 'light')
@@ -172,6 +173,10 @@ function share() {
   copy(location.href)
 }
 
+// Mirror the auto-imports available in a real b24ui app so REPL code can call
+// these composables without importing them.
+const composables = Object.values(publicComposables).flat()
+
 const previewOptions = {
   headHTML: [
     '<script>window.__VUE_PROD_DEVTOOLS__=false<\/script>',
@@ -181,7 +186,7 @@ const previewOptions = {
     '<style>#app { isolation: isolate; }</style>'
   ].join(''),
   customCode: {
-    importCode: `import b24Ui, { useToast, useOverlay, defineShortcuts, extractShortcuts, useDevice, useConfetti, useSpeechRecognition, useColorMode } from '@bitrix24/b24ui-builtin'\nimport { h } from 'vue'\nwindow.useToast = useToast\nwindow.useOverlay = useOverlay\nwindow.defineShortcuts = defineShortcuts\nwindow.extractShortcuts = extractShortcuts\nwindow.useDevice = useDevice\nwindow.useConfetti = useConfetti\nwindow.useSpeechRecognition = useSpeechRecognition\nwindow.useColorMode = useColorMode`,
+    importCode: `import b24Ui, { ${composables.join(', ')} } from '@bitrix24/b24ui-builtin'\nimport { h } from 'vue'\n${composables.map(name => `window.${name} = ${name}`).join('\n')}`,
     useCode: `app.use(b24Ui, { router: (event, context) => { if (context.external && context.href) { if (context.target === '_blank') window.open(context.href, '_blank'); else window.location.href = context.href; } else { console.log('Internal navigation disabled', context); } } })\napp.component('Placeholder', { template: '<div class="relative overflow-hidden rounded-sm border border-dashed border-accented opacity-75 px-4 flex items-center justify-center"><svg class="absolute inset-0 h-full w-full stroke-(--ui-color-divider-vibrant-accent-more)" fill="none"><defs><pattern id="placeholder-pattern" x="0" y="0" width="10" height="10" patternUnits="userSpaceOnUse"><path d="M-3 13 15-5M-5 5l18-18M-1 21 17 3" /></pattern></defs><rect stroke="none" fill="url(#placeholder-pattern)" width="100%" height="100%" /></svg><slot /></div>' })\nconst _Root = app._component\nconst _B24App = app.component('B24App')\nconst _origMount = app.mount\napp.mount = function(el) {\n  const wrapper = _createApp({ render() { return h(_B24App, null, { default: () => h(_Root) }) } })\n  Object.assign(wrapper._context.components, app._context.components)\n  Object.assign(wrapper._context.directives, app._context.directives)\n  Object.assign(wrapper._context.provides, app._context.provides)\n  wrapper.config.errorHandler = e => console.error(e)\n  wrapper.mount(el)\n  window.__app__ = wrapper\n}`
   }
 }


### PR DESCRIPTION
Syncs upstream nuxt/ui commit [`f400bc6`](https://github.com/nuxt/ui/commit/f400bc67670b90837d362bc97c1dd90cddfd786a) — *chore(playground): expose all public composables in repl*.

## What
In the REPL playground, replace the hand-maintained composable list with one derived from `publicComposables` (the auto-import source of truth), generating both the import and the `window.<name> = <name>` assignments dynamically — so REPL code can call every auto-imported composable without an explicit import.

## b24ui port
- **`playgrounds/repl/src/App.vue`** — import `publicComposables` from `../../../src/imports` (b24ui's own auto-import registry), `const composables = Object.values(publicComposables).flat()`, and rewrite `importCode` to `import b24Ui, { ${composables.join(', ')} } from '@bitrix24/b24ui-builtin'` plus dynamic `window.X = X` assignments (kept b24ui's `b24Ui` default import + `@bitrix24/b24ui-builtin` source).
- **Behavior delta:** the exposed list now matches b24ui's real auto-import surface. The previously-hardcoded `useColorMode` is dropped (it isn't in `publicComposables` — a commented `@todo`), and the many composables missing from the old hand list (defineLocale, useContentSearch, useFileUpload, useFormField, useKbd, useResizable, useScrollShadow, useScrollspy, useTour, useLocale, …) are now exposed.

## Tests
Playground/repl only — **not part of the `ci` gate**. Verified with `pnpm repl:build` (builds clean). Normal suite unchanged: **5557 passed / 6 skipped**.

## Verify (`CI=true`)
`dev:prepare` · `lint` · `typecheck` · `test` · `build` (+ `repl:build`) — all green.

Ledger: cursor advanced to `f400bc6`; previous entry `f8c0850` reconciled to PR #289.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JS8ypVfQSFzYVZzkTHhURb)_