### PR TITLE
perf(components): memoize tv slot invocations with simple args (4200e80)

### DIFF
--- a/.sync/log/4200e80c03719d0b6e36e2d3957575bf1c24bc7d.md
+++ b/.sync/log/4200e80c03719d0b6e36e2d3957575bf1c24bc7d.md
@@ -1,0 +1,47 @@
+# Port: perf(components): memoize tv slot invocations with simple args
+
+**Upstream:** `4200e80c03719d0b6e36e2d3957575bf1c24bc7d` (nuxt/ui)
+**Decision:** port — verbatim (naming adapted)
+
+## Upstream change
+Memoizes slot invocations inside `wrapSlots` so variant resolution + twMerge run
+once per distinct input rather than on every call (re-renders, table cells):
+
+- `isMemoizable()` — a slot call is cacheable only when every prop value is a
+  primitive or an array of primitives (depth-capped at 4). Objects (clsx class
+  maps) and functions (replacers) bail to the uncached path. Non-finite numbers
+  are rejected because `JSON.stringify` turns NaN/Infinity into `null`, which
+  would collide with a real `null` key that tv resolves differently.
+- `memoKey()` — only plain objects are keyed (an exotic prototype could carry
+  inherited enumerable props that tv reads but `JSON.stringify` drops, letting
+  two different inputs share one entry); the key is `JSON.stringify(slotProps)`.
+- `wrapSlots()` — a per-slot `Map` cache on the invocation result, so a factory
+  rebuild or variant-prop recompute starts fresh. `undefined` is a *real* slot
+  result (tv returns it, not `''`, for a slot resolving to no classes), so a
+  `has()` check backs up the `get()` miss. The cache clears at 500 entries to
+  bound pathological dynamic inputs.
+
+Plus 12 regression tests in `test/utils/tv.spec.ts`.
+
+## b24ui port
+- **`src/runtime/utils/tv.ts`** — applied verbatim. b24ui's `wrapSlots` was
+  byte-identical to upstream's pre-change version (only comments differ:
+  `:b24ui` / `app.config.b24ui` vs `:ui` / `app.config.ui`), and
+  `findReplacer` / `applyReplacer` are unchanged, so the patch drops straight
+  in. Adapted the two comment references to b24ui naming
+  (`[props.b24ui?.td, ...]`, `app.config.b24ui`).
+- **`test/utils/tv.spec.ts`** — appended the full `tv slot memoization`
+  describe block. b24ui's spec already declares the same permissive `tvt`
+  helper the new tests use, so they port unchanged.
+
+## Tests
+`tv` underpins every component's class resolution, so the full suite is the
+real verification — and it is unchanged at 5565 passed / 6 skipped with **no
+snapshot drift**, confirming the memoized path returns identical output.
+The tv spec itself grows from 16 to 28 cases (56 across both projects), covering
+cache hits, `undefined`-resolving slots, distinct-arg isolation, `undefined` vs
+absent keys, reordered keys, NaN-vs-null collision, clsx-object and replacer
+bail-outs, cyclic arrays, the 500-entry bound, and inherited enumerable props.
+
+## Verify (CI=true)
+`lint` · `typecheck` · `test` · `build` — all green.

--- a/.sync/nuxt-ui.json
+++ b/.sync/nuxt-ui.json
@@ -2,7 +2,7 @@
   "upstream": "nuxt/ui",
   "branch": "v4",
   "sync_enabled": false,
