### PR TITLE
chore(sync): no-op upstream CodSpeed workflow (8aa8041)

### DIFF
--- a/.sync/log/8aa804167e5d4e8a618feb0a370e3481e223af8a.md
+++ b/.sync/log/8aa804167e5d4e8a618feb0a370e3481e223af8a.md
@@ -1,0 +1,51 @@
+# Port: chore(github): add CodSpeed workflow
+
+**Upstream:** `8aa804167e5d4e8a618feb0a370e3481e223af8a` (nuxt/ui)
+**Decision:** no-op
+
+## Upstream change
+Wires the benchmark suite into [CodSpeed](https://codspeed.io), a hosted
+continuous-benchmarking service:
+- `package.json` — adds `@codspeed/vitest-plugin@^5.7.1`.
+- `vitest.config.ts` — registers `codspeedPlugin()` on the `vue` project
+  ("instruments benchmarks when running under the CodSpeed runner in CI,
+  inactive for a local `pnpm bench`").
+- `pnpm-workspace.yaml` — adds an `"@codspeed/vitest-plugin>vite": ^7.0.0 || ^8.0.0`
+  override, because the plugin caps its `vite` peer at `^7` and would otherwise
+  re-key the whole vite peer group down to vitest's vite 7.
+- `.github/workflows/module.yml` — a `benchmarks` job running
+  `CodSpeedHQ/action@v4` in `simulation` mode.
+- `test/bench/*.bench.ts` — replaces tinybench's `setup`/`teardown` with a lazy
+  `wrapper ??= await mountSuspended(...)`, because "CodSpeed's analysis runner
+  invokes the bench function without tinybench's `setup`/`teardown` options".
+
+## b24ui port
+**Not applicable.** Upstream's own workflow settles it — the job is gated:
+
+```yaml
+# Skip forks of the repo, they can't authenticate with CodSpeed
+if: github.repository_owner == 'nuxt'
+```
+
+b24ui is exactly such a fork (`bitrix24`), with no CodSpeed account, app
+installation or token, so the job could never run here. Everything else in the
+commit exists only to serve it:
+
+- **`@codspeed/vitest-plugin` + the `>vite` override** — the plugin's `vite ^7`
+  peer cap is the very problem that the `vite: ^8.1.5` / `rolldown: ~1.1.5`
+  overrides were added to solve in `282759e` (two vite copies → clashing
+  rolldown native ABIs → every nuxt-project test worker failing to start).
+  Adding a dependency that pulls the peer group back toward vite 7, purely to
+  feed a job that cannot run, trades real risk for no benefit.
+- **`codspeedPlugin()` in `vitest.config.ts`** — a no-op without the runner.
+- **The bench-file rewrite** — a *regression* outside CodSpeed: dropping
+  `setup`/`teardown` for a lazy mount means the wrapper is never unmounted, and
+  each bench keeps one mounted component alive for the whole run. b24ui's
+  benches keep the tinybench form, which is the better local behaviour.
+
+No-op — cursor advanced only. This also decides `6add5fb`
+(*chore(deps): update codspeedhq/action action to v5*), still ahead in the
+queue: with no CodSpeed workflow to bump, it is N/A for the same reason.
+
+## Tests
+No change. Suite unchanged: 5565 passed / 6 skipped.

--- a/.sync/nuxt-ui.json
+++ b/.sync/nuxt-ui.json
@@ -2,7 +2,7 @@
   "upstream": "nuxt/ui",
   "branch": "v4",
   "sync_enabled": false,
-  "cursor": "735b264e4df8565d05cd522df36406df35fe5896",
+  "cursor": "8aa804167e5d4e8a618feb0a370e3481e223af8a",
   "_cursor_note": "cursor = last upstream commit ported into b24ui (oldest-first, manual cadence). sync_enabled stays false until Phase 2 (porter workflow #67 + CLAUDE_CODE_OAUTH_TOKEN) is wired and trusted. `processed` is maintained per port from now on (backfilled #68-#72 on 2026-06-09).",
   "stats": {
     "queue_depth": 0,
@@ -1229,10 +1229,16 @@
       "summary": "chore(deps): update devdependency @nuxt/test-utils to ^4.1.0 — package.json ^4.0.2->^4.1.0 (lockfile regen, resolves 4.1.0) + test/nuxt/.nuxtrc setups pin 4.0.2->4.1.0 (must track the installed version or the nuxt test env desyncs from the package). N/A: upstream also drops its pnpm-workspace '@nuxt/test-utils': 4.0.2 override (b24ui never pinned it) and removes the package from renovate.json ignoreDeps (b24ui has no renovate config — bumps come through this sync). NOTE/CORRECTION: upstream carries vitest-environment-nuxt ^2.0.0 too; the 282759e entry wrongly listed it as a b24ui-only divergence when explaining the duplicate-vite diagnosis — the vite/rolldown overrides added there remain necessary regardless. Bumps the test harness itself; full suite is the verification: 5565 passed, no snapshot drift."
     },
     "735b264e4df8565d05cd522df36406df35fe5896": {
-      "pr": null,
-      "b24ui_sha": "pending-merge",
+      "pr": 312,
+      "b24ui_sha": "8ec218770084582490a710553f570d510491f836",
       "decision": "port",
       "summary": "fix(theme): unify motion easing and respect prefers-reduced-motion — (1) appended the @media (prefers-reduced-motion: reduce) block to keyframes.css redefining 26 presence keyframes to fade-only (all 26 exist in b24ui; matters MORE here — b24ui's PR #279 gated only decorative loops, leaving 77 animate-[] usages ungated; composes with existing motion-safe:). (2) rewrote 70 animate-[] easings across 19 theme files by upstream's per-type rule: 54 var(--ease-out) presence, 10 linear (carousel/shimmer/progressbar-loading), 6 var(--ease-in-out) (swing/elastic) — inside animate-[] the bare ease-out keyword is CSS cubic-bezier(0,0,.58,1) while the ease-out utility maps to Tailwind's --ease-out, which is the mismatch being unified. (3) same three transition edits as upstream on identical slots: progress indicator/status + toaster base get motion-reduce:transition-none, status/step get ease-out. SKIPPED: elastic keyframes margin->left/top — b24ui's Progress indicator is size-full and statically positioned, so left/top would silently stop it moving (table.thead::after is absolute and would be fine); change is cosmetic (90%->100%). NOT PORTED: the wider per-slot transition sweep — b24ui slots diverge and a blanket motion-reduce across its 80 transition-* would exceed upstream (reduced motion targets movement, not colour/opacity). 745 snapshots regen across 42 files, only expected tokens. Tests 5565."
+    },
+    "8aa804167e5d4e8a618feb0a370e3481e223af8a": {
+      "pr": null,
+      "b24ui_sha": "pending-merge",
+      "decision": "no-op",
+      "summary": "chore(github): add CodSpeed workflow — wires benchmarks into CodSpeed (hosted continuous benchmarking): @codspeed/vitest-plugin dep, codspeedPlugin() in vitest.config, a '@codspeed/vitest-plugin>vite' override (the plugin caps its vite peer at ^7), a CodSpeedHQ/action@v4 job in module.yml, and bench files rewritten to lazy-mount because CodSpeed's runner ignores tinybench setup/teardown. NOT APPLICABLE: upstream gates the job itself with `if: github.repository_owner == 'nuxt'` — 'Skip forks of the repo, they can't authenticate with CodSpeed'. b24ui is such a fork (no account/app/token), so the job can never run, and everything else serves only it: the plugin's vite ^7 peer cap is exactly the hazard the vite ^8.1.5 / rolldown ~1.1.5 overrides fixed in 282759e, and the bench rewrite is a regression outside CodSpeed (no unmount — each bench keeps a mounted component alive). No-op. Also pre-decides 6add5fb (codspeedhq/action v5) as N/A."
     }
   }
 }


