### PR TITLE
chore(github): improve workflows (c4b786c)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Install pnpm
         uses: pnpm/action-setup@v6
@@ -31,7 +33,7 @@ jobs:
       - name: Install node
         uses: actions/setup-node@v7
         with:
-          node-version: 22
+          node-version: 24
           cache: pnpm
 
       - name: Install dependencies

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -49,6 +49,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Install pnpm
         uses: pnpm/action-setup@v6

--- a/.sync/log/c4b786c952de69ca650807b7d5fcba7cf8114e28.md
+++ b/.sync/log/c4b786c952de69ca650807b7d5fcba7cf8114e28.md
@@ -1,0 +1,64 @@
+# Port: chore(github): improve workflows
+
+**Upstream:** `c4b786c952de69ca650807b7d5fcba7cf8114e28` (nuxt/ui)
+**Decision:** port — CI config (partial; one hunk deliberately not ported)
+
+## Upstream change
+Reworks six workflow files (`module`, `release`, `pr-labeler`, `reproduction`,
+`reproduire`, `stale`):
+- `concurrency` group on `module` — per-PR-number so a new push cancels the
+  previous run, but every push on `v4` gets its own group (each also covers
+  windows and publishes a preview package), with
+  `cancel-in-progress: ${{ github.event_name == 'pull_request' }}`.
+- `actions/checkout` gains `persist-credentials: false`.
+- `permissions: contents: read` on the `release` publish job.
+- CI node `22` → `24`.
+- Lint/Typecheck/Test (and the two playground builds) collapsed into
+  `- parallel:` step groups.
+
+## b24ui port
+b24ui's workflows are `ci.yml`, `deploy.yml`, `npm-publish.yml`
+(`ci` ≈ upstream `module`, `npm-publish` ≈ upstream `release`).
+
+Applied:
+- **`ci.yml`** — `persist-credentials: false` on checkout; `node-version`
+  `22` → `24` (b24ui's `engines` is `^20.19.0 || >=22.12.0`, so 24 qualifies).
+- **`npm-publish.yml`** — `persist-credentials: false` on the `process` job's
+  checkout.
+
+Neither workflow pushes via git (Pages deploys through `actions/deploy-pages`
+with OIDC; npm publishes with a registry token and `--no-git-checks`), so
+dropping the persisted credentials is safe.
+
+### Already satisfied — nothing to port
+- **`concurrency`** — `ci.yml` already has one (`group: ci-${{ github.ref }}`,
+  `cancel-in-progress: true`), and `deploy.yml` has `group: pages`. Upstream's
+  more elaborate grouping exists because their `v4` pushes fan out to windows
+  and publish preview packages; b24ui's `ci.yml` does neither, so cancelling
+  superseded runs on any ref is correct here.
+- **`permissions: contents: read`** — already declared at workflow level in
+  `npm-publish.yml` (with `id-token: write`, `actions: read`) and `deploy.yml`.
+
+### NOT ported (deliberate)
+- **The `- parallel:` step groups.** This key is **not part of the GitHub
+  Actions workflow syntax** — it isn't in the official workflow-syntax
+  reference, and steps in a job run sequentially by design. Copying it into
+  `ci.yml` would make the workflow invalid and take down the gate that every
+  subsequent sync PR depends on. Left the explicit sequential Lint / Typecheck
+  / Test steps in place. Worth revisiting only if this turns out to be a real
+  (currently undocumented) feature that upstream's own runs validate.
+
+### N/A
+- **`pr-labeler.yml`, `reproduction.yml`, `reproduire.yml`, `stale.yml`** —
+  none exist in b24ui (all still present upstream, so this is a divergence in
+  workflow inventory, not a deletion to mirror).
+
+### Out of scope
+- **`deploy.yml`** — left untouched. It has no upstream counterpart in this
+  commit; its `persist-credentials: false` / node bump would be independent
+  hardening rather than mirroring. Reasonable follow-up if wanted.
+
+## Tests
+CI config only — no source impact. Validated the YAML parses, and this PR's own
+`ci` run exercises the change end to end (node 24, checkout without persisted
+credentials). Suite unchanged: 5565 passed / 6 skipped.

--- a/.sync/nuxt-ui.json
+++ b/.sync/nuxt-ui.json
@@ -2,7 +2,7 @@
   "upstream": "nuxt/ui",
   "branch": "v4",
   "sync_enabled": false,
-  "cursor": "706cfd0db7584bcb6aeb55cb0e5dcfa628e45fbf",
+  "cursor": "c4b786c952de69ca650807b7d5fcba7cf8114e28",
   "_cursor_note": "cursor = last upstream commit ported into b24ui (oldest-first, manual cadence). sync_enabled stays false until Phase 2 (porter workflow #67 + CLAUDE_CODE_OAUTH_TOKEN) is wired and trusted. `processed` is maintained per port from now on (backfilled #68-#72 on 2026-06-09).",
   "stats": {
     "queue_depth": 0,
@@ -1199,10 +1199,16 @@
       "summary": "docs(installation): note vue-tsc build race with auto-import declarations — adds a ::warning to the Vue installation page that auto-imports.d.ts/components.d.ts are only written when Vite runs, while create-vue's default build runs vue-tsc in parallel (run-p), so a clean checkout can fail with 'Cannot find name useToast'; recommends run-s build-only type-check. Ported verbatim to b24ui's 2.vue.md (same unplugin-auto-import/vue-components setup, useToast is a real b24ui auto-import). Docs-only."
     },
     "706cfd0db7584bcb6aeb55cb0e5dcfa628e45fbf": {
+      "pr": 305,
+      "b24ui_sha": "6febc615603be90d2ad7bf4834edb12b1d0a8e84",
+      "decision": "port",
+      "summary": "fix(ContentToc): prevent list from collapsing — ContentToc.vue gains a listStyle computed exposing --list-height (links.length * linkHeight), bound on the desktop content div; theme content slot lg:min-h-0 -> lg:min-h-[min(var(--list-height,8rem),8rem)]. ADAPTED: upstream's 1.75rem constant is for text-sm+py-1; b24ui's link is font-size-lg (15px) x line-height-3xs (1.2) = 18px + pb-12px = 30px, emitted in px since b24ui tokens are px-based. SKIPPED: root's lg:overflow-hidden removal — upstream's root is a sticky overflow-y-auto/max-h scroll container, b24ui's root is just 'flex flex-col lg:overflow-hidden' with nothing to compensate; the collapse fix doesn't depend on it. Snapshots regen (16): only the min-h class swap + --list-height: 210px (7 links). Tests 5565."
+    },
+    "c4b786c952de69ca650807b7d5fcba7cf8114e28": {
       "pr": null,
       "b24ui_sha": "pending-merge",
       "decision": "port",
-      "summary": "fix(ContentToc): prevent list from collapsing — ContentToc.vue gains a listStyle computed exposing --list-height (links.length * linkHeight), bound on the desktop content div; theme content slot lg:min-h-0 -> lg:min-h-[min(var(--list-height,8rem),8rem)]. ADAPTED: upstream's 1.75rem constant is for text-sm+py-1; b24ui's link is font-size-lg (15px) x line-height-3xs (1.2) = 18px + pb-12px = 30px, emitted in px since b24ui tokens are px-based. SKIPPED: root's lg:overflow-hidden removal — upstream's root is a sticky overflow-y-auto/max-h scroll container, b24ui's root is just 'flex flex-col lg:overflow-hidden' with nothing to compensate; the collapse fix doesn't depend on it. Snapshots regen (16): only the min-h class swap + --list-height: 210px (7 links). Tests 5565."
+      "summary": "chore(github): improve workflows — applied to b24ui counterparts: ci.yml gains persist-credentials:false + node 22->24; npm-publish.yml process job gains persist-credentials:false (neither pushes via git — Pages uses deploy-pages/OIDC, npm uses registry token + --no-git-checks). ALREADY SATISFIED: concurrency (ci.yml + deploy.yml already have groups) and permissions: contents:read (already workflow-level in npm-publish/deploy). NOT PORTED (deliberate): upstream's '- parallel:' step groups — that key is not in the GitHub Actions workflow syntax reference; copying it would invalidate ci.yml and take down the gate every sync PR depends on. N/A: pr-labeler/reproduction/reproduire/stale (absent in b24ui). OUT OF SCOPE: deploy.yml (no upstream counterpart in this commit). YAML validated; PR's own CI exercises node 24."
     }
   }
 }


