### PR TITLE
fix(CommandPalette): always escape search highlight to prevent XSS (2a172ef)

### DIFF
--- a/.sync/log/2a172ef187763c74d437a85fda3168e3f80ff00a.md
+++ b/.sync/log/2a172ef187763c74d437a85fda3168e3f80ff00a.md
@@ -1,0 +1,34 @@
+# Port: fix(CommandPalette): always escape search highlight to prevent XSS
+
+**Upstream:** `2a172ef187763c74d437a85fda3168e3f80ff00a` (nuxt/ui, #6741)
+**Decision:** port — security fix (verbatim)
+
+## Upstream change
+The search-highlight helper (`src/runtime/utils/search.ts`) tried to detect
+already-escaped HTML entities via `isAlreadyEscaped()` and skip re-escaping in
+`sanitize()`. An attacker could exploit this by injecting a stray HTML entity so
+their payload was treated as "already escaped" and passed through unescaped —
+an XSS in the CommandPalette result highlighting. The fix removes
+`isAlreadyEscaped()`/`sanitize()` and always calls `escapeHTML()`. Four
+regression tests are added.
+
+## b24ui port
+- **`src/runtime/utils/search.ts`** — b24ui carried the identical vulnerable
+  code. Removed `isAlreadyEscaped()` + `sanitize()` and replaced all three
+  `sanitize()` calls in `highlight()`'s `generateHighlightedText` (leading
+  unmatched region, matched region, trailing tail) with `escapeHTML()`.
+  `sanitizeSnippet()` already used `escapeHTML` directly — untouched.
+- **`test/utils/search.spec.ts`** — imported `highlight` and added the four
+  upstream XSS regression tests (injected tag in the unmatched tail, the
+  entity-bypass regression, HTML-special chars around a highlight, and the
+  no-match `undefined` case). b24ui's `highlight` matches upstream's behavior
+  1:1 (`minTokenLength = searchTerm.length` without token search; early
+  `return` when `!item.matches?.length`), so the tests port verbatim.
+
+## Tests
+Security fix. `highlight` output for normal (non-pre-escaped) input is
+unchanged, so no snapshot churn. Suite grows by the 4 new tests (× nuxt+vue):
+search spec 20 passed. Full suite: 5565 passed / 6 skipped.
+
+## Verify (CI=true)
+`dev:prepare` · `lint` · `typecheck` · `test` · `build` — all green.

--- a/.sync/nuxt-ui.json
+++ b/.sync/nuxt-ui.json
@@ -2,7 +2,7 @@
   "upstream": "nuxt/ui",
   "branch": "v4",
   "sync_enabled": false,
