### PR TITLE
chore(release): v2.10.0

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -63,7 +63,7 @@ jobs:
           cache: pnpm
 
       - name: Install dependencies
-        run: pnpm install
+        run: pnpm install --frozen-lockfile
 
       - name: Prepare
         run: pnpm run dev:prepare

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,89 @@
 # Changelog
 
+## [2.10.0](https://github.com/bitrix24/b24ui/compare/v2.9.0...v2.10.0) (2026-08-06)
+
+### Features
+
+* **Listbox:** new component
+* **InputRating:** new component
+* **Calendar:** add month and year selection
+* **prose:** configurable heading anchors and copy button
+* **Empty:** add `loading` and `loadingIcon` props
+* **ChatPrompt:** add `body` slot
+* **ChatTool:** add `actions` prop for tool approval
+* **Prompt:** add claude action
+* **Drawer:** add `close` and `closeIcon` props
+* **Editor:** allow disabling starter kit for plain text
+* **ContentToc:** scroll list independently and center active link
+* **Table:** add `getScrollElement` virtualize option
+* **ScrollArea:** add `getScrollElement` virtualize option
+
+### Bug Fixes
+
+* **module:** avoid unhead v2-only `hookOnce` in colors plugin — fixes app initialization crash in SPA mode (`ssr: false`) on Nuxt `>= 4.5.1`
+* **module:** honour the `b24ui.version` option in `appConfig` — it was declared but ignored on the Nuxt path
+* **Modal:** emit transition events from overlay when scrollable
+* **theme:** unify motion easing and respect `prefers-reduced-motion`
+* **ContentToc:** prevent list from collapsing
+* **CommandPalette:** always escape search highlight to prevent XSS
+* **theme:** use logical properties for RTL
+* **components:** respect `prefers-reduced-motion` in animations
+* **Editor:** prevent suggestion menu blinking on keystroke
+* **types:** type prose components in app config
+* **defineShortcuts:** defer standalone shortcuts that prefix a chain
+* **defineShortcuts:** add missing `arrowdown` to shiftable keys
+* **useToast:** dedupe duplicate ids and handle max of 0
+* **useResizable:** recover from corrupted persisted storage
+* **useResizable:** share resize logic between mouse and touch
+* **useScrollspy:** unobserve previous headings on update
+* **useFileUpload:** keep dropzone type filter reactive to `accept`
+* **useComponentProps:** let app config `defaultVariants` override `withDefaults`
+* **inertia:** make `useRoute().fullPath` reactive across navigations
+* **FileUpload:** add `aria-disabled` attribute when disabled
+* **SelectMenu/InputMenu:** only re-highlight first item with `create-item`
+* **Link:** apply `rel` prop to internal links
+* **ChatMessages:** re-evaluate streaming indicator on each render
+* **Button:** allow inline event handlers with non-void return types
+* **docs:** register `loadingIcon` cast so the Empty page prerenders
+
+### Performance
+
+* **components:** memoize tv slot invocations with simple args
+* **Button/Select/SelectMenu/InputMenu:** narrow reactive dependencies
+* **vue:** skip rewriting unchanged templates
+* **module:** declare `sideEffects` for barrel tree-shaking
+* **types:** decouple `useComponentProps` from the component-types barrel
+* **types:** import cross-component types from source, not the barrel
+* **components:** drop the redundant inner in component extend
+
+### Docs
+
+* use content native sqlite connector
+* **input-rating:** remove stray `defaultValue` line in size
+* **chat:** sanitize ai endpoint error logging
+* **installation:** note vue-tsc build race with auto-import declarations
+* **useCanonical:** type link array as unhead `Link[]`
+* **typography:** improve headers and text page
+* **select-menu/input-menu:** use grouped items in items type example
+* **sidebar:** render examples with gpu transform
+* **color-mode-button:** remove fallback slot example
+
+### Tests
+
+* add benchmarks
+* **plugins:** bring `src/runtime/plugins/` under test — the directory matched no vitest `include`, so the SPA crash above could not have been caught
+* **composables:** add specs for `defineLocale`, `useKbd` and `useFormField`
+* **ChatPrompt:** avoid using fake timers before suspended
+
+### Chore
+
+* **deps:** update Nuxt framework to `^4.5.1` — moves `@unhead/vue` from `^2.1.15` to `^3.2.3` and Vite to v8
+* **deps:** update Tiptap to `^3.29.0`, reka-ui to `v2.10.1`, `@nuxt/test-utils` to `^4.1.0`, and 40 package versions refreshed in total
+* **docs:** drop the dead og-image stack — `@takumi-rs/core` and `nuxt-og-image` were unused and blocked upstream syncs; 54 packages leave the lockfile
+* **github:** improve workflows
+* **playground:** expose all public composables in repl
+* sync with nuxt/ui upstream (no-op syncs)
+
 ## [2.9.0](https://github.com/bitrix24/b24ui/compare/v2.8.0...v2.9.0) (2026-06-27)
 
 ### Features

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bitrix24/b24ui-nuxt",
   "description": "Bitrix24 UI-Kit for developing web applications REST API for NUXT & VUE",