-  "cursor": "702f481fb55e252154ea938398d30b259d99030d",
+  "cursor": "4200e80c03719d0b6e36e2d3957575bf1c24bc7d",
   "_cursor_note": "cursor = last upstream commit ported into b24ui (oldest-first, manual cadence). sync_enabled stays false until Phase 2 (porter workflow #67 + CLAUDE_CODE_OAUTH_TOKEN) is wired and trusted. `processed` is maintained per port from now on (backfilled #68-#72 on 2026-06-09).",
   "stats": {
     "queue_depth": 0,
@@ -1247,10 +1247,16 @@
       "summary": "fix(Modal): emit transition events from overlay when scrollable — in scrollable mode the content renders inside DialogOverlay, so the overlay is the transitioning element, but enter/after:enter/leave/after:leave were wired only to DialogContent. Guarded the content handlers with !props.scrollable && emits(...) and added the same four to the scrollable branch's DialogOverlay. Applied verbatim — b24ui's Modal has the identical structure (same scrollable prop, same four emits, same v-if branch wrapping ReuseContentTemplate); only the theme accessor differs (b24ui.overlay vs ui.overlay). Event-wiring only, no snapshot drift. Tests 5565."
     },
     "702f481fb55e252154ea938398d30b259d99030d": {
+      "pr": 318,
+      "b24ui_sha": "4f4ff6be577acab7560f2fdf9cc2f7337306c5ce",
+      "decision": "port",
+      "summary": "docs(input-rating): remove stray defaultValue line in size — the ### Size example's ::component-code front matter had a stray '- defaultValue' hanging off the end of items.size, making it a malformed mapping/sequence mix and offering defaultValue as a selectable size value (it is already covered by the block's ignore: list). b24ui carried the identical defect (InputRating arrived via the fork's own PR #283 from the same source example); removed verbatim. Docs-only."
+    },
+    "4200e80c03719d0b6e36e2d3957575bf1c24bc7d": {
       "pr": null,
       "b24ui_sha": "pending-merge",
       "decision": "port",
-      "summary": "docs(input-rating): remove stray defaultValue line in size — the ### Size example's ::component-code front matter had a stray '- defaultValue' hanging off the end of items.size, making it a malformed mapping/sequence mix and offering defaultValue as a selectable size value (it is already covered by the block's ignore: list). b24ui carried the identical defect (InputRating arrived via the fork's own PR #283 from the same source example); removed verbatim. Docs-only."
+      "summary": "perf(components): memoize tv slot invocations with simple args — wrapSlots gains a per-slot Map cache so variant resolution + twMerge run once per distinct input (re-renders, table cells). isMemoizable() accepts primitives and arrays of primitives (depth-capped 4), rejects non-finite numbers (JSON.stringify turns NaN/Infinity into null, colliding with a real null key tv resolves differently), and bails on objects (clsx maps) / functions (replacers). memoKey() only keys plain objects (an exotic prototype could carry inherited enumerable props tv reads but stringify drops). undefined is a real slot result so a has() check backs the get() miss; cache clears at 500 entries. Applied verbatim — b24ui's wrapSlots was byte-identical to upstream's pre-change version (only :b24ui/app.config.b24ui comment naming differs). Appended the full 12-case memoization describe to test/utils/tv.spec.ts (b24ui already declares the same tvt helper). Tests 5565 -> 5589 (+12 x2 projects), no snapshot drift — memoized path returns identical output."
     }
   }
 }

