### PR TITLE
chore(sync): defer upstream @takumi-rs/core v2 bump (a592f8e)

### DIFF
--- a/.sync/log/a592f8e3ca28e29c014ef3dc89c86f76ade9d681.md
+++ b/.sync/log/a592f8e3ca28e29c014ef3dc89c86f76ade9d681.md
@@ -1,0 +1,37 @@
+# Port: chore(deps): update dependency @takumi-rs/core to v2
+
+**Upstream:** `a592f8e3ca28e29c014ef3dc89c86f76ade9d681` (nuxt/ui, #6720)
+**Decision:** deferred — blocked by b24ui's pinned `nuxt-og-image`
+
+## Upstream change
+`docs/package.json`: `@takumi-rs/core` `^1.8.7` → `^2.5.4` (major), plus the
+lockfile. Nothing else — no source or config changes.
+
+## b24ui port
+**Not applied.** b24ui carries the same `^1.8.7`, but the package only exists
+here to serve `nuxt-og-image`, and the fork pins that module to a release that
+requires the v1 line:
+
+- `nuxt-og-image@6.5.3` (pinned via `pnpm-workspace.yaml` `overrides`, added by
+  b24ui's own PR #245) declares `"@takumi-rs/core": "^1.7.0"`.
+- Upstream can take v2 because it is on `nuxt-og-image: ^6.7.4`, unpinned.
+- b24ui's `docs/package.json` asks for `^6.6.0` and the override then holds it
+  at `6.5.3` — the same "b24ui is behind on nuxt-og-image" divergence already
+  recorded when skipping the `nuxt-og-image` bumps in `2a4218b`.
+
+Bumping the direct dependency to `^2.5.4` while the only consumer wants `^1.7.0`
+would either break the peer or install both majors of a native package, for no
+gain:
+
+- **b24ui does not use takumi directly.** There is no `import … from
+  '@takumi-rs/*'` anywhere in the repo; every reference is a *commented-out*
+  `defineOgImage('Docs.takumi')` / `defineOgImage('Component.takumi')` call in
+  `showcase.vue`, `templates.vue` and `docs/[...slug]/index.vue`. The takumi OG
+  renderer isn't even active in b24ui's docs.
+
+Cursor advanced; the bump is a follow-up to whenever b24ui upgrades
+`nuxt-og-image` (unpinning `6.5.3` and moving past `^6.6.0`), at which point
+this becomes a plain manifest edit.
+
+## Tests
+No change. Suite unchanged: 5589 passed / 6 skipped.

--- a/.sync/nuxt-ui.json
+++ b/.sync/nuxt-ui.json
@@ -2,7 +2,7 @@
   "upstream": "nuxt/ui",
   "branch": "v4",
   "sync_enabled": false,
-  "cursor": "4200e80c03719d0b6e36e2d3957575bf1c24bc7d",
+  "cursor": "a592f8e3ca28e29c014ef3dc89c86f76ade9d681",
   "_cursor_note": "cursor = last upstream commit ported into b24ui (oldest-first, manual cadence). sync_enabled stays false until Phase 2 (porter workflow #67 + CLAUDE_CODE_OAUTH_TOKEN) is wired and trusted. `processed` is maintained per port from now on (backfilled #68-#72 on 2026-06-09).",
   "stats": {
     "queue_depth": 0,
@@ -1253,10 +1253,16 @@
       "summary": "docs(input-rating): remove stray defaultValue line in size — the ### Size example's ::component-code front matter had a stray '- defaultValue' hanging off the end of items.size, making it a malformed mapping/sequence mix and offering defaultValue as a selectable size value (it is already covered by the block's ignore: list). b24ui carried the identical defect (InputRating arrived via the fork's own PR #283 from the same source example); removed verbatim. Docs-only."
     },
     "4200e80c03719d0b6e36e2d3957575bf1c24bc7d": {
-      "pr": null,
-      "b24ui_sha": "pending-merge",
+      "pr": 319,
+      "b24ui_sha": "152774a795c694342dc2f2e77d999308d6fd2ab2",
       "decision": "port",
       "summary": "perf(components): memoize tv slot invocations with simple args — wrapSlots gains a per-slot Map cache so variant resolution + twMerge run once per distinct input (re-renders, table cells). isMemoizable() accepts primitives and arrays of primitives (depth-capped 4), rejects non-finite numbers (JSON.stringify turns NaN/Infinity into null, colliding with a real null key tv resolves differently), and bails on objects (clsx maps) / functions (replacers). memoKey() only keys plain objects (an exotic prototype could carry inherited enumerable props tv reads but stringify drops). undefined is a real slot result so a has() check backs the get() miss; cache clears at 500 entries. Applied verbatim — b24ui's wrapSlots was byte-identical to upstream's pre-change version (only :b24ui/app.config.b24ui comment naming differs). Appended the full 12-case memoization describe to test/utils/tv.spec.ts (b24ui already declares the same tvt helper). Tests 5565 -> 5589 (+12 x2 projects), no snapshot drift — memoized path returns identical output."
+    },
+    "a592f8e3ca28e29c014ef3dc89c86f76ade9d681": {
+      "pr": null,
+      "b24ui_sha": "pending-merge",
+      "decision": "deferred",
+      "summary": "chore(deps): update dependency @takumi-rs/core to v2 — docs/package.json ^1.8.7 -> ^2.5.4 (major) + lockfile, nothing else. NOT APPLIED: b24ui has the same ^1.8.7 but the package exists only to serve nuxt-og-image, which the fork pins to 6.5.3 via pnpm-workspace overrides (b24ui's own PR #245); that release declares '@takumi-rs/core': '^1.7.0'. Upstream can take v2 because it is on unpinned nuxt-og-image ^6.7.4, while b24ui asks ^6.6.0 and holds 6.5.3 — the same 'behind on nuxt-og-image' divergence recorded when skipping its bumps in 2a4218b. Bumping the direct dep while the only consumer wants ^1.7.0 would break the peer or install both majors of a native package for no gain: b24ui has NO direct takumi imports — every reference is a commented-out defineOgImage('Docs.takumi'/'Component.takumi') in showcase.vue, templates.vue and docs/[...slug]/index.vue, so the takumi OG renderer isn't even active. Follow-up once nuxt-og-image is upgraded/unpinned; then it's a plain manifest edit."
     }
   }
 }


