### PR TITLE
docs(content): using @nuxt/content in a client-only app

### DIFF
--- a/docs/content/docs/1.getting-started/2.installation/1.nuxt.md
+++ b/docs/content/docs/1.getting-started/2.installation/1.nuxt.md
@@ -306,3 +306,29 @@ export default defineNuxtConfig({
 ::note
 When providing an array of component names, automatic detection is enabled and these components (along with their dependencies) are guaranteed to be included. This is useful for dynamic components like `<component :is="..." />` that can't be statically analyzed.
 ::
+
+## Using `@nuxt/content` in an SPA
+
+Bitrix24 UI's `<Prose>` and `<B24Content>` components work in a client-only app (`ssr: false`{lang="ts-type"}) exactly as they do with server rendering. Nuxt Content runs its database in the browser through WASM SQLite: on the first query it downloads a dump from `/__nuxt_content/<collection>/sql_dump.txt` and answers everything locally from there. Nothing about markdown rendering is disabled in this mode.
+
+What it does need is a working SQLite adapter **at build time** — the browser half only consumes a dump that the build produces. With pnpm that is the step most likely to be missing, because pnpm 10 and 11 do not run native install scripts by default:
+
+```yaml [pnpm-workspace.yaml]
+allowBuilds:
+  better-sqlite3: true
+```
+
+::note
+In pnpm 11 this is no longer read from `package.json`: the `pnpm.onlyBuiltDependencies` key moved to `pnpm-workspace.yaml`, and the warning about it is easy to miss in the install output. Without the native binding the build fails with `Could not locate the bindings file`, and no content reaches the page.
+::
+
+If a page renders nothing at all and the console stays silent, check what the query returns before suspecting the renderer — a path filter that matches no document returns an empty result rather than an error:
+
+```vue
+<script setup lang="ts">
+const { data: all } = await useAsyncData('all', () => queryCollection('docs').all())
+// `content/index.md` has the path `/`, not `/index`
+console.log(all.value?.length, all.value?.map(item => item.path))
+</script>
+```
+

--- a/docs/content/docs/1.getting-started/2.installation/1.nuxt.md
+++ b/docs/content/docs/1.getting-started/2.installation/1.nuxt.md
@@ -268,6 +268,10 @@ export default defineNuxtConfig({
 })
 ```
 
+::note{to="/docs/getting-started/integrations/content/#client-only-apps-spa"}
+`@nuxt/content` is supported in client-only apps (`ssr: false`{lang="ts-type"}) too, but the build needs a SQLite adapter for it.
+::
+
 ### `experimental.componentDetection`
 
 Use the `experimental.componentDetection` option to enable automatic component detection for tree-shaking. This feature scans your source code to detect which components are actually used and only generates the necessary CSS for those components (including their dependencies).
@@ -306,29 +310,4 @@ export default defineNuxtConfig({
 ::note
 When providing an array of component names, automatic detection is enabled and these components (along with their dependencies) are guaranteed to be included. This is useful for dynamic components like `<component :is="..." />` that can't be statically analyzed.
 ::
-
-## Using `@nuxt/content` in an SPA
-
-Bitrix24 UI's `<Prose>` and `<B24Content>` components work in a client-only app (`ssr: false`{lang="ts-type"}) exactly as they do with server rendering. Nuxt Content runs its database in the browser through WASM SQLite: on the first query it downloads a dump from `/__nuxt_content/<collection>/sql_dump.txt` and answers everything locally from there. Nothing about markdown rendering is disabled in this mode.
-
-What it does need is a working SQLite adapter **at build time** — the browser half only consumes a dump that the build produces. With pnpm that is the step most likely to be missing, because pnpm 10 and 11 do not run native install scripts by default:
-
-```yaml [pnpm-workspace.yaml]
-allowBuilds:
-  better-sqlite3: true
-```
-
-::note
-In pnpm 11 this is no longer read from `package.json`: the `pnpm.onlyBuiltDependencies` key moved to `pnpm-workspace.yaml`, and the warning about it is easy to miss in the install output. Without the native binding the build fails with `Could not locate the bindings file`, and no content reaches the page.
-::
-
-If a page renders nothing at all and the console stays silent, check what the query returns before suspecting the renderer — a path filter that matches no document returns an empty result rather than an error:
-
-```vue
-<script setup lang="ts">
-const { data: all } = await useAsyncData('all', () => queryCollection('docs').all())
-// `content/index.md` has the path `/`, not `/index`
-console.log(all.value?.length, all.value?.map(item => item.path))
-</script>
-```
 

--- a/docs/content/docs/1.getting-started/6.integrations/5.content.md
+++ b/docs/content/docs/1.getting-started/6.integrations/5.content.md
@@ -77,6 +77,71 @@ You can also use glob patterns to be more specific about which files to scan:
 Learn more about Tailwind's automatic content detection and best practices for optimizing build performance.
 ::
 
+## Client-only apps (SPA)
+
+Prose components work in a client-only app (`ssr: false`{lang="ts-type"}) exactly as they do with server rendering — nothing about markdown rendering is disabled in this mode. Nuxt Content moves its database into the browser instead: on the first query the client downloads a dump from `/__nuxt_content/<collection>/sql_dump.txt` and answers every query locally through WASM SQLite.
+
+::caution
+That dump is the **whole collection**, not just the pages you link to, and it is cached in `localStorage`. Anything you put in a collection that a client-rendered page queries is readable by every visitor, so keep drafts and non-public documents in a separate collection.
+::
+
+### The build still needs SQLite
+
+The dump is produced at build time, so the build needs a working SQLite adapter even though the deployed app never runs one. This is where a client-only build usually breaks: the default adapter, `better-sqlite3`, is a native module that has to be compiled during install. Without it the build fails with `Could not locate the bindings file` and produces no dump, so no content reaches the page.
+
+On Node.js 22.5 or later you can skip the native binding entirely and use Node's built-in `node:sqlite`. One line, no compiler, nothing package-manager specific:
+
+```ts [nuxt.config.ts]
+export default defineNuxtConfig({
+  content: {
+    experimental: {
+      sqliteConnector: 'native'
+    }
+  }
+})
+```
+
+This is what this documentation site is built with.
+
+On older Node.js `better-sqlite3` has to compile, and pnpm does not run a dependency's install scripts unless you say so:
+
+```yaml [pnpm-workspace.yaml]
+allowBuilds:
+  better-sqlite3: true
+```
+
+Running `pnpm approve-builds` writes that entry for you, which is the version-proof way to do it — pnpm 11 removed the older `onlyBuiltDependencies` and `ignoredBuiltDependencies` settings in favour of this map. It also fails the install outright with `ERR_PNPM_IGNORED_BUILDS`; pnpm 10 lets the install succeed and only prints a note, so that is the version where this is easy to miss. Approve the one package you need rather than reaching for `pnpm approve-builds --all` or `dangerouslyAllowAllBuilds`: an install script runs arbitrary code on your machine and in CI, which is what that default protects you from.
+
+npm and yarn run install scripts by default, so a `better-sqlite3` failure there is a missing C++ toolchain rather than a blocked script — install one, or switch the connector as above.
+
+::note{to="https://content.nuxt.com/docs/getting-started/configuration" target="_blank"}
+See the Nuxt Content configuration reference for the full list of SQLite connectors.
+::
+
+### When a page renders nothing
+
+Work outwards from the build — each step has a different answer:
+
+1. **Is the dump in the output?** Look for `.output/public/__nuxt_content/<collection>/sql_dump.txt` after a build. If it is missing, the build never produced it, and the SQLite adapter above is where to look.
+2. **Does the browser get it?** The Network tab should show that file being fetched on the first query. A 404 there usually means the site is served from a sub-path that `app.baseURL` does not account for.
+3. **Does the query match anything?** That fetch throws rather than returning nothing, so a missing dump surfaces in `error`, not in `data`. An empty `data` with no error is a different problem, usually a path filter that matches no document.
+
+```vue
+<script setup lang="ts">
+// `content` is the default collection name — use yours if you renamed it
+const { data: all, error } = await useAsyncData('all', () => queryCollection('content').all())
+
+// `content/index.md` has the path `/`, not `/index`
+if (import.meta.dev) {
+  console.log(error.value, all.value?.length, all.value?.map(item => item.path))
+}
+</script>
+```
+
+::note
+Collections marked `private: true`{lang="ts-type"} are deliberately left out of the browser dump and go through a server route instead, so they need a running server — a fully static export cannot answer them.
+::
+
 ## Components
 
 You might be using `@nuxt/content` to build a documentation. To help you with that, we've built some components that you can use in your pages:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -43,6 +43,11 @@ overrides:
   'fast-uri@^3.0.0': ^3.1.5
 
 allowBuilds:
+  # `docs` no longer needs this one — it runs @nuxt/content on the `native`
+  # (node:sqlite) connector since #322 — but better-sqlite3 is still pulled in
+  # transitively and is still the default connector for everyone else, which is
+  # why the integrations/content page tells readers to allow exactly this
+  # package. Removing the entry here would quietly contradict that page.
   better-sqlite3: true
   puppeteer: true
   sharp: true


### PR DESCRIPTION
### Linked issue

Refs #332 — the question landed here rather than upstream, so the answer belongs in our docs.

### Type of change

- [x] Documentation (updates to the documentation or readme)
- [ ] Bug fix (a non-breaking change that fixes an issue)
- [ ] Enhancement (improving an existing functionality)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Chore (updates to the build process or auxiliary tools and libraries)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Description

One new section, `## Client-only apps (SPA)`, on the **Content integration** page, plus a cross-link from the `content` option on the Nuxt installation page. No code changes.

#332 asks whether MDC was disabled for SPA. It was not — and rather than answer in a comment that will be hard to find in six months, the docs now say so, with the part that actually trips people up.

**Verified before writing it.** A minimal app on Nuxt **4.4.8** (the version in the report) with `@nuxt/content` 3.15.2 and `ssr: false`, driven in Chromium:

| configuration | result |
| --- | --- |
| content only, no b24ui | `<ContentRenderer>` renders the markdown |
| \+ `@bitrix24/b24ui-nuxt@2.10.0` | renders, with `Prose*` styling applied |
| `nuxt build`, served by nitro | renders; the dump is emitted to `.output/public/__nuxt_content/docs/sql_dump.txt` |
| `better-sqlite3` removed entirely, `sqliteConnector: 'native'` | builds and renders — no native binding involved |

The mechanism, from the module source and confirmed in the network panel: the client queries WASM SQLite, downloading `/__nuxt_content/<collection>/sql_dump.txt`, and the module marks that route `prerender: true` for every non-private collection.

### What the section says, and what review changed about it

The first draft named `allowBuilds: better-sqlite3: true` as *the* fix. Review — five reviewers plus a `/review` pass — converged on the same blocker: this repository itself moved to the `native` (`node:sqlite`) connector in #322 and dropped `better-sqlite3` from `docs`, so the PR was recommending a path we had already left, on a rationale that was no longer true of us. The section now leads with:

```ts [nuxt.config.ts]
export default defineNuxtConfig({
  content: { experimental: { sqliteConnector: 'native' } }
})
```

and keeps the `better-sqlite3` + pnpm route as the fallback for Node < 22.5. Also corrected, each against a primary source rather than the issue thread:

- **pnpm 11 did not *move* `pnpm.onlyBuiltDependencies`.** It removed it — with `onlyBuiltDependenciesFile`, `neverBuiltDependencies`, `ignoredBuiltDependencies` and `ignoreDepScripts` — and replaced them with the differently-shaped `allowBuilds` map. It also defaults `strictDepBuilds` to `true`, so a missing entry fails the install with `ERR_PNPM_IGNORED_BUILDS` instead of printing a warning that scrolls past; the softer behaviour the first draft described is pnpm **10**'s. (pnpm 11.0.0 changelog, "Security & Build Defaults".) `pnpm approve-builds` writes whichever form the installed version expects, so that is what the section recommends.
- **The debugging snippet read the wrong field.** A missing dump makes `$fetch` throw, so the failure lands in `error`, not `data` — the snippet destructured only `data` and would have printed `undefined` for the exact failure the section spends the most words on. Replaced with a three-step ladder that separates *no dump was built* → *the browser cannot fetch it* → *the query matches nothing*.
- **`queryCollection('docs')` was our collection name, not the default.** A reader copying it verbatim gets an empty result for an unrelated reason. Now `content`, matching `createDefaultCollections` and the example further down the same page.
- **Says plainly that the dump is the whole collection**, not just the pages you link to, and that it is cached in `localStorage` — so drafts do not belong in a collection a client-rendered page queries. Adds why pnpm blocks build scripts at all, so the fix does not read as an invitation to `approve-builds --all` or `dangerouslyAllowAllBuilds`.
- **Adds the npm/yarn case** (scripts run by default there, so a failure is a missing toolchain), the `private: true` caveat, and a link out to upstream configuration docs — matching the `::note{to=...}` style already used twice on this page.

**Placement.** The first draft appended this to the installation page, after `experimental.componentDetection`. That page's `## Options` documents b24ui's own module options, so a build-tooling note about a peer module read as a non-sequitur there. It now lives on the Content integration page, with a cross-link left where the installation page mentions `@nuxt/content`.

**One non-docs change.** `pnpm-workspace.yaml` gains a comment above `better-sqlite3: true` explaining why the entry stays even though `docs` no longer needs it — without it, a future "remove unused config" cleanup would silently contradict the page.

### Checklist

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LWWrBHgfqGSbeU3V6UuMF8)_