### PR TITLE
docs: use content native sqlite connector (3a19e23)

### DIFF
--- a/.sync/log/3a19e23631d5700200c978472d8ab7bdda9cdd89.md
+++ b/.sync/log/3a19e23631d5700200c978472d8ab7bdda9cdd89.md
@@ -1,0 +1,46 @@
+# Port: docs: use content native sqlite connector
+
+**Upstream:** `3a19e23631d5700200c978472d8ab7bdda9cdd89` (nuxt/ui, #6792)
+**Decision:** port — verbatim
+
+## Upstream change
+Switches `@nuxt/content` from the `better-sqlite3` native addon to Node's
+built-in `node:sqlite`:
+- `docs/nuxt.config.ts` — adds `content.experimental.sqliteConnector: 'native'`.
+- `docs/package.json` — drops the direct `better-sqlite3` dependency.
+
+## b24ui port
+Applied verbatim; b24ui was in the identical pre-change state.
+
+- **`docs/nuxt.config.ts`** — added the `experimental: { sqliteConnector:
+  'native' }` block as a sibling of the existing `content.build` config.
+- **`docs/package.json`** — removed `"better-sqlite3": "^12.11.1"`.
+
+Notes:
+- `better-sqlite3` still appears in the lockfile: `@nuxt/content` keeps it as a
+  transitive dependency, exactly as upstream. Only the direct entry is gone.
+- The `allowBuilds: better-sqlite3: true` entry in `pnpm-workspace.yaml` was
+  left alone — upstream didn't touch its equivalent in this commit, and the
+  entry is inert once nothing builds the addon.
+- **Node requirement:** `node:sqlite` landed in Node 22.5. b24ui's `engines`
+  allows `^20.19.0 || >=22.12.0`, so a Node 20 contributor building the docs
+  locally would not have it — but the docs app isn't shipped, and both
+  workflows that build it are new enough (`ci.yml` on node 24 since `c4b786c`,
+  `deploy.yml` on node 22).
+
+## Tests
+The unit suite doesn't touch the content DB, and the `ci` gate never builds the
+docs site — only the deploy workflow (`docs:full:generate`) does, so a broken
+connector would surface only after merge. Verified locally instead by running
+the real thing on Node v22.22.2 (the deploy's version) with the deploy's env
+and `NODE_OPTIONS=--max-old-space-size=8192`:
+
+```
+[nitro] Prerendered 1240 routes in 228.509 seconds
+GEN-EXIT:0
+```
+
+Suite unchanged: 5589 passed / 6 skipped.
+
+## Verify (CI=true)
+`dev:prepare` · `lint` · `typecheck` · `test` · `build` · `docs:generate` — all green.

--- a/.sync/nuxt-ui.json
+++ b/.sync/nuxt-ui.json
@@ -2,7 +2,7 @@
   "upstream": "nuxt/ui",
   "branch": "v4",
   "sync_enabled": false,
-  "cursor": "a592f8e3ca28e29c014ef3dc89c86f76ade9d681",
+  "cursor": "3a19e23631d5700200c978472d8ab7bdda9cdd89",
   "_cursor_note": "cursor = last upstream commit ported into b24ui (oldest-first, manual cadence). sync_enabled stays false until Phase 2 (porter workflow #67 + CLAUDE_CODE_OAUTH_TOKEN) is wired and trusted. `processed` is maintained per port from now on (backfilled #68-#72 on 2026-06-09).",
   "stats": {
     "queue_depth": 0,
@@ -1259,10 +1259,17 @@
       "summary": "perf(components): memoize tv slot invocations with simple args — wrapSlots gains a per-slot Map cache so variant resolution + twMerge run once per distinct input (re-renders, table cells). isMemoizable() accepts primitives and arrays of primitives (depth-capped 4), rejects non-finite numbers (JSON.stringify turns NaN/Infinity into null, colliding with a real null key tv resolves differently), and bails on objects (clsx maps) / functions (replacers). memoKey() only keys plain objects (an exotic prototype could carry inherited enumerable props tv reads but stringify drops). undefined is a real slot result so a has() check backs the get() miss; cache clears at 500 entries. Applied verbatim — b24ui's wrapSlots was byte-identical to upstream's pre-change version (only :b24ui/app.config.b24ui comment naming differs). Appended the full 12-case memoization describe to test/utils/tv.spec.ts (b24ui already declares the same tvt helper). Tests 5565 -> 5589 (+12 x2 projects), no snapshot drift — memoized path returns identical output."
     },
     "a592f8e3ca28e29c014ef3dc89c86f76ade9d681": {
+      "pr": 320,
+      "b24ui_sha": "4b63c4204d80214d421992edce4926bb59642818",
+      "decision": "deferred",
+      "summary": "chore(deps): update dependency @takumi-rs/core to v2 — docs/package.json ^1.8.7 -> ^2.5.4 (major) + lockfile, nothing else. NOT APPLIED: b24ui has the same ^1.8.7 but the package exists only to serve nuxt-og-image, which the fork pins to 6.5.3 via pnpm-workspace overrides (b24ui's own PR #245); that release declares '@takumi-rs/core': '^1.7.0'. Upstream can take v2 because it is on unpinned nuxt-og-image ^6.7.4, while b24ui asks ^6.6.0 and holds 6.5.3 — the same 'behind on nuxt-og-image' divergence recorded when skipping its bumps in 2a4218b. Bumping the direct dep while the only consumer wants ^1.7.0 would break the peer or install both majors of a native package for no gain: b24ui has NO direct takumi imports — every reference is a commented-out defineOgImage('Docs.takumi'/'Component.takumi') in showcase.vue, templates.vue and docs/[...slug]/index.vue, so the takumi OG renderer isn't even active. Follow-up once nuxt-og-image is upgraded/unpinned; then it's a plain manifest edit.",
+      "issue": 321
+    },
+    "3a19e23631d5700200c978472d8ab7bdda9cdd89": {
       "pr": null,
       "b24ui_sha": "pending-merge",
-      "decision": "deferred",
-      "summary": "chore(deps): update dependency @takumi-rs/core to v2 — docs/package.json ^1.8.7 -> ^2.5.4 (major) + lockfile, nothing else. NOT APPLIED: b24ui has the same ^1.8.7 but the package exists only to serve nuxt-og-image, which the fork pins to 6.5.3 via pnpm-workspace overrides (b24ui's own PR #245); that release declares '@takumi-rs/core': '^1.7.0'. Upstream can take v2 because it is on unpinned nuxt-og-image ^6.7.4, while b24ui asks ^6.6.0 and holds 6.5.3 — the same 'behind on nuxt-og-image' divergence recorded when skipping its bumps in 2a4218b. Bumping the direct dep while the only consumer wants ^1.7.0 would break the peer or install both majors of a native package for no gain: b24ui has NO direct takumi imports — every reference is a commented-out defineOgImage('Docs.takumi'/'Component.takumi') in showcase.vue, templates.vue and docs/[...slug]/index.vue, so the takumi OG renderer isn't even active. Follow-up once nuxt-og-image is upgraded/unpinned; then it's a plain manifest edit."
+      "decision": "port",
+      "summary": "docs: use content native sqlite connector — switches @nuxt/content from the better-sqlite3 native addon to Node's built-in node:sqlite: docs/nuxt.config.ts gains content.experimental.sqliteConnector:'native', docs/package.json drops the direct better-sqlite3 dep. Applied verbatim (b24ui was in the identical pre-change state). better-sqlite3 remains in the lockfile transitively via @nuxt/content, same as upstream; the inert allowBuilds:better-sqlite3 entry in pnpm-workspace was left alone (upstream didn't touch its equivalent). node:sqlite landed in Node 22.5 — b24ui engines allow ^20.19.0 so a Node 20 contributor lacks it, but the docs app isn't shipped and both building workflows are new enough (ci.yml node 24 since c4b786c, deploy.yml node 22). VERIFICATION: the ci gate never builds the docs site (only deploy's docs:full:generate does), so ran the real thing locally on Node v22.22.2 with the deploy env — Prerendered 1240 routes in 228.5s, exit 0. Tests 5589."
     }
   }
 }

