### PR TITLE
fix(Modal): emit transition events from overlay when scrollable (5afbd5c)

### DIFF
--- a/.sync/log/5afbd5c9aeaffe427c90b7e97249c8e1de9acf04.md
+++ b/.sync/log/5afbd5c9aeaffe427c90b7e97249c8e1de9acf04.md
@@ -1,0 +1,29 @@
+# Port: fix(Modal): emit transition events from overlay when scrollable
+
+**Upstream:** `5afbd5c9aeaffe427c90b7e97249c8e1de9acf04` (nuxt/ui)
+**Decision:** port — verbatim
+
+## Upstream change
+In `scrollable` mode the Modal renders its content *inside* `DialogOverlay`, so
+the overlay is the element that actually transitions. The transition events
+were still wired only to `DialogContent`, so `enter` / `after:enter` / `leave` /
+`after:leave` fired against the wrong element's lifecycle. The fix:
+
+- guard the content handlers with `!props.scrollable && emits(...)`,
+- add the same four handlers to the `scrollable` branch's `DialogOverlay`.
+
+## b24ui port
+- **`src/runtime/components/Modal.vue`** — applied both hunks verbatim. b24ui's
+  Modal has the identical structure: the same `scrollable` prop ("enables
+  scrollable overlay mode where content scrolls within the overlay"), the same
+  four emits on `DialogContent`, and the same
+  `v-if="props.scrollable"` branch wrapping `<ReuseContentTemplate />` in
+  `DialogOverlay`. Only the theme accessor differs (`b24ui.overlay(...)` vs
+  upstream's `ui.overlay(...)`), which is preserved.
+
+## Tests
+Event-wiring change with no markup or class impact — no snapshot drift. Suite
+unchanged: 5565 passed / 6 skipped.
+
+## Verify (CI=true)
+`lint` · `typecheck` · `test` · `build` — all green.

--- a/.sync/nuxt-ui.json
+++ b/.sync/nuxt-ui.json
@@ -2,7 +2,7 @@
   "upstream": "nuxt/ui",
   "branch": "v4",
   "sync_enabled": false,
-  "cursor": "8aa804167e5d4e8a618feb0a370e3481e223af8a",
+  "cursor": "5afbd5c9aeaffe427c90b7e97249c8e1de9acf04",
   "_cursor_note": "cursor = last upstream commit ported into b24ui (oldest-first, manual cadence). sync_enabled stays false until Phase 2 (porter workflow #67 + CLAUDE_CODE_OAUTH_TOKEN) is wired and trusted. `processed` is maintained per port from now on (backfilled #68-#72 on 2026-06-09).",
   "stats": {
     "queue_depth": 0,
@@ -1235,10 +1235,16 @@
       "summary": "fix(theme): unify motion easing and respect prefers-reduced-motion — (1) appended the @media (prefers-reduced-motion: reduce) block to keyframes.css redefining 26 presence keyframes to fade-only (all 26 exist in b24ui; matters MORE here — b24ui's PR #279 gated only decorative loops, leaving 77 animate-[] usages ungated; composes with existing motion-safe:). (2) rewrote 70 animate-[] easings across 19 theme files by upstream's per-type rule: 54 var(--ease-out) presence, 10 linear (carousel/shimmer/progressbar-loading), 6 var(--ease-in-out) (swing/elastic) — inside animate-[] the bare ease-out keyword is CSS cubic-bezier(0,0,.58,1) while the ease-out utility maps to Tailwind's --ease-out, which is the mismatch being unified. (3) same three transition edits as upstream on identical slots: progress indicator/status + toaster base get motion-reduce:transition-none, status/step get ease-out. SKIPPED: elastic keyframes margin->left/top — b24ui's Progress indicator is size-full and statically positioned, so left/top would silently stop it moving (table.thead::after is absolute and would be fine); change is cosmetic (90%->100%). NOT PORTED: the wider per-slot transition sweep — b24ui slots diverge and a blanket motion-reduce across its 80 transition-* would exceed upstream (reduced motion targets movement, not colour/opacity). 745 snapshots regen across 42 files, only expected tokens. Tests 5565."
     },
     "8aa804167e5d4e8a618feb0a370e3481e223af8a": {
-      "pr": null,
-      "b24ui_sha": "pending-merge",
+      "pr": 316,
+      "b24ui_sha": "51ef367b80a17a2e024fa30c33da068d3e292594",
       "decision": "no-op",
       "summary": "chore(github): add CodSpeed workflow — wires benchmarks into CodSpeed (hosted continuous benchmarking): @codspeed/vitest-plugin dep, codspeedPlugin() in vitest.config, a '@codspeed/vitest-plugin>vite' override (the plugin caps its vite peer at ^7), a CodSpeedHQ/action@v4 job in module.yml, and bench files rewritten to lazy-mount because CodSpeed's runner ignores tinybench setup/teardown. NOT APPLICABLE: upstream gates the job itself with `if: github.repository_owner == 'nuxt'` — 'Skip forks of the repo, they can't authenticate with CodSpeed'. b24ui is such a fork (no account/app/token), so the job can never run, and everything else serves only it: the plugin's vite ^7 peer cap is exactly the hazard the vite ^8.1.5 / rolldown ~1.1.5 overrides fixed in 282759e, and the bench rewrite is a regression outside CodSpeed (no unmount — each bench keeps a mounted component alive). No-op. Also pre-decides 6add5fb (codspeedhq/action v5) as N/A."
+    },
+    "5afbd5c9aeaffe427c90b7e97249c8e1de9acf04": {
+      "pr": null,
+      "b24ui_sha": "pending-merge",
+      "decision": "port",
+      "summary": "fix(Modal): emit transition events from overlay when scrollable — in scrollable mode the content renders inside DialogOverlay, so the overlay is the transitioning element, but enter/after:enter/leave/after:leave were wired only to DialogContent. Guarded the content handlers with !props.scrollable && emits(...) and added the same four to the scrollable branch's DialogOverlay. Applied verbatim — b24ui's Modal has the identical structure (same scrollable prop, same four emits, same v-if branch wrapping ReuseContentTemplate); only the theme accessor differs (b24ui.overlay vs ui.overlay). Event-wiring only, no snapshot drift. Tests 5565."
     }
   }
 }

