### PR TITLE
docs(installation): note vue-tsc build race with auto-import declarations (a158e26)

### DIFF
--- a/.sync/log/a158e26b784c8caac8d4c4aa925060fb40083071.md
+++ b/.sync/log/a158e26b784c8caac8d4c4aa925060fb40083071.md
@@ -1,0 +1,29 @@
+# Port: docs(installation): note vue-tsc build race with auto-import declarations
+
+**Upstream:** `a158e26b784c8caac8d4c4aa925060fb40083071` (nuxt/ui)
+**Decision:** port — docs-content only
+
+## Upstream change
+Adds a `::warning` block to the Vue installation page: the `auto-imports.d.ts` /
+`components.d.ts` declaration files are only written when Vite runs, but
+`create-vue`'s default `build` script runs `vue-tsc` in parallel with
+`vite build` (`run-p type-check "build-only {@}"`). On a clean checkout the
+type-check can start before the files exist and fail with e.g.
+`Cannot find name 'useToast'`. Recommends `run-s build-only type-check`.
+
+## b24ui port
+- **`docs/content/docs/1.getting-started/2.installation/2.vue.md`** — added the
+  same warning, in the same position (right after the block documenting the
+  generated declaration files, before the `::tip` about the theme-types alias).
+
+The warning applies verbatim: b24ui registers `unplugin-auto-import` and
+`unplugin-vue-components` and generates the same two declaration files, and
+`useToast` is a real b24ui auto-import (it's in `publicComposables`), so the
+example error is accurate for the fork.
+
+## Tests
+Docs-content (Markdown) only — no runtime/theme/test/snapshot impact. Suite
+unchanged: 5565 passed / 6 skipped.
+
+## Verify (CI=true)
+`lint` green locally; `typecheck` · `test` · `build` covered by CI.

--- a/.sync/nuxt-ui.json
+++ b/.sync/nuxt-ui.json
@@ -2,7 +2,7 @@
   "upstream": "nuxt/ui",
   "branch": "v4",
   "sync_enabled": false,
-  "cursor": "282759e7c6b6df3d9ae842df7f379f9f8f9298b4",
+  "cursor": "a158e26b784c8caac8d4c4aa925060fb40083071",
   "_cursor_note": "cursor = last upstream commit ported into b24ui (oldest-first, manual cadence). sync_enabled stays false until Phase 2 (porter workflow #67 + CLAUDE_CODE_OAUTH_TOKEN) is wired and trusted. `processed` is maintained per port from now on (backfilled #68-#72 on 2026-06-09).",
   "stats": {
     "queue_depth": 0,
@@ -1187,10 +1187,16 @@
       "summary": "docs(mcp): update server config for several providers — updates 7.ai/1.mcp.md MCP-server config snippets (Cursor url->httpUrl, Continue serverUrl, Windsurf simplified, etc.) for ui.nuxt.com/mcp. NOT APPLICABLE: b24ui has no 1.mcp.md page (7.ai/ has only llms-txt + skills); snippets are nuxt-ui-specific. No-op."
     },
     "282759e7c6b6df3d9ae842df7f379f9f8f9298b4": {
+      "pr": 300,
+      "b24ui_sha": "3faefaaaca68aabe4123f99febdd8b736ec661f6",
+      "decision": "port",
+      "summary": "chore(deps): update nuxt framework — nuxt/@nuxt/kit/@nuxt/schema ^4.4.8->^4.5.1, @unhead/vue v2->v3, magic-string 0.30->1.1, vite 7->8 (playgrounds). Ported upstream's accompanying fixes: vitest.config.ts #components -> \\0virtual id (vite 8 rewrites '#components' to '?import#components'), FormField.spec.ts vi.mock('vue') hoisted to top level, pnpm-workspace @nuxt/kit override ->^4.5.1 (4.4.8 kit lacks buildDiagnostics that nuxt 4.5.1 CLI imports). b24ui-specific: bumped playgrounds/demo nuxt (b24ui-only workspace, else dup nuxt); fixed stale @tiptap/pm override ->^3.29.0; added vite ^8.1.5 + rolldown ~1.1.5 overrides — b24ui's dep set (unplugin/unhead peers + legacy vitest-environment-nuxt) otherwise resolved 2 vite + 2 rolldown copies, whose clashing native ABIs killed all 125 nuxt-project test workers with 'Missing field moduleType'. colors.ts: headData typed Parameters<typeof useHead>[0] (unhead v3 dropped UseHeadInput). SKIPPED: ContentNavigation.vue (absent); setup.ts iconify fetch stub (N/A — b24icons doesn't fetch). Tests 5565, no snapshot drift."
+    },
+    "a158e26b784c8caac8d4c4aa925060fb40083071": {
       "pr": null,
       "b24ui_sha": "pending-merge",
       "decision": "port",
-      "summary": "chore(deps): update nuxt framework — nuxt/@nuxt/kit/@nuxt/schema ^4.4.8->^4.5.1, @unhead/vue v2->v3, magic-string 0.30->1.1, vite 7->8 (playgrounds). Ported upstream's accompanying fixes: vitest.config.ts #components -> \\0virtual id (vite 8 rewrites '#components' to '?import#components'), FormField.spec.ts vi.mock('vue') hoisted to top level, pnpm-workspace @nuxt/kit override ->^4.5.1 (4.4.8 kit lacks buildDiagnostics that nuxt 4.5.1 CLI imports). b24ui-specific: bumped playgrounds/demo nuxt (b24ui-only workspace, else dup nuxt); fixed stale @tiptap/pm override ->^3.29.0; added vite ^8.1.5 + rolldown ~1.1.5 overrides — b24ui's dep set (unplugin/unhead peers + legacy vitest-environment-nuxt) otherwise resolved 2 vite + 2 rolldown copies, whose clashing native ABIs killed all 125 nuxt-project test workers with 'Missing field moduleType'. colors.ts: headData typed Parameters<typeof useHead>[0] (unhead v3 dropped UseHeadInput). SKIPPED: ContentNavigation.vue (absent); setup.ts iconify fetch stub (N/A — b24icons doesn't fetch). Tests 5565, no snapshot drift."
+      "summary": "docs(installation): note vue-tsc build race with auto-import declarations — adds a ::warning to the Vue installation page that auto-imports.d.ts/components.d.ts are only written when Vite runs, while create-vue's default build runs vue-tsc in parallel (run-p), so a clean checkout can fail with 'Cannot find name useToast'; recommends run-s build-only type-check. Ported verbatim to b24ui's 2.vue.md (same unplugin-auto-import/vue-components setup, useToast is a real b24ui auto-import). Docs-only."
     }
   }
 }

