### PR TITLE
chore(deps): update actions/setup-node action to v7 (365c010)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
         uses: pnpm/action-setup@v6
 
       - name: Install node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: 22
           cache: pnpm

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -43,7 +43,7 @@ jobs:
         uses: pnpm/action-setup@v6
 
       - name: Install node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: ${{ matrix.node }}
           cache: pnpm

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -54,7 +54,7 @@ jobs:
         uses: pnpm/action-setup@v6
 
       - name: Install node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: 'lts/*'
           registry-url: 'https://registry.npmjs.org'

--- a/.sync/log/365c010ff3dfdbb7c4f8821ebbb72e70151e34b4.md
+++ b/.sync/log/365c010ff3dfdbb7c4f8821ebbb72e70151e34b4.md
@@ -1,0 +1,22 @@
+# Port: chore(deps): update actions/setup-node action to v7
+
+**Upstream:** `365c010ff3dfdbb7c4f8821ebbb72e70151e34b4` (nuxt/ui, #6775)
+**Decision:** port — CI config
+
+## Upstream change
+Bumps `actions/setup-node@v6` → `@v7` across `.github/workflows/module.yml`
+(14×) and `release.yml` (1×). Pure version bump — no `node-version`/`cache`/
+other params changed.
+
+## b24ui port
+b24ui's workflows differ (`ci.yml`, `deploy.yml`, `npm-publish.yml`), each with
+a single `actions/setup-node@v6` step. Bumped all three to `@v7`; no other
+parameters touched.
+
+- `.github/workflows/ci.yml`
+- `.github/workflows/deploy.yml`
+- `.github/workflows/npm-publish.yml`
+
+## Tests
+CI-config only. Validated by this PR's own `ci` run, which now executes on
+`actions/setup-node@v7`. Local suite unchanged: 5565 passed / 6 skipped.

--- a/.sync/nuxt-ui.json
+++ b/.sync/nuxt-ui.json
@@ -2,7 +2,7 @@
   "upstream": "nuxt/ui",
   "branch": "v4",
   "sync_enabled": false,
-  "cursor": "f69c471ce9a75477e844d6f8e4f20ca37b7f4a58",
+  "cursor": "365c010ff3dfdbb7c4f8821ebbb72e70151e34b4",
   "_cursor_note": "cursor = last upstream commit ported into b24ui (oldest-first, manual cadence). sync_enabled stays false until Phase 2 (porter workflow #67 + CLAUDE_CODE_OAUTH_TOKEN) is wired and trusted. `processed` is maintained per port from now on (backfilled #68-#72 on 2026-06-09).",
   "stats": {
     "queue_depth": 0,
@@ -1163,10 +1163,16 @@
       "summary": "chore(deps): update all non-major dependencies — §2 manifest mirroring of the subset where b24ui shares upstream's old range. Bumped: pnpm@11.13.0->11.17.0, @tailwindcss/postcss+vite+tailwindcss ^4.3.2->^4.3.3, @tanstack/vue-virtual ->^3.13.34, @unhead/vue ->^2.1.16, vue-component-type-helpers/meta/vue-tsc ^3.3.7->^3.3.8, @nuxt/module-builder ->^1.0.3, @vitejs/plugin-vue ->^6.0.8, eslint ->^10.8.0, happy-dom ->^20.11.1, vue ->^3.5.40, @comark/vue ->^0.5.1, @nuxt/content ->^3.15.2, @nuxtjs/mdc ->^0.22.2, vue-router ->^5.2.0. SKIPPED (b24ui diverges): @ai-sdk/deepseek+vue(v3)+mcp(v1)+ai(v6) vs upstream anthropic/gateway/vue4/mcp2/ai7, @iconify-json/* (b24icons), @regle/* (^1.28.0), prettier (^3.8.4), nuxt-og-image (^6.6.0), nuxt-schema-org (^6.2.1). Lockfile regen w/ pnpm 11.17.0. Tests 5565."
     },
     "f69c471ce9a75477e844d6f8e4f20ca37b7f4a58": {
-      "pr": null,
-      "b24ui_sha": "pending-merge",
+      "pr": 296,
+      "b24ui_sha": "25aa68d810be03f7dea0e0029c2a583189526b90",
       "decision": "no-op",
       "summary": "chore(deps): update actions/labeler action to v7 — bumps .github/workflows/pr-labeler.yml actions/labeler@v6->v7. NOT APPLICABLE: b24ui has no labeler workflow (only ci/deploy/npm-publish). No-op."
+    },
+    "365c010ff3dfdbb7c4f8821ebbb72e70151e34b4": {
+      "pr": null,
+      "b24ui_sha": "pending-merge",
+      "decision": "port",
+      "summary": "chore(deps): update actions/setup-node action to v7 — upstream bumps setup-node@v6->v7 in module.yml (14x)+release.yml (1x). b24ui has different workflows; bumped the single setup-node@v6 in ci.yml, deploy.yml, npm-publish.yml to @v7. Pure version bump, no other params. Validated by PR's own ci run on setup-node@v7."
     }
   }
 }


### PR DESCRIPTION
Syncs upstream nuxt/ui commit [`365c010`](https://github.com/nuxt/ui/commit/365c010ff3dfdbb7c4f8821ebbb72e70151e34b4) — *chore(deps): update actions/setup-node action to v7* (#6775).

## b24ui port
Upstream bumps `actions/setup-node@v6`→`@v7` across `module.yml` (14×) and `release.yml` (1×). b24ui's workflows differ — each of `ci.yml`, `deploy.yml`, and `npm-publish.yml` has a single `actions/setup-node@v6` step, all bumped to `@v7`. Pure version bump; no `node-version`/`cache`/other params touched.

## Tests
CI-config only. Validated by **this PR's own `ci` run**, which now executes on `actions/setup-node@v7`. Local suite unchanged: **5565 passed / 6 skipped**.

Ledger: cursor advanced to `365c010`; previous entry `f69c471` reconciled to PR #296.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JS8ypVfQSFzYVZzkTHhURb)_