--- a/docs/nuxt.config.ts
+++ b/docs/nuxt.config.ts
@@ -293,6 +293,9 @@ export default defineNuxtConfig({
           langs: ['bash', 'ts', 'typescript', 'diff', 'vue', 'json', 'yml', 'css', 'mdc', 'blade', 'edge']
         }
       }
+    },
+    experimental: {
+      sqliteConnector: 'native'
     }
   },
 

--- a/docs/package.json
+++ b/docs/package.json
@@ -28,7 +28,6 @@
     "@tiptap/extension-text-align": "^3.29.0",
     "@vueuse/integrations": "^14.3.0",
     "ai": "^6.0.214",
-    "better-sqlite3": "^12.11.1",
     "capture-website": "^5.1.0",
     "fflate": "^0.8.3",
     "joi": "^18.2.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -380,9 +380,6 @@ importers:
       ai:
         specifier: ^6.0.214
         version: 6.0.214(zod@4.4.3)
-      better-sqlite3:
-        specifier: ^12.11.1
-        version: 12.11.1
       capture-website:
         specifier: ^5.1.0
         version: 5.1.0(supports-color@10.2.2)(typescript@6.0.3)
@@ -14481,6 +14478,7 @@ snapshots:
     dependencies:
       bindings: 1.5.0
       prebuild-install: 7.1.3