--- a/src/runtime/components/Modal.vue
+++ b/src/runtime/components/Modal.vue
@@ -168,10 +168,10 @@ const b24ui = computed(() => tv({ extend: theme, ...(appConfig.b24ui?.modal || {
         data-slot="content"
         :class="b24ui.content({ class: [!slots.default && props.class, props.b24ui?.content] })"
         v-bind="contentProps"
-        @enter="emits('enter')"
-        @after-enter="emits('after:enter')"
-        @leave="emits('leave')"
-        @after-leave="emits('after:leave')"
+        @enter="!props.scrollable && emits('enter')"
+        @after-enter="!props.scrollable && emits('after:enter')"
+        @leave="!props.scrollable && emits('leave')"
+        @after-leave="!props.scrollable && emits('after:leave')"
         v-on="contentEvents"
       >
         <VisuallyHidden v-if="(!props.title && !slots.title) || (!props.description && !slots.description) || !!slots.content">
@@ -256,7 +256,14 @@ const b24ui = computed(() => tv({ extend: theme, ...(appConfig.b24ui?.modal || {
     <DialogPortal v-bind="portalProps" :force-mount="(portalProps.disabled && props.unmountOnHide === false) || undefined">
       <FieldGroupReset>
         <template v-if="props.scrollable">
-          <DialogOverlay data-slot="overlay" :class="b24ui.overlay({ class: props.b24ui?.overlay })">
+          <DialogOverlay
+            data-slot="overlay"
+            :class="b24ui.overlay({ class: props.b24ui?.overlay })"
+            @enter="emits('enter')"
+            @after-enter="emits('after:enter')"
+            @leave="emits('leave')"
+            @after-leave="emits('after:leave')"
+          >
             <ReuseContentTemplate />
           </DialogOverlay>
         </template>


### PR DESCRIPTION
Syncs upstream nuxt/ui commit [`5afbd5c`](https://github.com/nuxt/ui/commit/5afbd5c9aeaffe427c90b7e97249c8e1de9acf04) — *fix(Modal): emit transition events from overlay when scrollable*.

## What
In `scrollable` mode the Modal renders its content **inside** `DialogOverlay`, so the overlay is the element that actually transitions — but `enter` / `after:enter` / `leave` / `after:leave` were wired only to `DialogContent`, firing against the wrong element's lifecycle.

- Guard the content handlers with `!props.scrollable && emits(...)`.
- Add the same four handlers to the `scrollable` branch's `DialogOverlay`.

## b24ui port
Applied **verbatim**. b24ui's Modal has the identical structure: the same `scrollable` prop ("enables scrollable overlay mode where content scrolls within the overlay"), the same four emits on `DialogContent`, and the same `v-if="props.scrollable"` branch wrapping `<ReuseContentTemplate />` in `DialogOverlay`. Only the theme accessor differs (`b24ui.overlay(...)` vs upstream's `ui.overlay(...)`), which is preserved.

## Tests
Event wiring only — no markup or class impact, **no snapshot drift**. Suite unchanged: **5565 passed / 6 skipped**.

## Verify (`CI=true`)
`lint` · `typecheck` · `test` · `build` — all green.

Ledger: cursor advanced to `5afbd5c`; previous entry `8aa8041` reconciled to PR #316.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JS8ypVfQSFzYVZzkTHhURb)_