### PR TITLE
docs(chat): sanitize ai endpoint error logging (4ee416f)

### DIFF
--- a/.sync/log/4ee416f8d479316a5f5b233b5e6604c875af048a.md
+++ b/.sync/log/4ee416f8d479316a5f5b233b5e6604c875af048a.md
@@ -1,0 +1,88 @@
+# Port: docs(chat): rework ai endpoint around ToolLoopAgent
+
+**Upstream:** `4ee416f8d479316a5f5b233b5e6604c875af048a` (nuxt/ui)
+**Decision:** port — narrow subset (one provider-agnostic hardening); the
+architecture rework is N/A / deferred
+
+## Upstream change
+Reworks the docs AI stack (`ai.post.ts` 410 → 472 lines, plus `chat.post.ts`,
+`completion.post.ts`, a new `chatUser.ts`, `useChat.ts`, `Chat.vue`):
+- `streamText` + manual stream plumbing → `ToolLoopAgent` +
+  `createAgentUIStreamResponse`, MCP tools wrapped in `tool()`/`dynamicTool()`.
+- Typed `ApplyThemeSettings` for the `applyTheme` tool; `componentNames` read
+  from the built theme.
+- Page context moved from the system prompt into a part appended to the last
+  user message, with a `safeCurrentPage` prompt-injection guard.
+- Vercel AI Gateway wiring everywhere: `providerOptions.gateway` with
+  `caching: 'auto'`, `user: getChatUser(event)`, `tags`, fallback `models`;
+  models addressed as strings (`'anthropic/claude-sonnet-5'`); Anthropic
+  provider options.
+- Sanitized `onError` that logs only name/message/statusCode and returns a
+  friendly message (429 → rate-limit copy).
+
+## b24ui port
+b24ui's `ai.post.ts` is 115 lines against upstream's 472 — the endpoint has
+diverged substantially by design, and most of this commit is either already
+present or inapplicable.
+
+**Ported — sanitized error handling** (`docs/server/api/ai.post.ts`):
+- `onError` now logs only `name` / `message` / `statusCode` instead of the whole
+  error object. This is a real leak fix that applies to any provider: AI SDK
+  provider errors carry `requestBodyValues` (the outgoing prompt, i.e. the
+  user's chat content) and the raw `responseBody`, and b24ui was logging the
+  error verbatim.
+- Added `.toUIMessageStreamResponse({ onError })` returning the upstream
+  user-facing copy, with 429 mapped to the rate-limit message.
+- `APICallError` is a core `ai` export (re-exported from `@ai-sdk/provider`) and
+  is present in b24ui's `ai@6.0.214`, so `APICallError.isInstance` works as-is.
+- Adapted to the `streamText` idiom: its `onError` is
+  `(event: { error: unknown }) => void` (logging only), so the error → message
+  mapping goes on `toUIMessageStreamResponse`, which takes
+  `onError: (error) => string`.
+
+**Already present in b24ui — nothing to port:**
+- The `safeCurrentPage` prompt-injection guard (same 128-char / no-CRLF /
+  `^/docs/[\w/-]*$` validation).
+- `AbortController` wired to `event.node.req.on('close')`.
+- Request validation (`throw createError` on a missing/invalid `messages`).
+- `smoothStream()`, `stopWhen: stepCountIs(...)`.
+
+**N/A — Vercel AI Gateway specifics:**
+- `providerOptions.gateway` (`caching`, `user`, `tags`, fallback `models`),
+  model-as-string routing, `AnthropicLanguageModelOptions`, and the new
+  `chatUser.ts` helper. b24ui uses `createDeepSeek({ apiKey })` with
+  `deepseek-reasoner` / `deepseek-chat` and no gateway, so none of it maps.
+  This is the same AI-SDK divergence recorded in every deps sync (b24ui on
+  `ai` ^6 / `@ai-sdk/vue` ^3 / deepseek vs upstream `ai` ^7 / anthropic+gateway).
+
+**N/A — `applyTheme` tool:** b24ui ships no live-theming tool. Its system prompt
+deliberately tells users the library follows Bitrix24 styling and to use the
+standard `color`/`variant` props instead, so `ApplyThemeSettings`,
+`componentNames` and the theme-icon/CSS-variable plumbing have no counterpart.
+
+**Deferred — the `ToolLoopAgent` / `createAgentUIStreamResponse` rewrite.**
+The APIs do exist in `ai@6.0.214` (verified: `ToolLoopAgent`,
+`createAgentUIStreamResponse`, `dynamicTool`, `consumeStream` all export), so
+this is not blocked — but for b24ui it is a pure architecture swap with no
+functional gain: a single MCP tool set, one provider, no agent-level fallback
+models. It replaces the whole streaming path of an endpoint that cannot be
+exercised here (needs `DEEPSEEK_API_KEY`), so the risk/benefit doesn't justify
+it inside a sync commit. Worth doing deliberately if b24ui later adopts the
+`ai` v7 line. Note upstream's `isStepCount` is `stepCountIs` in v6 — b24ui
+already uses the correct name.
+
+**Not ported — page context as a message part.** Upstream moved it out of the
+system prompt; b24ui interpolates `safeCurrentPage` into its own system prompt
+and already carries the injection guard there. Switching would rewrite b24ui's
+bespoke prompt for no security or behavioural gain.
+
+**Not ported — `chat.post.ts` / `completion.post.ts`.** Their entire diff is the
+gateway `providerOptions` block plus model-as-string routing (N/A above).
+
+## Tests
+Docs server route; not covered by the unit suite. `typecheck` (which runs
+`nuxt typecheck docs`) validates the new `onError` signatures and the
+`APICallError` import. Suite unchanged: 5565 passed / 6 skipped.
+
+## Verify (CI=true)
+`lint` · `typecheck` · `test` · `build` — all green.

--- a/.sync/nuxt-ui.json
+++ b/.sync/nuxt-ui.json
@@ -2,7 +2,7 @@
   "upstream": "nuxt/ui",
   "branch": "v4",
   "sync_enabled": false,
-  "cursor": "c4b786c952de69ca650807b7d5fcba7cf8114e28",
+  "cursor": "4ee416f8d479316a5f5b233b5e6604c875af048a",
   "_cursor_note": "cursor = last upstream commit ported into b24ui (oldest-first, manual cadence). sync_enabled stays false until Phase 2 (porter workflow #67 + CLAUDE_CODE_OAUTH_TOKEN) is wired and trusted. `processed` is maintained per port from now on (backfilled #68-#72 on 2026-06-09).",
   "stats": {
     "queue_depth": 0,
@@ -1205,10 +1205,16 @@
       "summary": "fix(ContentToc): prevent list from collapsing — ContentToc.vue gains a listStyle computed exposing --list-height (links.length * linkHeight), bound on the desktop content div; theme content slot lg:min-h-0 -> lg:min-h-[min(var(--list-height,8rem),8rem)]. ADAPTED: upstream's 1.75rem constant is for text-sm+py-1; b24ui's link is font-size-lg (15px) x line-height-3xs (1.2) = 18px + pb-12px = 30px, emitted in px since b24ui tokens are px-based. SKIPPED: root's lg:overflow-hidden removal — upstream's root is a sticky overflow-y-auto/max-h scroll container, b24ui's root is just 'flex flex-col lg:overflow-hidden' with nothing to compensate; the collapse fix doesn't depend on it. Snapshots regen (16): only the min-h class swap + --list-height: 210px (7 links). Tests 5565."
     },
     "c4b786c952de69ca650807b7d5fcba7cf8114e28": {
+      "pr": 307,
+      "b24ui_sha": "d320047fead1a222d966ac6f67e9114436bba204",
+      "decision": "port",
+      "summary": "chore(github): improve workflows — applied to b24ui counterparts: ci.yml gains persist-credentials:false + node 22->24; npm-publish.yml process job gains persist-credentials:false (neither pushes via git — Pages uses deploy-pages/OIDC, npm uses registry token + --no-git-checks). ALREADY SATISFIED: concurrency (ci.yml + deploy.yml already have groups) and permissions: contents:read (already workflow-level in npm-publish/deploy). NOT PORTED (deliberate): upstream's '- parallel:' step groups — that key is not in the GitHub Actions workflow syntax reference; copying it would invalidate ci.yml and take down the gate every sync PR depends on. N/A: pr-labeler/reproduction/reproduire/stale (absent in b24ui). OUT OF SCOPE: deploy.yml (no upstream counterpart in this commit). YAML validated; PR's own CI exercises node 24."
+    },
+    "4ee416f8d479316a5f5b233b5e6604c875af048a": {
       "pr": null,
       "b24ui_sha": "pending-merge",
       "decision": "port",
-      "summary": "chore(github): improve workflows — applied to b24ui counterparts: ci.yml gains persist-credentials:false + node 22->24; npm-publish.yml process job gains persist-credentials:false (neither pushes via git — Pages uses deploy-pages/OIDC, npm uses registry token + --no-git-checks). ALREADY SATISFIED: concurrency (ci.yml + deploy.yml already have groups) and permissions: contents:read (already workflow-level in npm-publish/deploy). NOT PORTED (deliberate): upstream's '- parallel:' step groups — that key is not in the GitHub Actions workflow syntax reference; copying it would invalidate ci.yml and take down the gate every sync PR depends on. N/A: pr-labeler/reproduction/reproduire/stale (absent in b24ui). OUT OF SCOPE: deploy.yml (no upstream counterpart in this commit). YAML validated; PR's own CI exercises node 24."
+      "summary": "docs(chat): rework ai endpoint around ToolLoopAgent — narrow subset ported. PORTED: sanitized onError in docs/server/api/ai.post.ts (log only name/message/statusCode instead of the whole error — AI SDK provider errors carry requestBodyValues = the user's prompt — plus .toUIMessageStreamResponse({onError}) mapping 429 to the rate-limit copy; APICallError is a core ai export, present in ai@6.0.214; adapted to the streamText idiom where onError is ({error})=>void so the message mapping lives on toUIMessageStreamResponse). ALREADY PRESENT: safeCurrentPage injection guard, AbortController on req close, messages validation, smoothStream/stepCountIs. N/A: all Vercel AI Gateway wiring (providerOptions.gateway caching/user/tags/models, model-as-string routing, AnthropicLanguageModelOptions, new chatUser.ts) — b24ui uses createDeepSeek with an API key, no gateway; also the applyTheme tool + ApplyThemeSettings + componentNames (b24ui ships no live-theming tool by design). DEFERRED: the ToolLoopAgent/createAgentUIStreamResponse rewrite — APIs do exist in ai v6 (verified), but it's a pure architecture swap with no functional gain for b24ui's single-provider/single-toolset setup and can't be runtime-verified without DEEPSEEK_API_KEY. NOT PORTED: page context as a message part (b24ui interpolates into its own system prompt, guard already there); chat.post.ts/completion.post.ts (their whole diff is gateway options). b24ui's ai.post.ts is 115 lines vs upstream's 472."
     }
   }
 }