+    optional: true
 
   bindings@1.5.0:
     dependencies:
@@ -14495,6 +14493,7 @@ snapshots:
       buffer: 5.7.1
       inherits: 2.0.4
       readable-stream: 3.6.2
+    optional: true
 
   body-parser@2.2.2(supports-color@10.2.2):
     dependencies:
@@ -14554,6 +14553,7 @@ snapshots:
     dependencies:
       base64-js: 1.5.1
       ieee754: 1.2.1
+    optional: true
 
   buffer@6.0.3:
     dependencies:
@@ -14664,7 +14664,8 @@ snapshots:
     dependencies:
       readdirp: 5.0.0
 
-  chownr@1.1.4: {}
+  chownr@1.1.4:
+    optional: true
 
   chownr@3.0.0: {}
 
@@ -14988,7 +14989,8 @@ snapshots:
     dependencies:
       mimic-response: 3.1.0
 
-  deep-extend@0.6.0: {}
+  deep-extend@0.6.0:
+    optional: true
 
   deep-is@0.1.4: {}
 
@@ -15542,7 +15544,8 @@ snapshots:
       signal-exit: 4.1.0
       strip-final-newline: 3.0.0
 
-  expand-template@2.0.3: {}
+  expand-template@2.0.3:
+    optional: true
 
   expect-type@1.3.0: {}
 
@@ -15789,7 +15792,8 @@ snapshots:
 
   fresh@2.0.0: {}
 
-  fs-constants@1.0.0: {}
+  fs-constants@1.0.0:
+    optional: true
 
   fsevents@2.3.3:
     optional: true
@@ -15859,7 +15863,8 @@ snapshots:
     dependencies:
       git-up: 8.1.1
 
-  github-from-package@0.0.0: {}
+  github-from-package@0.0.0:
+    optional: true
 
   github-slugger@2.0.0: {}
 
@@ -17082,7 +17087,8 @@ snapshots:
 
   mitt@3.0.1: {}
 
-  mkdirp-classic@0.5.3: {}
+  mkdirp-classic@0.5.3:
+    optional: true
 
   mkdist@2.4.1(typescript@6.0.3)(vue-sfc-transformer@0.2.3(@volar/typescript@2.4.28)(@vue/compiler-core@3.5.40)(@vue/language-core@3.3.8)(esbuild@0.27.7)(rolldown@1.1.5)(typescript@6.0.3)(vue@3.5.40(typescript@6.0.3)))(vue-tsc@3.3.8(typescript@6.0.3))(vue@3.5.40(typescript@6.0.3)):
     dependencies:
@@ -17143,7 +17149,8 @@ snapshots:
 
   nanotar@0.3.0: {}
 
-  napi-build-utils@2.0.0: {}
+  napi-build-utils@2.0.0:
+    optional: true
 
   napi-postinstall@0.3.4: {}
 
