### PR TITLE
feat(Timeline,Stepper): resolve model values through `valueKey` for numbers too

### DIFF
--- a/docs/content/docs/2.components/stepper.md
+++ b/docs/content/docs/2.components/stepper.md
@@ -47,7 +47,7 @@ props:
 Use the `items` prop as an array of objects with the following properties:
 
 - `title?: string`{lang="ts-type"}
-- `description?: AvatarProps`{lang="ts-type"}
+- `description?: string`{lang="ts-type"}
 - `content?: string`{lang="ts-type"}
 - [`icon?: IconComponent`{lang="ts-type"}](#with-controls)
 - `value?: string | number`{lang="ts-type"}
@@ -208,6 +208,8 @@ You can control the active item by using the `default-value` prop or the `v-mode
 
 ::tip
 Use the `value-key` prop to change the key used to match items when a `v-model` or `default-value` is provided.
+
+The value is matched against `value-key` on each item, whatever its type. A number keeps its positional meaning when the item at that position carries no `value-key` — so plain arrays keep working by index — and falls back to a position when it matches no item. Out-of-range numbers select nothing.
 ::
 
 ### With content slot

--- a/docs/content/docs/2.components/timeline.md
+++ b/docs/content/docs/2.components/timeline.md
@@ -57,7 +57,7 @@ Use the `items` prop as an array of objects with the following properties:
 
 - `date?: string`{lang="ts-type"}
 - `title?: string`{lang="ts-type"}
-- `description?: AvatarProps`{lang="ts-type"}
+- `description?: string`{lang="ts-type"}
 - [`icon?: IconComponent`{lang="ts-type"}](#with-alternating-layout)
 - `avatar?: AvatarProps`{lang="ts-type"}
 - `value?: string | number`{lang="ts-type"}
@@ -243,6 +243,8 @@ You can control the active item by using the `default-value` prop or the `v-mode
 
 ::tip
 Use the `value-key` prop to change the key used to match items when a `v-model` or `default-value` is provided.
+
+The value is matched against `value-key` on each item, whatever its type. A number keeps its positional meaning when the item at that position carries no `value-key` — so plain arrays keep working by index — and falls back to a position when it matches no item. Out-of-range numbers select nothing.
 ::
 
 ### With select event

--- a/src/runtime/components/Stepper.vue
+++ b/src/runtime/components/Stepper.vue
@@ -85,7 +85,7 @@ import { useAppConfig } from '#imports'
 import { useComponentProps } from '../composables/useComponentProps'
 import { useForwardProps } from '../composables/useForwardProps'
 import { tv } from '../utils/tv'
-import { get } from '../utils'
+import { get, itemValueIndex } from '../utils'
 
 const _props = withDefaults(defineProps<StepperProps<T>>(), {
   orientation: 'horizontal',
@@ -114,9 +114,25 @@ const currentStepIndex = computed({
   get() {
     const value = modelValue.value ?? props.defaultValue
 
-    return ((typeof value === 'string')
-      ? props.items.findIndex(item => get(item, props.valueKey as string) === value)
-      : value) ?? 0
+    if (value == null) return 0
+
+    // A number keeps its positional meaning while the item in that slot
+    // carries no `valueKey` — which is also what keeps `set()` round-trips
+    // stable, since it writes the index for exactly those items. Otherwise
+    // items are matched on `valueKey` first, any type; a number that matches
+    // nothing falls back to its position, everything else selects no step.
+    const count = props.items.length
+    const position = typeof value === 'number' ? value : -1
+    const inRange = position >= 0 && position < count
+
+    if (inRange && get(props.items[position] as Record<string, any>, props.valueKey as string) === undefined) {
+      return position
+    }
+
+    const matched = itemValueIndex(props.items, value, props.valueKey as string)
+    if (matched !== -1) return matched
+
+    return inRange ? position : -1
   },
   set(value: number) {
     modelValue.value = get(props.items?.[value], props.valueKey as string) ?? value

--- a/src/runtime/components/Timeline.vue
+++ b/src/runtime/components/Timeline.vue
@@ -76,7 +76,7 @@ import { Primitive, Separator } from 'reka-ui'
 import { useAppConfig } from '#imports'
 import { useComponentProps } from '../composables/useComponentProps'
 import { tv } from '../utils/tv'
-import { get } from '../utils'
+import { get, itemValueIndex } from '../utils'
 import B24Avatar from './Avatar.vue'
 
 const _props = withDefaults(defineProps<TimelineProps<T>>(), {
@@ -103,15 +103,24 @@ const b24ui = computed(() => tv({ extend: theme, ...(appConfig.b24ui?.timeline |
 const currentStepIndex = computed(() => {
   const value = modelValue.value ?? props.defaultValue
 
-  if (typeof value === 'string') {
-    return props.items.findIndex(item => get(item, props.valueKey as string) === value) ?? -1
+  if (value == null) return -1
+
+  // A number keeps its positional meaning while the item in that slot carries
+  // no `valueKey`; otherwise items are matched on `valueKey` first, with a
+  // number that matches nothing falling back to its position. Out-of-range
+  // numbers select nothing.
+  const count = props.items.length
+  const position = typeof value === 'number' ? (props.reverse ? count - 1 - value : value) : -1
+  const inRange = position >= 0 && position < count
+
+  if (inRange && get(props.items[position] as Record<string, any>, props.valueKey as string) === undefined) {
+    return position
   }
 
-  if (props.reverse) {
-    return value != null ? props.items.length - 1 - value : -1
-  } else {
-    return value ?? -1
-  }
+  const matched = itemValueIndex(props.items, value, props.valueKey as string)
+  if (matched !== -1) return matched
+
+  return inRange ? position : -1
 })
 
 function getItemState(index: number): 'active' | 'completed' | undefined {

--- a/src/runtime/utils/index.ts
+++ b/src/runtime/utils/index.ts
@@ -61,6 +61,14 @@ export function set(object: Record<string, any>, path: (string | number)[] | str
   }, object)
 }
 
+/**
+ * Index of the first item whose `valueKey` field strictly equals `value`.
+ * Timeline and Stepper resolve their active item through this.
+ */
+export function itemValueIndex<T>(items: T[], value: unknown, valueKey: string): number {
+  return items.findIndex(item => get(item as Record<string, any>, valueKey) === value)
+}
+
 export function looseToNumber(val: any): any {
   const n = Number.parseFloat(val)
   return Number.isNaN(n) ? val : n

--- a/test/components/Stepper.spec.ts
+++ b/test/components/Stepper.spec.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from 'vitest'
+import { nextTick } from 'vue'
 import { axe } from 'vitest-axe'
 import { mountSuspended } from '@nuxt/test-utils/runtime'
 import { renderEach } from '../component-render'
@@ -61,5 +62,63 @@ describe('Stepper', () => {
     })
 
     expect(await axe(wrapper.element)).toHaveNoViolations()
+  })
+
+  describe('resolving the active step', () => {
+    // `set()` writes the model back through `valueKey`, so reading it back only
+    // for strings made the round trip lossy: a numeric `items[].value` was
+    // written out and then read as a position.
+    const numeric = [
+      { title: 'First', value: 10 },
+      { title: 'Second', value: 20 },
+      { title: 'Third', value: 30 }
+    ]
+
+    async function activeTitle(props: Record<string, unknown>) {
+      const wrapper = await mountSuspended(Stepper, { props: props as any })
+      return wrapper.element.querySelector('[data-state="active"]')?.textContent?.trim()
+    }
+
+    it('matches a numeric value against valueKey', async () => {
+      expect(await activeTitle({ items: numeric, modelValue: 20 })).toContain('Second')
+    })
+
+    it('matches a numeric defaultValue against valueKey', async () => {
+      expect(await activeTitle({ items: numeric, defaultValue: 30 })).toContain('Third')
+    })
+
+    it('falls back to a positional index when no item carries the value', async () => {
+      expect(await activeTitle({ items, modelValue: 1 })).toContain('Shipping')
+    })
+
+    it('still matches strings against valueKey', async () => {
+      const named = [{ title: 'A', value: 'a' }, { title: 'B', value: 'b' }]
+      expect(await activeTitle({ items: named, modelValue: 'b' })).toContain('B')
+    })
+
+    it('activates nothing when a string matches no item', async () => {
+      const named = [{ title: 'A', value: 'a' }, { title: 'B', value: 'b' }]
+      expect(await activeTitle({ items: named, modelValue: 'zzz' })).toBeUndefined()
+    })
+
+    it('keeps a number positional when the item in that slot has no value', async () => {
+      // The shape set() produces for value-less items: without the positional
+      // slot rule, Intro's `value: 1` would capture the write-back and clicks
+      // past it could never advance.
+      const mixed = [{ title: 'Intro', value: 1 }, { title: 'Details' }, { title: 'Done' }]
+      expect(await activeTitle({ items: mixed, modelValue: 1 })).toContain('Details')
+    })
+
+    it('clicking a step activates that step, not a value collision', async () => {
+      // set() writes the index for value-less items; the positional-slot rule
+      // is what keeps that write from being captured by Three's `value: 1`.
+      const items = [{ title: 'One' }, { title: 'Two' }, { title: 'Three', value: 1 }]
+      const wrapper = await mountSuspended(Stepper, { props: { items, linear: false } as any })
+
+      await wrapper.findAll('[data-slot="trigger"]')[1]!.trigger('mousedown')
+      await nextTick()
+
+      expect(wrapper.element.querySelector('[data-state="active"]')?.textContent?.trim()).toContain('Two')
+    })
   })
 })

--- a/test/components/Timeline.spec.ts
+++ b/test/components/Timeline.spec.ts
@@ -73,4 +73,77 @@ describe('Timeline', () => {
 
     expect(await axe(wrapper.element)).toHaveNoViolations()
   })
+
+  describe('resolving the active item', () => {
+    // `items[].value` and `defaultValue` are both typed `string | number`, so a
+    // numeric value has to be matched through `valueKey` like a string one.
+    // Matching used to run for strings only, which sent numbers straight to the
+    // positional branch and left numeric item values unreachable.
+    const numeric = [
+      { title: 'First', value: 10 },
+      { title: 'Second', value: 20 },
+      { title: 'Third', value: 30 }
+    ]
+
+    async function activeTitle(props: Record<string, unknown>) {
+      const wrapper = await mountSuspended(Timeline, { props: props as any })
+      return wrapper.element.querySelector('[data-state="active"]')?.textContent?.trim()
+    }
+
+    it('matches a numeric value against valueKey', async () => {
+      expect(await activeTitle({ items: numeric, modelValue: 20 })).toBe('Second')
+    })
+
+    it('matches a numeric defaultValue against valueKey', async () => {
+      expect(await activeTitle({ items: numeric, defaultValue: 30 })).toBe('Third')
+    })
+
+    it('matches a numeric value through a custom valueKey', async () => {
+      const items = [{ title: 'A', step: 1 }, { title: 'B', step: 2 }]
+      expect(await activeTitle({ items, valueKey: 'step', modelValue: 2 })).toBe('B')
+    })
+
+    it('falls back to a positional index when no item carries the value', async () => {
+      // Items without a `value` field — the shape most of the docs examples use.
+      const plain = [{ title: 'First' }, { title: 'Second' }, { title: 'Third' }]
+      expect(await activeTitle({ items: plain, modelValue: 1 })).toBe('Second')
+    })
+
+    it('still matches strings against valueKey', async () => {
+      expect(await activeTitle({ items, modelValue: 'design' })).toContain('Design Phase')
+    })
+
+    it('activates nothing when a string matches no item', async () => {
+      expect(await activeTitle({ items, modelValue: 'nope' })).toBeUndefined()
+    })
+
+    it('keeps a number positional when the item in that slot has no value', async () => {
+      // Mixed arrays: the slot the number points at opted out of values, so
+      // C's `value: 1` must not capture it.
+      const mixed = [{ title: 'A' }, { title: 'B' }, { title: 'C', value: 1 }]
+      expect(await activeTitle({ items: mixed, modelValue: 1 })).toBe('B')
+    })
+
+    it('activates nothing for an out-of-range number', async () => {
+      const plain = [{ title: 'First' }, { title: 'Second' }, { title: 'Third' }]
+      expect(await activeTitle({ items: plain, modelValue: 5 })).toBeUndefined()
+      expect(await activeTitle({ items: plain, reverse: true, modelValue: 5 })).toBeUndefined()
+    })
+
+    it('does not reverse-flip an index that matched valueKey directly', async () => {
+      expect(await activeTitle({ items: numeric, reverse: true, modelValue: 20 })).toBe('Second')
+    })
+
+    it('applies the reverse flip only to the positional fallback', async () => {
+      const plain = [{ title: 'First' }, { title: 'Second' }, { title: 'Third' }]
+      expect(await activeTitle({ items: plain, reverse: true, modelValue: 0 })).toBe('Third')
+    })
+
+    it('matches a zero value against valueKey, not just truthy ones', async () => {
+      // Zero deliberately sits away from position 0, so a positional read
+      // cannot masquerade as a match.
+      const withZero = [{ title: 'A', value: 10 }, { title: 'Zero', value: 0 }, { title: 'C', value: 30 }]
+      expect(await activeTitle({ items: withZero, modelValue: 0 })).toBe('Zero')
+    })
+  })
 })


### PR DESCRIPTION
### Linked issue

Resolves #310

### Type of change

- [ ] Documentation (updates to the documentation or readme)
- [ ] Bug fix (a non-breaking change that fixes an issue)
- [x] Enhancement (improving an existing functionality)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Chore (updates to the build process or auxiliary tools and libraries)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Retyped from `fix` to `feat` after review** — issue #310 itself said this variant "belongs in a minor release", and release-please will now derive the bump from the commit type. For one shape of input the meaning of a numeric model changes deliberately; see the behaviour note.

### Description

`items[].value` and `defaultValue` are both typed `string | number`, and the `value-key` docs say the key is used to match items. Matching only ever ran for strings; numbers went straight to positional indexing. So a numeric `items[].value` could never be selected — with `[{ value: 10 }, { value: 20 }]` a model of `20` resolved to index 20 and highlighted nothing. The mirror case produced the issue report itself: a string against items with **no** `value` field silently resolves to `-1`, which is the shape most docs examples use, so "only numbers work" was the natural reading.

### The resolution rule (second cut, after review)

The first cut matched unconditionally, and the review round proved **three regressions** empirically — mounted probes, not speculation:

- mixed arrays flipped to the value carrier: `[{A}, {B}, {C, value: 1}]` with model `1` activated C instead of B;
- Stepper's `set()`/`get()` round trip looped: `set()` writes the index for value-less items, `get()` re-captured that number as another item's value — `next()` teleported past steps, `prev()` became a no-op, some steps unreachable by click;
- an unmatched string in Stepper started activating step 0 where it used to activate nothing.

The rule that survives review:

1. **a number keeps its positional meaning while the item in that slot carries no `valueKey`** — plain arrays and Stepper's index write-backs stay stable;
2. otherwise items are matched on `valueKey`, any type;
3. a number that matches nothing falls back to its position, in range only;
4. anything else selects nothing — which also preserves Stepper's old `-1` for unmatched strings and turns the out-of-range artifact (every item rendering "completed", present since before this change) into "nothing selected".

The matching predicate lives in `utils` as `itemValueIndex()`, beside `compare()` and `get()` — one home for the semantics, per the reuse finding.

**Behaviour note for release notes:** in fully-valued arrays a number now selects the item carrying that value, not the position. Arrays with duplicated values resolve to the first carrier, exactly as strings always have.

### Verification

Break-verified in both directions, not assumed:

| mutation | expected | observed |
| --- | --- | --- |
| remove the positional-slot rule | mixed + round-trip specs fail | exactly those 3 fail |
| restore strings-only matching (the #310 bug) | numeric-matching specs fail | exactly those 5 fail |
| intact | all green | **80/80**, snapshots byte-identical |

`vue-tsc --noEmit` clean, `eslint` clean. The round-trip spec is DOM-driven (clicks the trigger) rather than poking `vm`, so it exercises the real reka-ui path.

### Docs

`description` was listed as `AvatarProps` on **both** component pages — copy-paste from the `avatar` line below it; it is and always was `string`. The `value-key` tip now states the resolution rule above, including that out-of-range numbers select nothing.

### Upstream

`nuxt/ui@v4` carries the same strings-only logic and the same docs typo, line for line. Per maintainer, not raised there — worth remembering when reviewing sync PRs, since a sync could reintroduce both.

### Checklist

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.