### PR TITLE
chore(sync): no-op upstream actions/labeler v7 bump (f69c471)

### DIFF
--- a/.sync/log/f69c471ce9a75477e844d6f8e4f20ca37b7f4a58.md
+++ b/.sync/log/f69c471ce9a75477e844d6f8e4f20ca37b7f4a58.md
@@ -1,0 +1,15 @@
+# Port: chore(deps): update actions/labeler action to v7
+
+**Upstream:** `f69c471ce9a75477e844d6f8e4f20ca37b7f4a58` (nuxt/ui, #6774)
+**Decision:** no-op
+
+## Upstream change
+Bumps `.github/workflows/pr-labeler.yml`: `actions/labeler@v6` → `@v7`.
+
+## b24ui port
+**Not applicable.** b24ui has no PR-labeler workflow — its `.github/workflows/`
+contains only `ci.yml`, `deploy.yml`, and `npm-publish.yml`, none of which use
+`actions/labeler`. No-op — cursor advanced only.
+
+## Tests
+CI-config only, nothing to run. Suite unchanged: 5565 passed / 6 skipped.

--- a/.sync/nuxt-ui.json
+++ b/.sync/nuxt-ui.json
@@ -2,7 +2,7 @@
   "upstream": "nuxt/ui",
   "branch": "v4",
   "sync_enabled": false,
-  "cursor": "2a4218b85f540f6b4e4d3be96f23e41ce3c858f0",
+  "cursor": "f69c471ce9a75477e844d6f8e4f20ca37b7f4a58",
   "_cursor_note": "cursor = last upstream commit ported into b24ui (oldest-first, manual cadence). sync_enabled stays false until Phase 2 (porter workflow #67 + CLAUDE_CODE_OAUTH_TOKEN) is wired and trusted. `processed` is maintained per port from now on (backfilled #68-#72 on 2026-06-09).",
   "stats": {
     "queue_depth": 0,
@@ -1157,10 +1157,16 @@
       "summary": "docs(useCanonical): type link array as unhead Link[] — docs/app/composables/useCanonical.ts: import type { Link } from '@unhead/vue' and change the head-links annotation from Array<{rel,href,type?}> to Link[]. Type-only, docs-app. Tests 5565."
     },
     "2a4218b85f540f6b4e4d3be96f23e41ce3c858f0": {
-      "pr": null,
-      "b24ui_sha": "pending-merge",
+      "pr": 295,
+      "b24ui_sha": "af007d10898e69ab8091dd2e250920786ac029f2",
       "decision": "port",
       "summary": "chore(deps): update all non-major dependencies — §2 manifest mirroring of the subset where b24ui shares upstream's old range. Bumped: pnpm@11.13.0->11.17.0, @tailwindcss/postcss+vite+tailwindcss ^4.3.2->^4.3.3, @tanstack/vue-virtual ->^3.13.34, @unhead/vue ->^2.1.16, vue-component-type-helpers/meta/vue-tsc ^3.3.7->^3.3.8, @nuxt/module-builder ->^1.0.3, @vitejs/plugin-vue ->^6.0.8, eslint ->^10.8.0, happy-dom ->^20.11.1, vue ->^3.5.40, @comark/vue ->^0.5.1, @nuxt/content ->^3.15.2, @nuxtjs/mdc ->^0.22.2, vue-router ->^5.2.0. SKIPPED (b24ui diverges): @ai-sdk/deepseek+vue(v3)+mcp(v1)+ai(v6) vs upstream anthropic/gateway/vue4/mcp2/ai7, @iconify-json/* (b24icons), @regle/* (^1.28.0), prettier (^3.8.4), nuxt-og-image (^6.6.0), nuxt-schema-org (^6.2.1). Lockfile regen w/ pnpm 11.17.0. Tests 5565."
+    },
+    "f69c471ce9a75477e844d6f8e4f20ca37b7f4a58": {
+      "pr": null,
+      "b24ui_sha": "pending-merge",
+      "decision": "no-op",
+      "summary": "chore(deps): update actions/labeler action to v7 — bumps .github/workflows/pr-labeler.yml actions/labeler@v6->v7. NOT APPLICABLE: b24ui has no labeler workflow (only ci/deploy/npm-publish). No-op."
     }
   }
 }


### PR DESCRIPTION
Syncs upstream nuxt/ui commit [`f69c471`](https://github.com/nuxt/ui/commit/f69c471ce9a75477e844d6f8e4f20ca37b7f4a58) — *chore(deps): update actions/labeler action to v7* (#6774).

## Decision: no-op
Upstream bumps `.github/workflows/pr-labeler.yml` `actions/labeler@v6`→`@v7`.

**Not applicable to b24ui:** the fork has no PR-labeler workflow — `.github/workflows/` contains only `ci.yml`, `deploy.yml`, and `npm-publish.yml`, none of which use `actions/labeler`.

Ledger-only: cursor advanced to `f69c471`; previous entry `2a4218b` reconciled to PR #295.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JS8ypVfQSFzYVZzkTHhURb)_