-  "version": "2.9.0",
+  "version": "2.10.0",
   "packageManager": "pnpm@11.17.0",
   "repository": {
     "type": "git",

--- a/skills/b24-ui-nuxt/references/components.md
+++ b/skills/b24-ui-nuxt/references/components.md
@@ -54,6 +54,8 @@ Quick-reference index of 125+ components. For detailed API specifications (props
 | `B24InputDate` | Date picker with calendar | [input-date.md](https://bitrix24.github.io/b24ui/raw/docs/components/input-date.md) |
 | `B24InputTime` | Time picker (12/24h) | [input-time.md](https://bitrix24.github.io/b24ui/raw/docs/components/input-time.md) |
 | `B24InputTags` | Tag/chip input | [input-tags.md](https://bitrix24.github.io/b24ui/raw/docs/components/input-tags.md) |
+| `B24InputRating` | Star/icon rating input | [input-rating.md](https://bitrix24.github.io/b24ui/raw/docs/components/input-rating.md) |
+| `B24Listbox` | Single/multi selection list, always expanded | [listbox.md](https://bitrix24.github.io/b24ui/raw/docs/components/listbox.md) |
 | `B24PinInput` | Verification code input | [pin-input.md](https://bitrix24.github.io/b24ui/raw/docs/components/pin-input.md) |
 | `B24Checkbox` | Single boolean checkbox | [checkbox.md](https://bitrix24.github.io/b24ui/raw/docs/components/checkbox.md) |
 | `B24CheckboxGroup` | Multiple checkboxes | [checkbox-group.md](https://bitrix24.github.io/b24ui/raw/docs/components/checkbox-group.md) |


### PR DESCRIPTION
### Linked issue

Resolves #301

### Type of change

- [ ] Documentation (updates to the documentation or readme)
- [x] Bug fix (a non-breaking change that fixes an issue)
- [ ] Enhancement (improving an existing functionality)
- [ ] New feature (a non-breaking change that adds functionality)
- [x] Chore (updates to the build process or auxiliary tools and libraries)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Description

Bumps `package.json` 2.9.0 -> 2.10.0 and adds the `CHANGELOG.md` entry covering the 89 commits since v2.9.0. Minor bump per semver — the range adds new components (`Listbox`, `InputRating`).

**Cutting this release is what actually closes #301.** No runtime code changes are needed; both halves of the fix are already on `main` but unreleased:

- `acb5c96b` — `fix(module): avoid unhead v2-only hookOnce in colors plugin`. At tag `v2.9.0` the SPA branch of `src/runtime/plugins/colors.ts` still called `injectHead().hooks.hookOnce('dom:rendered', ...)`. Nuxt `4.5.1` moves `@unhead/vue` from v2 to v3, where `head.hooks` is a `HookableCore` exposing only `hook()` / `removeHook()` / `callHook()` — so `hookOnce` is `undefined` and the app dies at init with `NUXT_E1005`. This only reproduces with `ssr: false`, because the call sits behind `!nuxtApp.payload.serverRendered`.
- `#300` — moved `@unhead/vue` to `^3.2.3`.

`v2.9.0` was published on 2026-06-27; `acb5c96b` landed on 2026-06-29, two days and eight commits later. Nothing since has been released, so every user on the current npm version still hits the crash.

### Verification

Reproduced and verified end-to-end against the real packed artifact of this tree (`npm pack`), in a Nuxt app with `ssr: false` + `@nuxt/content`, driven with Chromium:

| nuxt | b24ui | app boots | MDC renders | temp style removed |
| --- | --- | --- | --- | --- |
| 4.5.1 | *(not installed)* | ✅ | ✅ | n/a |
| 4.5.1 | published 2.9.0 (`hookOnce`) | ❌ `NUXT_E1005` | ❌ | n/a |
| 4.4.8 | published 2.9.0 (`hookOnce`) | ✅ | ✅ | ✅ |
| 4.5.1 | this tree, built | ✅ | ✅ | ✅ |
| 4.4.8 | this tree, built | ✅ | ✅ | ✅ |

Notes from those runs:

- The second half of issue #301 — "MDC renders nothing in SPA" — turned out to be a **consequence of the crash**, not a separate bug. When the plugin throws, the app never mounts and the page shows only the error, so nothing renders. With the fix in place MDC renders and b24ui `Prose*` components are applied.
- The temporary `[data-bitrix24-ui-colors]` style is removed on `dom:rendered`, matching the v2 `hookOnce` semantics — the self-unhook is behaviourally equivalent, not merely crash-free.
- **Last row matters for compatibility:** on Nuxt 4.4.8 the tree resolves two `@unhead/vue` copies (v3 from b24ui's own dependency, v2 from Nuxt) and the app still boots and renders normally. The plugin obtains its head instance through `#imports`, so it uses whichever unhead the host Nuxt provides, and `hook()` exists in both majors. No migration note is needed for users who have not moved to Nuxt 4.5.1 yet.
- `Button`, `Badge`, `DropdownMenu` and `Alert` were additionally mounted in SPA to check nothing else in the SPA path regressed on unhead v3.

### On the changelog entry counts

They no longer map 1:1 onto commit subjects, deliberately. #324 landed as a single `chore` squash carrying three unrelated issues, so its parts are listed where a reader would look for them — the `b24ui.version` fix under **Bug Fixes**, the plugin test coverage under **Tests**, the og-image removal under **Chore** — rather than lumped under Chore because of its subject line. Every other section still matches the commit range one for one.

### Review follow-ups folded into this PR

- CHANGELOG: restored two missing `test` entries and the `chore(playground)` entry.
- CHANGELOG: corrected the dependency rollup — 40 package versions changed between v2.9.0 and this commit, not the 27 previously stated.
- `skills/b24-ui-nuxt/references/components.md`: added `B24Listbox` and `B24InputRating`. Both ship in this release and the skill's component index did not list them, so an agent using it would not know they exist.
- `.github/workflows/npm-publish.yml`: install with `--frozen-lockfile`, matching `ci.yml`. Without it the publishing runner — the one holding `id-token: write` — could resolve dependencies newer than the ones the awaited CI run validated, which defeats the point of the `await-ci` gate.

### Follow-ups filed separately

- #313 — plugin coverage is still partial: `platform.ts` and `ui-version.ts` remain untested even though `src/runtime/plugins/` is now inside the vitest include.
- #315 — release cadence (a crash fix sat unreleased for five weeks) plus the remaining publish-workflow hardening.

### Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

### Before tagging

- The `CHANGELOG.md` entry was assembled mechanically from conventional-commit subjects; previous entries look hand-curated, so it is worth a pass for wording.
- The entry is a snapshot taken at `3faa2e4a`, the merge of #324. `main` moves quickly and this branch has been rebased several times for that reason — anything merged after that point needs adding before the tag is cut.
- The release still needs a tag + GitHub Release after merge: `npm-publish.yml` triggers on `release: published` and waits for `ci.yml` to be green on the same SHA. Merging alone publishes nothing.