### PR TITLE
chore(sync): no-op upstream docs(mcp) provider config update (34554bf)

### DIFF
--- a/.sync/log/34554bf868b4dbc5a5781466634cafa3e2bf5c3e.md
+++ b/.sync/log/34554bf868b4dbc5a5781466634cafa3e2bf5c3e.md
@@ -1,0 +1,20 @@
+# Port: docs(mcp): update server config for several providers
+
+**Upstream:** `34554bf868b4dbc5a5781466634cafa3e2bf5c3e` (nuxt/ui)
+**Decision:** no-op
+
+## Upstream change
+Docs-only update to `docs/content/docs/1.getting-started/7.ai/1.mcp.md` —
+standardizes the MCP-server config snippets for five AI tools (Claude CLI,
+Cursor `url`→`httpUrl`, GitHub Copilot label, Continue `serverUrl`, Windsurf
+simplified) all pointing at `https://ui.nuxt.com/mcp`.
+
+## b24ui port
+**Not applicable.** b24ui does not ship an MCP provider-config docs page — its
+`docs/content/docs/1.getting-started/7.ai/` folder contains only `2.llms-txt.md`
+and `3.skills.md`, with no `1.mcp.md`. The upstream snippets are also
+nuxt-ui-specific (`ui.nuxt.com/mcp`, `nuxt-ui` server name); b24ui's MCP setup
+is its own (`docs/server/mcp`, deepseek). No-op — cursor advanced only.
+
+## Tests
+Docs-content only, nothing to run. Suite unchanged: 5565 passed / 6 skipped.

--- a/.sync/nuxt-ui.json
+++ b/.sync/nuxt-ui.json
@@ -2,7 +2,7 @@
   "upstream": "nuxt/ui",
   "branch": "v4",
   "sync_enabled": false,
-  "cursor": "bfe1177393f6d49835c3506303d5e46ff0e86654",
+  "cursor": "34554bf868b4dbc5a5781466634cafa3e2bf5c3e",
   "_cursor_note": "cursor = last upstream commit ported into b24ui (oldest-first, manual cadence). sync_enabled stays false until Phase 2 (porter workflow #67 + CLAUDE_CODE_OAUTH_TOKEN) is wired and trusted. `processed` is maintained per port from now on (backfilled #68-#72 on 2026-06-09).",
   "stats": {
     "queue_depth": 0,
@@ -1175,10 +1175,16 @@
       "summary": "chore(deps): update actions/setup-node action to v7 — upstream bumps setup-node@v6->v7 in module.yml (14x)+release.yml (1x). b24ui has different workflows; bumped the single setup-node@v6 in ci.yml, deploy.yml, npm-publish.yml to @v7. Pure version bump, no other params. Validated by PR's own ci run on setup-node@v7."
     },
     "bfe1177393f6d49835c3506303d5e46ff0e86654": {
-      "pr": null,
-      "b24ui_sha": "pending-merge",
+      "pr": 298,
+      "b24ui_sha": "9cc9f434744580a696e34dc120a9a17d3149174f",
       "decision": "port",
       "summary": "chore(deps): update tiptap to ^3.29.0 — §2 mirror. b24ui has all @tiptap/* at ^3.27.3 (== upstream old); bumped 25 entries to ^3.29.0 (package.json 17 + docs/demo/nuxt/vue 2 each: emoji+text-align). Lockfile regen w/ pnpm 11.17.0. tiptap powers Editor; full gauntlet green, no snapshot drift. Tests 5565."
+    },
+    "34554bf868b4dbc5a5781466634cafa3e2bf5c3e": {
+      "pr": null,
+      "b24ui_sha": "pending-merge",
+      "decision": "no-op",
+      "summary": "docs(mcp): update server config for several providers — updates 7.ai/1.mcp.md MCP-server config snippets (Cursor url->httpUrl, Continue serverUrl, Windsurf simplified, etc.) for ui.nuxt.com/mcp. NOT APPLICABLE: b24ui has no 1.mcp.md page (7.ai/ has only llms-txt + skills); snippets are nuxt-ui-specific. No-op."
     }
   }
 }


### PR DESCRIPTION
Syncs upstream nuxt/ui commit [`34554bf`](https://github.com/nuxt/ui/commit/34554bf868b4dbc5a5781466634cafa3e2bf5c3e) — *docs(mcp): update server config for several providers*.

## Decision: no-op
Upstream updates `docs/content/docs/1.getting-started/7.ai/1.mcp.md`, standardizing the MCP-server config snippets for five AI tools (Claude CLI, Cursor `url`→`httpUrl`, GitHub Copilot label, Continue `serverUrl`, Windsurf simplified), all pointing at `https://ui.nuxt.com/mcp`.

**Not applicable to b24ui:** the fork ships no MCP provider-config docs page — `docs/content/docs/1.getting-started/7.ai/` contains only `2.llms-txt.md` and `3.skills.md`, with no `1.mcp.md`. The upstream snippets are also nuxt-ui-specific (`ui.nuxt.com/mcp`, `nuxt-ui` server name); b24ui's MCP setup is its own (`docs/server/mcp`).

Ledger-only: cursor advanced to `34554bf` (upstream v4 HEAD); previous entry `bfe1177` reconciled to PR #298.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JS8ypVfQSFzYVZzkTHhURb)_