### PR DESCRIPTION
Syncs upstream nuxt/ui commit [`c4b786c`](https://github.com/nuxt/ui/commit/c4b786c952de69ca650807b7d5fcba7cf8114e28) — *chore(github): improve workflows*, applied to b24ui's counterparts (`ci.yml` ≈ upstream `module.yml`, `npm-publish.yml` ≈ upstream `release.yml`).

## Applied
- **`ci.yml`** — checkout gains `persist-credentials: false`; `node-version` `22` → `24` (b24ui's `engines` is `^20.19.0 || >=22.12.0`, so 24 qualifies).
- **`npm-publish.yml`** — checkout in the `process` job gains `persist-credentials: false`.

Neither workflow pushes via git — Pages deploys through `actions/deploy-pages` (OIDC), npm publishes with a registry token and `--no-git-checks` — so dropping the persisted credentials is safe.

## Already satisfied — nothing to port
- **`concurrency`** — `ci.yml` already declares `group: ci-${{ github.ref }}` / `cancel-in-progress: true`, `deploy.yml` declares `group: pages`. Upstream's more elaborate per-PR grouping exists because their `v4` pushes fan out to windows and publish preview packages; b24ui's CI does neither.
- **`permissions: contents: read`** — already declared at workflow level in `npm-publish.yml` (with `id-token: write`, `actions: read`) and `deploy.yml`.

## ⚠️ NOT ported (deliberate)
Upstream collapses Lint / Typecheck / Test into **`- parallel:`** step groups. That key is **not part of the GitHub Actions workflow syntax** — it doesn't appear in the [official workflow-syntax reference](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax), and steps within a job run sequentially by design. Copying it would make `ci.yml` invalid and take down the gate that every subsequent sync PR depends on, so the explicit sequential steps stay. Worth revisiting if it turns out to be a real but undocumented feature that upstream's own runs validate.

## N/A / out of scope
- `pr-labeler.yml`, `reproduction.yml`, `reproduire.yml`, `stale.yml` — none exist in b24ui.
- `deploy.yml` — untouched; it has no upstream counterpart in this commit, so hardening it would be independent work rather than mirroring. Reasonable follow-up.

## Tests
CI config only — no source impact. YAML validated locally, and **this PR's own `ci` run exercises the change end to end** (node 24 + credential-less checkout). Suite unchanged: **5565 passed / 6 skipped**.

Ledger: cursor advanced to `c4b786c`; previous entry `706cfd0` reconciled to PR #305.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JS8ypVfQSFzYVZzkTHhURb)_