-  "cursor": "f400bc67670b90837d362bc97c1dd90cddfd786a",
+  "cursor": "2a172ef187763c74d437a85fda3168e3f80ff00a",
   "_cursor_note": "cursor = last upstream commit ported into b24ui (oldest-first, manual cadence). sync_enabled stays false until Phase 2 (porter workflow #67 + CLAUDE_CODE_OAUTH_TOKEN) is wired and trusted. `processed` is maintained per port from now on (backfilled #68-#72 on 2026-06-09).",
   "stats": {
     "queue_depth": 0,
@@ -1127,10 +1127,16 @@
       "summary": "docs: update badges — relabel :badge{label=Soon}->4.10+ across chat-prompt/chat-tool/drawer/empty/modal/scroll-area/slideover/table + input-rating Soon->New + use-tour drops New. NOT APPLICABLE: targets upstream version string (4.10+) vs b24ui independent versioning; b24ui uses New-style badges and affected docs already correct (scroll-area/table/input-rating already label=New; drawer/empty/modal/slideover/chat-* carry no availability badge). No-op."
     },
     "f400bc67670b90837d362bc97c1dd90cddfd786a": {
+      "pr": 290,
+      "b24ui_sha": "cabc07a00e05b13cd8ee04a4e455ece9112b3734",
+      "decision": "port",
+      "summary": "chore(playground): expose all public composables in repl — in playgrounds/repl/src/App.vue, replace hardcoded importCode composable list with Object.values(publicComposables).flat() (imported from ../../../src/imports) + dynamic window.X=X assignments. Adapted: kept b24Ui default import + @bitrix24/b24ui-builtin source. New list = b24ui's real auto-import surface; drops previously-hardcoded useColorMode (not in publicComposables — @todo), adds the many that were missing. Playground/repl only, not in ci gate; verified pnpm repl:build. Tests 5557."
+    },
+    "2a172ef187763c74d437a85fda3168e3f80ff00a": {
       "pr": null,
       "b24ui_sha": "pending-merge",
       "decision": "port",
-      "summary": "chore(playground): expose all public composables in repl — in playgrounds/repl/src/App.vue, replace hardcoded importCode composable list with Object.values(publicComposables).flat() (imported from ../../../src/imports) + dynamic window.X=X assignments. Adapted: kept b24Ui default import + @bitrix24/b24ui-builtin source. New list = b24ui's real auto-import surface; drops previously-hardcoded useColorMode (not in publicComposables — @todo), adds the many that were missing. Playground/repl only, not in ci gate; verified pnpm repl:build. Tests 5557."
+      "summary": "fix(CommandPalette): always escape search highlight to prevent XSS — src/runtime/utils/search.ts removed isAlreadyEscaped()/sanitize() (entity-detection bypass was the vuln) and replaced 3 sanitize() calls in highlight() with escapeHTML(). Added 4 upstream XSS regression tests to test/utils/search.spec.ts (highlight signature matches 1:1). sanitizeSnippet untouched. Normal-input output unchanged → no snapshot churn. Tests 5565 (+4 highlight)."
     }
   }
 }