--- a/docs/server/api/ai.post.ts
+++ b/docs/server/api/ai.post.ts
@@ -1,5 +1,5 @@
 // @memo we not use jsonSchema
-import { streamText, convertToModelMessages, smoothStream, stepCountIs, jsonSchema } from 'ai'
+import { streamText, convertToModelMessages, smoothStream, stepCountIs, jsonSchema, APICallError } from 'ai'
 import { createDeepSeek } from '@ai-sdk/deepseek'
 import { z } from 'zod'
 import { tools as mcpToolDefinitions } from '#nuxt-mcp-toolkit/tools.mjs'
@@ -108,8 +108,22 @@ Guidelines:
     tools: {
       ...mcpTools
     },
-    onError: (error) => {
-      console.error('streamText error:', error)
+    onError: ({ error }) => {
+      // Provider errors carry the outgoing prompt in `requestBodyValues` and the raw
+      // `responseBody`, so log identifying fields only and keep chat content out of the logs.
+      console.error('[api/ai] stream error:', {
+        name: error instanceof Error ? error.name : 'UnknownError',
+        message: error instanceof Error ? error.message : String(error),
+        statusCode: APICallError.isInstance(error) ? error.statusCode : undefined
+      })
     }
-  }).toUIMessageStreamResponse()
+  }).toUIMessageStreamResponse({
+    onError: (error) => {
+      if (APICallError.isInstance(error) && error.statusCode === 429) {
+        return 'You have reached the message limit for now. Please try again later.'
+      }
+
+      return 'An error occurred.'
+    }
+  })
 })