--- a/src/runtime/utils/tv.ts
+++ b/src/runtime/utils/tv.ts
@@ -157,12 +157,77 @@ function applyReplacer(replacer: SlotClassReplacer, slotProps: Record<string, an
 }
 
 /**
+ * A slot invocation is memoizable only when its output is fully determined by a
+ * serializable key: primitives and arrays of primitives. Objects (clsx-style
+ * class maps) and functions (replacers) bail to the uncached path.
+ */
+function isMemoizable(value: unknown, depth = 0): boolean {
+  if (value === undefined || value === null) {
+    return true
+  }
+  const type = typeof value
+  if (type === 'string' || type === 'boolean') {
+    return true
+  }
+  // `JSON.stringify` turns NaN/Infinity into `null`, colliding with real `null`
+  // keys that tv resolves differently (default variant vs `key || "false"` lookup).
+  if (type === 'number') {
+    return Number.isFinite(value)
+  }
+  if (Array.isArray(value)) {
+    // Stop a few levels down rather than recurse without bound: a cyclic array
+    // reaching a variant would blow the stack, where tv itself resolves it. The
+    // arrays components pass (`[props.b24ui?.td, ...]`) are one or two deep.
+    if (depth >= 4) {
+      return false
+    }
+    for (const item of value) {
+      if (!isMemoizable(item, depth + 1)) {
+        return false
+      }
+    }
+    return true
+  }
+  return false
+}
+
+function memoKey(slotProps: Record<string, any>): string | undefined {
+  // Only plain objects: an exotic prototype could carry inherited enumerable
+  // props that tv would read but `JSON.stringify` would drop from the key,
+  // making two different inputs share one cache entry.
+  const proto = Object.getPrototypeOf(slotProps)
+  if (proto !== Object.prototype && proto !== null) {
+    return undefined
+  }
+
+  // `Object.keys` matches exactly what `JSON.stringify` serializes (own
+  // enumerable keys), so everything the key omits is also never inspected here.
+  for (const key of Object.keys(slotProps)) {
+    if (!isMemoizable(slotProps[key])) {
+      return undefined
+    }
+  }
+  // `JSON.stringify` drops `undefined`-valued keys, matching tv's semantics
+  // (an undefined variant is the same as an absent one).
+  return JSON.stringify(slotProps)
+}
+
+/**
  * Wrap the slot functions returned by `tv()` so a replacer (from `:b24ui` / `class`
  * at call time, or from `app.config.b24ui` at construction time) drops the slot's
  * baked-in default chain and returns only its replacement. Without a replacer the
  * original slot function runs untouched, so the common merge path is unaffected.
+ *
+ * Repeated invocations with identical simple args (re-renders, table cells) are
+ * memoized per slot: variant resolution + twMerge only run once per distinct
+ * input. The cache lives on the invocation result, so a factory rebuild (e.g.
+ * `app.config.b24ui` change) or variant-prop recompute starts fresh.
  */
 function wrapSlots(slots: Record<string, any>, directives?: Record<string, SlotClassReplacer>) {
+  // `undefined` is a real slot result: `tv` returns it (not `''`) for a slot
+  // whose chain resolves to no classes, so it can't double as a miss sentinel.
+  const memo = new Map<string, Map<string, string | undefined>>()
+
   return new Proxy(slots, {
     get(target, key: string) {
       const slot = target[key]
@@ -173,7 +238,30 @@ function wrapSlots(slots: Record<string, any>, directives?: Record<string, SlotC
       return (slotProps: Record<string, any> = {}) => {
         const replacer = findReplacer(slotProps.class) ?? findReplacer(slotProps.className) ?? directives?.[key]
         if (!replacer) {
-          return slot(slotProps)
+          const cacheKey = memoKey(slotProps)
+          if (cacheKey === undefined) {
+            return slot(slotProps)
+          }
+
+          let cache = memo.get(key)
+          if (!cache) {
+            cache = new Map()
+            memo.set(key, cache)
+          }
+
+          let result = cache.get(cacheKey)
+          // The extra `has` only runs for the rare slot that resolves to no
+          // classes, so the hot path stays a single lookup.
+          if (result === undefined && !cache.has(cacheKey)) {
+            if (cache.size >= 500) {
+              // Pathological dynamic inputs (e.g. per-row generated classes):
+              // reset rather than grow unbounded.
+              cache.clear()
+            }
+            result = slot(slotProps) as string
+            cache.set(cacheKey, result)
+          }
+          return result
         }
         return applyReplacer(replacer, slotProps, () => slot({ ...slotProps, class: undefined, className: undefined }))
       }

--- a/test/utils/tv.spec.ts
+++ b/test/utils/tv.spec.ts
@@ -122,3 +122,153 @@ describe('tv class replace (slotless component)', () => {
     expect(ui()).toBe('block')
   })
 })
+
+describe('tv slot memoization', () => {
+  const theme = {
+    slots: { base: 'inline-flex text-sm', label: 'truncate' },
+    variants: {
+      active: {
+        true: { base: 'font-bold' },
+        false: { base: 'font-light' }
+      }
+    }
+  }
+
+  const build = () => tvt({ extend: tvt(theme) })()
+
+  // Counts how often the `active` variant is read. Building the cache key reads
+  // it a fixed number of times per call, so a call served from the cache reads
+  // it strictly fewer times than one that runs the slot, without either test
+  // having to pin the exact counts.
+  function countingProps(active: boolean) {
+    const counter = { reads: 0 }
+    const props = {
+      get active() {
+        counter.reads++
+        return active
+      }
+    }
+    return [props, counter] as const
+  }
+
+  it('runs the slot once for repeated identical args', () => {
+    const ui = build()
+    const [props, counter] = countingProps(true)
+
+    expect(ui.base(props)).toContain('font-bold')
+    const miss = counter.reads
+
+    counter.reads = 0
+    expect(ui.base(props)).toContain('font-bold')
+    expect(counter.reads).toBeLessThan(miss)
+  })
+
+  it('caches a slot whose chain resolves to no classes', () => {
+    // `tv` returns `undefined` for such a slot rather than `''`, so it can't
+    // double as the "not cached yet" sentinel (`navigation-menu` has two).
+    const ui = tvt({ extend: tvt({ slots: { base: '' }, variants: { active: { true: {}, false: {} } } }) })()
+    const [props, counter] = countingProps(true)
+
+    expect(ui.base(props)).toBeUndefined()
+    const miss = counter.reads
+
+    counter.reads = 0
+    expect(ui.base(props)).toBeUndefined()
+    expect(counter.reads).toBeLessThan(miss)
+  })
+
+  it('returns correct output for repeated identical args', () => {
+    const ui = build()
+    const first = ui.base({ active: true, class: 'p-2' })
+    expect(ui.base({ active: true, class: 'p-2' })).toBe(first)
+    expect(first).toContain('font-bold')
+    expect(first).toContain('p-2')
+  })
+
+  it('never shares entries across distinct args', () => {
+    const ui = build()
+    expect(ui.base({ active: true })).toContain('font-bold')
+    expect(ui.base({ active: false })).toContain('font-light')
+    expect(ui.base({ active: true, class: 'p-2' })).toContain('p-2')
+    expect(ui.base({ active: true })).not.toContain('p-2')
+    // String and array class forms resolve to the same output independently.
+    expect(ui.base({ class: ['p-2', undefined] })).toContain('p-2')
+  })
+
+  it('treats an `undefined`-valued key the same as an absent one', () => {
+    const ui = build()
+    expect(ui.base({ active: undefined, class: 'p-2' })).toBe(ui.base({ class: 'p-2' }))
+  })
+
+  it('returns identical output for reordered keys (a cache miss, not a shared entry)', () => {
+    const ui = build()
+    expect(ui.base({ active: true, class: 'p-2' })).toBe(ui.base({ class: 'p-2', active: true }))
+  })
+
+  it('does not share entries between NaN and null variant values', () => {
+    const ui = tvt({ extend: tvt(theme), defaultVariants: { active: true } })()
+    // Both serialize to `"null"`, but tv resolves `null` to the default variant
+    // while NaN falls through the `key || "false"` lookup.
+    expect(ui.base({ active: Number.NaN })).toContain('font-light')
+    expect(ui.base({ active: null })).toContain('font-bold')
+  })
+
+  it('does not poison the cache through clsx object classes', () => {
+    const ui = build()
+    // Object classes bail out of the memo but still resolve...
+    expect(ui.label({ class: { 'font-bold': true, 'opacity-50': false } })).toBe('truncate font-bold')
+    // ...and cached plain calls before/after stay independent.
+    expect(ui.label({})).toBe('truncate')
+    expect(ui.label({ class: { 'font-bold': false } })).toBe('truncate')
+  })
+
+  it('does not poison the cache through replacers', () => {
+    const ui = build()
+    expect(ui.label({ class: 'p-2' })).toBe('truncate p-2')
+    expect(ui.label({ class: () => 'block' })).toBe('block')
+    expect(ui.label({ class: 'p-2' })).toBe('truncate p-2')
+  })
+
+  it('falls back to the uncached path for a cyclic array', () => {
+    const ui = build()
+    const cyclic: any[] = ['p-2']
+    cyclic.push(cyclic)
+    // tv resolves this to the default variant (`String(cyclic)` matches no key),
+    // so keying it must stop recursing rather than blow the stack.
+    expect(() => ui.base({ active: cyclic })).not.toThrow()
+  })
+
+  it('keeps each slot cache bounded', () => {
+    const ui = build()
+    const counter = { reads: 0 }
+    const props = (i: number) => ({
+      class: `w-[${i}px]`,
+      get active() {
+        counter.reads++
+        return true
+      }
+    })
+
+    for (let i = 0; i < 600; i++) {
+      ui.base(props(i))
+    }
+
+    // The 501st distinct key resets the cache, so it now holds 500 onwards.
+    counter.reads = 0
+    expect(ui.base(props(599))).toContain('w-[599px]')
+    const hit = counter.reads
+
+    // Entry 0 went with the reset and has to be resolved again.
+    counter.reads = 0
+    expect(ui.base(props(0))).toContain('w-[0px]')
+    expect(counter.reads).toBeGreaterThan(hit)
+  })
+
+  it('does not key inputs carrying inherited enumerable props as plain ones', () => {
+    const ui = build()
+    // Inherited `class` is read by tv but invisible to `JSON.stringify`: without
+    // the plain-object guard this would cache a `font-bold` result under `{}`.
+    expect(ui.label(Object.create({ class: 'font-bold' }))).toBe('truncate font-bold')
+    expect(ui.label({})).toBe('truncate')
+  })
+})


### PR DESCRIPTION
Syncs upstream nuxt/ui commit [`4200e80`](https://github.com/nuxt/ui/commit/4200e80c03719d0b6e36e2d3957575bf1c24bc7d) — *perf(components): memoize tv slot invocations with simple args*.

## What
`wrapSlots` gains a per-slot `Map` cache so variant resolution + `twMerge` run **once per distinct input** rather than on every call (re-renders, table cells).

- **`isMemoizable()`** — a call is cacheable only when every prop value is a primitive or an array of primitives (depth-capped at 4). Objects (clsx class maps) and functions (replacers) bail to the uncached path. Non-finite numbers are rejected because `JSON.stringify` turns NaN/Infinity into `null`, colliding with a real `null` key that tv resolves differently.
- **`memoKey()`** — only plain objects are keyed: an exotic prototype could carry inherited enumerable props that tv reads but `JSON.stringify` drops, letting two different inputs share one entry.
- **`wrapSlots()`** — the cache lives on the invocation result, so a factory rebuild or variant-prop recompute starts fresh. `undefined` is a *real* slot result (tv returns it, not `''`, for a slot resolving to no classes), so a `has()` check backs up the `get()` miss. The cache clears at 500 entries to bound pathological dynamic inputs.

## b24ui port
- **`src/runtime/utils/tv.ts`** — applied **verbatim**. b24ui's `wrapSlots` was byte-identical to upstream's pre-change version (only comments differ: `:b24ui` / `app.config.b24ui` vs `:ui` / `app.config.ui`), and `findReplacer` / `applyReplacer` are unchanged, so the patch drops straight in. The two comment references were adapted to b24ui naming.
- **`test/utils/tv.spec.ts`** — appended the full 12-case `tv slot memoization` describe. b24ui's spec already declares the same permissive `tvt` helper those tests use, so they port unchanged.

## Tests
`tv` underpins **every** component's class resolution, so the full suite is the real verification: **5589 passed / 6 skipped** (up from 5565 by the 12 new cases × 2 projects) with **no snapshot drift** — confirming the memoized path returns identical output.

New coverage: cache hits, slots resolving to `undefined`, distinct-arg isolation, `undefined` vs absent keys, reordered keys, the NaN-vs-`null` collision, clsx-object and replacer bail-outs, cyclic arrays, the 500-entry bound, and inherited enumerable props.

## Verify (`CI=true`)
`lint` · `typecheck` · `test` · `build` — all green.

Ledger: cursor advanced to `4200e80`; previous entry `702f481` reconciled to PR #318.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JS8ypVfQSFzYVZzkTHhURb)_