--- a/src/runtime/utils/search.ts
+++ b/src/runtime/utils/search.ts
@@ -13,18 +13,6 @@ function escapeHTML(str: string): string {
   return str.replace(/[&<>"']/g, char => htmlEscapes[char]!)
 }
 
-// Check if string is already HTML-escaped to avoid double-escaping
-function isAlreadyEscaped(str: string): boolean {
-  return /&(?:amp|lt|gt|quot|#39);/.test(str)
-}
-
-function sanitize(str: string): string {
-  if (isAlreadyEscaped(str)) {
-    return str
-  }
-  return escapeHTML(str)
-}
-
 function truncateHTMLFromStart(html: string, maxLength: number) {
   let truncated = ''
   let totalLength = 0
@@ -93,16 +81,16 @@ export function highlight<T>(item: T & { matches?: FuseResult<T>['matches'] }, s
       const isMatched = (lastIndiceNextIndex - region[0]) >= minTokenLength
 
       content += [
-        sanitize(value.substring(nextUnhighlightedRegionStartingIndex, region[0])),
+        escapeHTML(value.substring(nextUnhighlightedRegionStartingIndex, region[0])),
         isMatched && `<mark>`,
-        sanitize(value.substring(region[0], lastIndiceNextIndex)),
+        escapeHTML(value.substring(region[0], lastIndiceNextIndex)),
         isMatched && '</mark>'
       ].filter(Boolean).join('')
 
       nextUnhighlightedRegionStartingIndex = lastIndiceNextIndex
     })
 
-    content += sanitize(value.substring(nextUnhighlightedRegionStartingIndex))
+    content += escapeHTML(value.substring(nextUnhighlightedRegionStartingIndex))
 
     const markIndex = content.indexOf('<mark>')
     if (markIndex !== -1) {

--- a/test/utils/search.spec.ts
+++ b/test/utils/search.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { sanitizeSnippet } from '../../src/runtime/utils/search'
+import { highlight, sanitizeSnippet } from '../../src/runtime/utils/search'
 
 describe('sanitizeSnippet', () => {
   it('preserves <mark> highlights', () => {
@@ -27,5 +27,37 @@ describe('sanitizeSnippet', () => {
 
   it('handles empty input', () => {
     expect(sanitizeSnippet('')).toBe('')
+  })
+})
+
+describe('highlight', () => {
+  it('escapes an injected tag in the unmatched tail while keeping the match highlighted', () => {
+    const value = 'zzzzz &<img src=x onerror=alert(1)>'
+    const result = highlight({ label: value, matches: [{ key: 'label', value, indices: [[0, 4]] }] }, 'zzzzz', 'label')
+
+    expect(result).toContain('<mark>zzzzz</mark>')
+    expect(result).not.toContain('<img')
+    expect(result).toContain('&lt;img')
+    expect(result).toContain('&amp;')
+  })
+
+  it('escapes payloads that contain a pre-existing HTML entity (regression: sanitize bypass)', () => {
+    const value = '&amp;<img src=x onerror=alert(1)>'
+    const result = highlight({ label: value, matches: [{ key: 'label', value, indices: [] }] }, 'x', 'label')
+
+    expect(result).not.toContain('<img')
+    expect(result).toBe('&amp;amp;&lt;img src=x onerror=alert(1)&gt;')
+  })
+
+  it('escapes HTML-special characters around the highlighted region', () => {
+    const value = `match < & "a" 'b'`
+    const result = highlight({ label: value, matches: [{ key: 'label', value, indices: [[0, 4]] }] }, 'match', 'label')
+
+    expect(result).toBe(`<mark>match</mark> &lt; &amp; &quot;a&quot; &#39;b&#39;`)
+  })
+
+  it('returns undefined when there are no matches', () => {
+    expect(highlight({ label: 'foo', matches: [] }, 'foo', 'label')).toBeUndefined()
+    expect(highlight({ label: 'foo' }, 'foo', 'label')).toBeUndefined()
   })
 })


### PR DESCRIPTION
Syncs upstream nuxt/ui commit [`2a172ef`](https://github.com/nuxt/ui/commit/2a172ef187763c74d437a85fda3168e3f80ff00a) — *fix(CommandPalette): always escape search highlight to prevent XSS* (#6741). **Security fix.**

## Vulnerability
The search-highlight helper tried to detect already-escaped HTML entities (`isAlreadyEscaped`) and skip re-escaping (`sanitize`). An attacker could inject a stray HTML entity so their payload was treated as "already escaped" and passed through unescaped — an XSS in CommandPalette result highlighting.

## b24ui port
- **`src/runtime/utils/search.ts`** — b24ui carried the identical vulnerable code. Removed `isAlreadyEscaped()` + `sanitize()` and replaced all three `sanitize()` calls in `highlight()`'s `generateHighlightedText` (leading unmatched region, matched region, trailing tail) with `escapeHTML()`. `sanitizeSnippet()` already used `escapeHTML` directly — untouched.
- **`test/utils/search.spec.ts`** — imported `highlight` and added the four upstream XSS regression tests (injected tag in the unmatched tail; the entity-bypass regression; HTML-special chars around a highlight; the no-match `undefined` case). b24ui's `highlight` matches upstream 1:1 (`minTokenLength = searchTerm.length` without token search; early `return` on `!item.matches?.length`), so the tests port verbatim.

## Tests
`highlight` output for normal (non-pre-escaped) input is unchanged → **no snapshot churn**. Suite grows by the 4 new tests (× nuxt+vue): **5565 passed / 6 skipped**. (An unrelated `EditorToolbar` timing flake surfaced once under full-suite contention and passed on isolated + full reruns.)

## Verify (`CI=true`)
`dev:prepare` · `lint` · `typecheck` · `test` · `build` — all green.

Ledger: cursor advanced to `2a172ef`; previous entry `f400bc6` reconciled to PR #290.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JS8ypVfQSFzYVZzkTHhURb)_