### PR DESCRIPTION
Syncs the portable subset of upstream nuxt/ui commit [`4ee416f`](https://github.com/nuxt/ui/commit/4ee416f8d479316a5f5b233b5e6604c875af048a) — *docs(chat): rework ai endpoint around ToolLoopAgent*.

b24ui's `ai.post.ts` is **115 lines against upstream's 472** — the endpoint has diverged by design, so most of this commit is either already present or inapplicable. One piece is a genuine, provider-agnostic fix and is ported.

## Ported — sanitized error handling (`docs/server/api/ai.post.ts`)
- `onError` now logs only `name` / `message` / `statusCode` instead of the whole error object. **This is a real leak fix:** AI SDK provider errors carry `requestBodyValues` (the outgoing prompt — i.e. the user's chat content) and the raw `responseBody`, and b24ui was logging the error verbatim.
- Added `.toUIMessageStreamResponse({ onError })` returning upstream's user-facing copy, with `429` mapped to the rate-limit message.
- `APICallError` is a core `ai` export (re-exported from `@ai-sdk/provider`) and is present in b24ui's `ai@6.0.214`. Adapted to the `streamText` idiom: its `onError` is `(event: { error: unknown }) => void` (logging only), so the error → message mapping belongs on `toUIMessageStreamResponse`, which takes `onError: (error) => string`.

## Already present — nothing to port
The `safeCurrentPage` prompt-injection guard, the `AbortController` wired to request close, `messages` validation, `smoothStream()` and `stopWhen: stepCountIs()`.

## N/A
- **Every Vercel AI Gateway piece** — `providerOptions.gateway` (`caching`, `user`, `tags`, fallback `models`), model-as-string routing (`'anthropic/claude-sonnet-5'`), `AnthropicLanguageModelOptions`, and the new `chatUser.ts`. b24ui uses `createDeepSeek({ apiKey })` with `deepseek-reasoner`/`deepseek-chat` and no gateway — the same AI-SDK divergence recorded in every deps sync.
- **`applyTheme` tool / `ApplyThemeSettings` / `componentNames`** — b24ui ships no live-theming tool; its system prompt deliberately points users at the standard `color`/`variant` props instead.
- **`chat.post.ts` / `completion.post.ts`** — their entire diff is the gateway block.

## Deferred
The **`ToolLoopAgent` / `createAgentUIStreamResponse` rewrite**. Those APIs *do* exist in `ai@6.0.214` (verified: `ToolLoopAgent`, `createAgentUIStreamResponse`, `dynamicTool`, `consumeStream` all export), so this isn't blocked — but for b24ui it's a pure architecture swap with no functional gain (one provider, one MCP tool set, no agent-level fallback models), and it replaces the whole streaming path of an endpoint that can't be exercised here without `DEEPSEEK_API_KEY`. Worth doing deliberately if b24ui adopts the `ai` v7 line. *(Note: upstream's `isStepCount` is `stepCountIs` in v6 — b24ui already uses the correct name.)*

## Tests
Docs server route, not covered by the unit suite; `typecheck` (which runs `nuxt typecheck docs`) validates the new `onError` signatures and the `APICallError` import. Suite unchanged: **5565 passed / 6 skipped**.

## Verify (`CI=true`)
`lint` · `typecheck` · `test` · `build` — all green.

Ledger: cursor advanced to `4ee416f`; previous entry `c4b786c` reconciled to PR #307.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JS8ypVfQSFzYVZzkTHhURb)_