@@ -17266,6 +17273,7 @@ snapshots:
   node-abi@3.89.0:
     dependencies:
       semver: 7.8.5
+    optional: true
 
   node-addon-api@7.1.1: {}
 
@@ -18872,6 +18880,7 @@ snapshots:
       simple-get: 4.0.1
       tar-fs: 2.1.4
       tunnel-agent: 0.6.0
+    optional: true
 
   prelude-ls@1.2.1: {}
 
@@ -19074,6 +19083,7 @@ snapshots:
       ini: 1.3.8
       minimist: 1.2.8
       strip-json-comments: 2.0.1
+    optional: true
 
   readable-stream@2.3.8:
     dependencies:
@@ -19090,6 +19100,7 @@ snapshots:
       inherits: 2.0.4
       string_decoder: 1.3.0
       util-deprecate: 1.0.2
+    optional: true
 
   readable-stream@4.7.0:
     dependencies:
@@ -19778,7 +19789,8 @@ snapshots:
 
   strip-indent@4.1.1: {}
 
-  strip-json-comments@2.0.1: {}
+  strip-json-comments@2.0.1:
+    optional: true
 
   strip-literal@3.1.0:
     dependencies:
@@ -19844,6 +19856,7 @@ snapshots:
       mkdirp-classic: 0.5.3
       pump: 3.0.4
       tar-stream: 2.2.0
+    optional: true
 
   tar-fs@3.1.2:
     dependencies:
@@ -19864,6 +19877,7 @@ snapshots:
       fs-constants: 1.0.0
       inherits: 2.0.4
       readable-stream: 3.6.2
+    optional: true
 
   tar-stream@3.1.8:
     dependencies:
@@ -19985,6 +19999,7 @@ snapshots:
   tunnel-agent@0.6.0:
     dependencies:
       safe-buffer: 5.2.1
+    optional: true
 
   type-check@0.4.0:
     dependencies:


### PR DESCRIPTION
Syncs upstream nuxt/ui commit [`3a19e23`](https://github.com/nuxt/ui/commit/3a19e23631d5700200c978472d8ab7bdda9cdd89) — *docs: use content native sqlite connector* (#6792).

## What
Switches `@nuxt/content` from the `better-sqlite3` native addon to Node's built-in `node:sqlite`:
- **`docs/nuxt.config.ts`** — adds `content.experimental.sqliteConnector: 'native'`.
- **`docs/package.json`** — drops the direct `better-sqlite3` dependency.

Applied **verbatim** — b24ui was in the identical pre-change state.

## Notes
- `better-sqlite3` still appears in the lockfile: `@nuxt/content` keeps it as a **transitive** dependency, exactly as upstream. Only the direct entry is gone.
- The `allowBuilds: better-sqlite3: true` entry in `pnpm-workspace.yaml` was left alone — upstream didn't touch its equivalent here, and it's inert once nothing builds the addon.
- **Node requirement:** `node:sqlite` landed in Node 22.5. b24ui's `engines` allows `^20.19.0 || >=22.12.0`, so a Node 20 contributor building the docs locally wouldn't have it — but the docs app isn't shipped, and both workflows that build it are new enough (`ci.yml` on node 24 since `c4b786c`, `deploy.yml` on node 22).

## ⚠️ Verification note
The unit suite never touches the content DB, and **the `ci` gate never builds the docs site** — only the deploy workflow (`docs:full:generate`) does, so a broken connector would surface *after* merge, in production. So this was verified by running the real thing locally on **Node v22.22.2** (the deploy's version) with the deploy's env and `NODE_OPTIONS=--max-old-space-size=8192`:

```
[nitro] Initializing prerenderer
[nitro] Prerendering 191 initial routes with crawler
[nitro] Prerendered 1240 routes in 228.509 seconds
GEN-EXIT:0
```

Suite unchanged: **5589 passed / 6 skipped**.

## Verify (`CI=true`)
`dev:prepare` · `lint` · `typecheck` · `test` · `build` · **`docs:generate`** — all green.

Ledger: cursor advanced to `3a19e23`; previous entry `a592f8e` reconciled to PR #320 (deferral tracked in #321).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JS8ypVfQSFzYVZzkTHhURb)_