### PR DESCRIPTION
Syncs upstream nuxt/ui commit [`a592f8e`](https://github.com/nuxt/ui/commit/a592f8e3ca28e29c014ef3dc89c86f76ade9d681) — *chore(deps): update dependency @takumi-rs/core to v2* (#6720), which bumps `docs/package.json` `@takumi-rs/core` `^1.8.7` → `^2.5.4` (major) plus the lockfile.

> **Follow-up tracked in #321** — the `nuxt-og-image` upgrade that unblocks this bump.

## Decision: deferred
b24ui carries the same `^1.8.7`, but the package exists here **only to serve `nuxt-og-image`**, and the fork pins that module to a release requiring the v1 line:

- **`nuxt-og-image@6.5.3`** — pinned in `pnpm-workspace.yaml` `overrides` (added by b24ui's own PR #245) — declares `"@takumi-rs/core": "^1.7.0"`.
- Upstream can take v2 because it's on **`nuxt-og-image: ^6.7.4`, unpinned**. b24ui's `docs/package.json` asks for `^6.6.0` and the override then holds `6.5.3` — the same *"behind on nuxt-og-image"* divergence already recorded when its bumps were skipped in [`2a4218b`](https://github.com/bitrix24/b24ui/pull/295).

Bumping the direct dependency while its only consumer wants `^1.7.0` would either break the peer or install **both majors of a native package**, for no gain:

- **b24ui has no direct takumi imports.** There is no `import … from '@takumi-rs/*'` anywhere in the repo — every reference is a *commented-out* `defineOgImage('Docs.takumi')` / `defineOgImage('Component.takumi')` call in `showcase.vue`, `templates.vue` and `docs/[...slug]/index.vue`. The takumi OG renderer isn't even active in b24ui's docs.

Ledger-only: cursor advanced to `a592f8e`; previous entry `4200e80` reconciled to PR #319.

**Unblocking is tracked in #321** — upgrade `nuxt-og-image` past the `6.5.3` pin (together with the adjacent `nuxtseo-shared: 5.2.6`), after which this becomes a plain manifest edit. That issue also raises whether `@takumi-rs/core` should simply be dropped from `docs/package.json`, since the renderer is unused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)