### PR TITLE
chore(sync): no-op upstream codspeedhq/action v5 bump (6add5fb)

### DIFF
--- a/.sync/log/6add5fb7d8a1280dcbe2c4675e78d8f45f61e7fd.md
+++ b/.sync/log/6add5fb7d8a1280dcbe2c4675e78d8f45f61e7fd.md
@@ -1,0 +1,32 @@
+# Port: chore(deps): update codspeedhq/action action to v5
+
+**Upstream:** `6add5fb7d8a1280dcbe2c4675e78d8f45f61e7fd` (nuxt/ui, #6795)
+**Decision:** no-op
+
+## Upstream change
+One line in `.github/workflows/module.yml`:
+
+```diff
+-  uses: CodSpeedHQ/action@v4
++  uses: CodSpeedHQ/action@v5
+```
+
+## b24ui port
+**Not applicable**, exactly as predicted when `8aa8041` (the commit that
+introduced that workflow job) was recorded as a no-op in PR #316.
+
+b24ui has no CodSpeed integration to bump — verified: no occurrence of
+`CodSpeed` / `codspeed` anywhere in `.github/`, `package.json`,
+`vitest.config.ts` or `pnpm-workspace.yaml`, and its workflow inventory is just
+`ci.yml`, `deploy.yml`, `npm-publish.yml`.
+
+The upstream job it belongs to is itself gated with
+`if: github.repository_owner == 'nuxt'` ("Skip forks of the repo, they can't
+authenticate with CodSpeed"), so adopting the toolchain was declined for b24ui
+in the first place. See `.sync/log/8aa804167e5d4e8a618feb0a370e3481e223af8a.md`
+for the full reasoning.
+
+No-op — cursor advanced only.
+
+## Tests
+No change. Suite unchanged: 5589 passed / 6 skipped.

--- a/.sync/nuxt-ui.json
+++ b/.sync/nuxt-ui.json
@@ -2,7 +2,7 @@
   "upstream": "nuxt/ui",
   "branch": "v4",
   "sync_enabled": false,
-  "cursor": "3a19e23631d5700200c978472d8ab7bdda9cdd89",
+  "cursor": "6add5fb7d8a1280dcbe2c4675e78d8f45f61e7fd",
   "_cursor_note": "cursor = last upstream commit ported into b24ui (oldest-first, manual cadence). sync_enabled stays false until Phase 2 (porter workflow #67 + CLAUDE_CODE_OAUTH_TOKEN) is wired and trusted. `processed` is maintained per port from now on (backfilled #68-#72 on 2026-06-09).",
   "stats": {
     "queue_depth": 0,
@@ -1266,10 +1266,16 @@
       "issue": 321
     },
     "3a19e23631d5700200c978472d8ab7bdda9cdd89": {
-      "pr": null,
-      "b24ui_sha": "pending-merge",
+      "pr": 322,
+      "b24ui_sha": "345059ffe0ad998c2899df44dfb7bd77ec5b5a04",
       "decision": "port",
       "summary": "docs: use content native sqlite connector — switches @nuxt/content from the better-sqlite3 native addon to Node's built-in node:sqlite: docs/nuxt.config.ts gains content.experimental.sqliteConnector:'native', docs/package.json drops the direct better-sqlite3 dep. Applied verbatim (b24ui was in the identical pre-change state). better-sqlite3 remains in the lockfile transitively via @nuxt/content, same as upstream; the inert allowBuilds:better-sqlite3 entry in pnpm-workspace was left alone (upstream didn't touch its equivalent). node:sqlite landed in Node 22.5 — b24ui engines allow ^20.19.0 so a Node 20 contributor lacks it, but the docs app isn't shipped and both building workflows are new enough (ci.yml node 24 since c4b786c, deploy.yml node 22). VERIFICATION: the ci gate never builds the docs site (only deploy's docs:full:generate does), so ran the real thing locally on Node v22.22.2 with the deploy env — Prerendered 1240 routes in 228.5s, exit 0. Tests 5589."
+    },
+    "6add5fb7d8a1280dcbe2c4675e78d8f45f61e7fd": {
+      "pr": null,
+      "b24ui_sha": "pending-merge",
+      "decision": "no-op",
+      "summary": "chore(deps): update codspeedhq/action action to v5 — one line in .github/workflows/module.yml: CodSpeedHQ/action@v4 -> @v5. NOT APPLICABLE, as predicted when 8aa8041 (the commit introducing that job) was recorded as a no-op in PR #316: b24ui has no CodSpeed integration to bump — verified no occurrence of CodSpeed/codspeed anywhere in .github/, package.json, vitest.config.ts or pnpm-workspace.yaml, and its workflow inventory is only ci.yml/deploy.yml/npm-publish.yml. Upstream's own job is gated `if: github.repository_owner == 'nuxt'` ('Skip forks of the repo, they can't authenticate with CodSpeed'). No-op."
     }
   }
 }


### PR DESCRIPTION
Syncs upstream nuxt/ui commit [`6add5fb`](https://github.com/nuxt/ui/commit/6add5fb7d8a1280dcbe2c4675e78d8f45f61e7fd) — *chore(deps): update codspeedhq/action action to v5* (#6795), a one-line bump in `.github/workflows/module.yml`:

```diff
-  uses: CodSpeedHQ/action@v4
+  uses: CodSpeedHQ/action@v5
```

## Decision: no-op
**Not applicable**, exactly as predicted when [`8aa8041`](https://github.com/bitrix24/b24ui/pull/316) — the commit that introduced that workflow job — was recorded as a no-op.

b24ui has no CodSpeed integration to bump. Verified: **no occurrence** of `CodSpeed` / `codspeed` anywhere in `.github/`, `package.json`, `vitest.config.ts` or `pnpm-workspace.yaml`, and the workflow inventory is just `ci.yml`, `deploy.yml`, `npm-publish.yml`.

Upstream's own job is gated with `if: github.repository_owner == 'nuxt'` (*"Skip forks of the repo, they can't authenticate with CodSpeed"*), so adopting the toolchain was declined for b24ui in the first place — see PR #316 for the full reasoning.

Ledger-only: cursor advanced to `6add5fb` (upstream v4 HEAD at the start of this batch); previous entry `3a19e23` reconciled to PR #322.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JS8ypVfQSFzYVZzkTHhURb)_