### PR DESCRIPTION
Syncs upstream nuxt/ui commit [`8aa8041`](https://github.com/nuxt/ui/commit/8aa804167e5d4e8a618feb0a370e3481e223af8a) — *chore(github): add CodSpeed workflow*.

## Upstream change
Wires the benchmark suite into [CodSpeed](https://codspeed.io) (hosted continuous benchmarking): `@codspeed/vitest-plugin@^5.7.1`, `codspeedPlugin()` in `vitest.config.ts`, a `"@codspeed/vitest-plugin>vite": ^7.0.0 || ^8.0.0` override, a `benchmarks` job running `CodSpeedHQ/action@v4`, and bench files rewritten to lazy-mount.

## Decision: no-op
Upstream's own workflow settles it — the job is gated:

```yaml
# Skip forks of the repo, they can't authenticate with CodSpeed
if: github.repository_owner == 'nuxt'
```

b24ui is exactly such a fork (`bitrix24`), with no CodSpeed account, app installation or token, so the job could never run here. Everything else in the commit exists only to serve it:

- **`@codspeed/vitest-plugin` + the `>vite` override** — the plugin caps its `vite` peer at `^7`, which is *precisely* the hazard the `vite: ^8.1.5` / `rolldown: ~1.1.5` overrides were added to fix in [`282759e`](https://github.com/bitrix24/b24ui/pull/300) (two vite copies → clashing rolldown native ABIs → every nuxt-project test worker failing to start with `Missing field \`moduleType\``). Pulling the peer group back toward vite 7 to feed a job that cannot run is real risk for zero benefit.
- **`codspeedPlugin()`** — a no-op without the runner.
- **The bench-file rewrite** — a *regression* outside CodSpeed: it drops tinybench's `setup`/`teardown` for a lazy `wrapper ??= await mountSuspended(...)`, so the wrapper is never unmounted and each bench keeps a mounted component alive for the whole run. b24ui keeps the tinybench form, which is the better local behaviour.

Ledger-only: cursor advanced to `8aa8041`; previous entry `735b264` reconciled to PR #312.

**This also decides `6add5fb`** (*chore(deps): update codspeedhq/action action to v5*), still ahead in the queue — with no CodSpeed workflow to bump, it is N/A for the same reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JS8ypVfQSFzYVZzkTHhURb)_