--- a/docs/content/docs/1.getting-started/2.installation/2.vue.md
+++ b/docs/content/docs/1.getting-started/2.installation/2.vue.md
@@ -172,6 +172,19 @@ components.d.ts
 
 ::
 
+::warning
+These declaration files are only written when Vite runs. The default `create-vue` `build` script runs `vue-tsc` in parallel with `vite build` (`run-p type-check "build-only {@}"`), so on a clean checkout type-checking can start before the files exist and fail with errors like `Cannot find name 'useToast'`. Run the type-check after the build instead so the declarations are generated first.
+
+```json [package.json]
+{
+  "scripts": {
+    "build": "run-s build-only type-check"
+  }
+}
+```
+
+::
+
 ::tip
 Internally, Bitrix24 UI relies on custom alias to resolve the theme types. If you're using TypeScript, you should add an alias to your `tsconfig` to enable auto-completion in your `vite.config.ts`.
 


### PR DESCRIPTION
Syncs upstream nuxt/ui commit [`a158e26`](https://github.com/nuxt/ui/commit/a158e26b784c8caac8d4c4aa925060fb40083071) — *docs(installation): note vue-tsc build race with auto-import declarations*.

## b24ui port
- **`docs/content/docs/1.getting-started/2.installation/2.vue.md`** — added the upstream `::warning`, in the same position (right after the block documenting the generated declaration files, before the `::tip` about the theme-types alias).

The warning applies verbatim to the fork: b24ui registers `unplugin-auto-import` and `unplugin-vue-components` and generates the same `auto-imports.d.ts` / `components.d.ts`, and `useToast` is a real b24ui auto-import — so the quoted `Cannot find name 'useToast'` failure and the `run-s build-only type-check` remedy are accurate here too.

## Tests
Docs-content (Markdown) only — no runtime/theme/test/snapshot impact. Suite unchanged: **5565 passed / 6 skipped**.

## Verify (`CI=true`)
`lint` green locally; `typecheck` · `test` · `build` covered by CI.

Ledger: cursor advanced to `a158e26`; previous entry `282759e` reconciled to PR #300.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JS8ypVfQSFzYVZzkTHhURb)_