### PR TITLE
fix(CommandPalette): stop the raw label and suffix reaching v-html

### DIFF
--- a/.sync/PORTING.md
+++ b/.sync/PORTING.md
@@ -138,6 +138,16 @@ History of the maps lives in git; no separate version field.
 
 - New `v-html` / `innerHTML` → keep the upstream sanitization (or add one),
   annotate `<!-- SECURITY: needs sanitization review -->`, and list it in the PR.
+- **Port both halves of a hunk that pairs a new guard with a simplified sink.**
+  When upstream adds a `v-if`/`v-else` around a `v-html` / `innerHTML` / `:src`
+  and *simultaneously* drops a fallback from the expression (`A || B` → `A`),
+  the second half is not tidy-up. Taking only the guard leaves the old fallback
+  reachable the moment anyone loosens the guard later, and — because the guard
+  and the expression then test the same value — nothing renders differently, no
+  test fails, and it reads as safe. That is the shape PR #338 had to go back and
+  finish, from a port made in `0536b294`. Diff the whole hunk, not just the
+  added control-flow keyword. `test/utils/v-html-bindings.spec.ts` now fails on
+  a `v-html` that contains `||` or `??`, so this one is enforced.
 - No new runtime network calls, eval, or dynamic `import()` of remote code.
 - Changes stay within `src/` (+ tests/snapshots).
 
@@ -162,5 +172,6 @@ History of the maps lives in git; no separate version field.
 - 2026-06-15 — port of `ffaf163f` (PR #140): added the §1 rewrite — **rename inferred type variables too**: when porting types that `infer UI` (or otherwise name a `UI` type-var), rename it to `B24UI`, consistent with `ui → b24ui`. Caught in review of the `ComponentAppConfig` rewrite (`A extends { b24ui: infer UI }` → `infer B24UI`). Last reviewed: 2026-06-15.
 - 2026-06-17 — skip of `fa525382` (PR #167): added the §2 **Locales** invariant — b24ui does not adopt new languages from upstream. The Latvian (`lv`) addition was ported then reverted on maintainer instruction; PR #167 closed without merge and recorded as `decision: skip`. Future upstream new-locale commits are skipped the same way (edits to existing locales still port). Last reviewed: 2026-06-17.
 - 2026-08-08 — fix of #310 (PR #326): added the §2 **Timeline / Stepper value resolution** invariant. b24ui now resolves numeric model values through `valueKey`, while upstream still matches strings only — so a faithful port of any upstream commit touching `currentStepIndex` would silently revert the fix and bring back the reported bug (a numeric `items[].value` selecting nothing). Guarded by `test/components/Timeline.spec.ts` and `Stepper.spec.ts`; those snapshots must not be regenerated to make a port compile. Last reviewed: 2026-08-08.
+- 2026-08-09 — hardening around #82 (PR #338): added the §5 rule **port both halves of a hunk that pairs a new guard with a simplified sink**. `0536b294` ported upstream `e751b374` into `CommandPalette.vue`, took its new `v-if`/`v-else` split, and left the paired `v-html="item.labelHtml || get(...)"` fallback in place — dead code, because guard and expression read the same scalar, which is why it survived two years and several reviews. Also added `labelHtml`/`suffixHtml`/`descriptionHtml` to `CommandPaletteItem` with `@warning` jsDoc: upstream leaves them to the `[key: string]: any` index signature, and this is a deliberate divergence, since they are the runtime's only `v-html` sinks and a caller that sets them bypasses the palette's escaping. Enforced by `test/utils/v-html-bindings.spec.ts`. Last reviewed: 2026-08-09.
 - 2026-08-08 — hardening of #315 (PR #331): added the §2 **workflow actions stay pinned to commit SHAs** invariant. Upstream bumps actions by tag and PR #297 replayed such a bump verbatim, rewriting `uses:` from `@v6` to `@v7`; b24ui pins commits because that runner holds the npm publishing OIDC token. `ci.yml` now fails on any unpinned `uses:`, so the rule is enforced rather than remembered. Last reviewed: 2026-08-08.
 - 2026-08-08 — fixes of #80/#81 (PR #335): added two §2 invariants — the **generated CSS template name** (`b24ui.css`, not upstream's `ui.css`) and **`ChatMessages` measuring with `getBoundingClientRect()`** rather than `useElementBounding()`. Both were found by the June 2026 audit rather than by a failing test, because both fail silently: a template filter that matches nothing still returns, and a leaked observer costs memory rather than correctness. Now guarded by `test/utils/templates.spec.ts` and a ResizeObserver-count case. The same PR also closed #79 and #83, which need no rule here — `Countdown` is a Bitrix24-only component with no upstream counterpart, and the vitest include patterns are b24ui test infrastructure. Last reviewed: 2026-08-08.

--- a/docs/content/docs/2.components/command-palette.md
+++ b/docs/content/docs/2.components/command-palette.md
@@ -103,11 +103,18 @@ Each group contains an `items` array of objects that define the commands. Each i
 - [`slot?: string`{lang="ts-type"}](#with-custom-slot)
 - `placeholder?: string`{lang="ts-type"}
 - `children?: CommandPaletteItem[]`{lang="ts-type"}
+- `labelHtml?: string`{lang="ts-type"}
+- `suffixHtml?: string`{lang="ts-type"}
+- `descriptionHtml?: string`{lang="ts-type"}
 - `onSelect?: (e: Event) => void`{lang="ts-type"}
 - `class?: any`{lang="ts-type"}
 - `b24ui?: { item?: ClassNameValue, itemLeadingIcon?: ClassNameValue, itemLeadingAvatarSize?: ClassNameValue, itemLeadingAvatar?: ClassNameValue, itemLeadingChipSize?: ClassNameValue, itemLeadingChip?: ClassNameValue, itemLabel?: ClassNameValue, itemLabelPrefix?: ClassNameValue, itemLabelBase?: ClassNameValue, itemLabelSuffix?: ClassNameValue, itemTrailing?: ClassNameValue, itemTrailingKbds?: ClassNameValue, itemTrailingKbdsSize?: ClassNameValue, itemTrailingHighlightedIcon?: ClassNameValue, itemTrailingIcon?: ClassNameValue }`{lang="ts-type"}
 
 You can pass any property from the [Link](/docs/components/link/#props) component such as `to`, `target`, etc.
+
+::caution
+`labelHtml`, `suffixHtml` and `descriptionHtml` are inserted with `v-html`. The palette normally computes them for you from the search match — everything escaped, `<mark>` around the matched run — but a value you set yourself skips that entirely and is rendered as raw HTML. Sanitize anything that comes from a CMS, an API or your users before putting it there.
+::
 
 ::component-code
 ---

--- a/src/runtime/components/CommandPalette.vue
+++ b/src/runtime/components/CommandPalette.vue
@@ -597,7 +597,7 @@ function onSelect(e: Event, item: T) {
                     v-if="item.labelHtml"
                     data-slot="itemLabelBase"
                     :class="b24ui.itemLabelBase({ class: [props.b24ui?.itemLabelBase, item.b24ui?.itemLabelBase], active: active || item.active })"
-                    v-html="item.labelHtml || get(item, props.labelKey as string)"
+                    v-html="item.labelHtml"
                   />
                   <span
                     v-else
@@ -609,7 +609,7 @@ function onSelect(e: Event, item: T) {
                     v-if="item.suffixHtml"
                     data-slot="itemLabelSuffix"
                     :class="b24ui.itemLabelSuffix({ class: [props.b24ui?.itemLabelSuffix, item.b24ui?.itemLabelSuffix], active: active || item.active })"
-                    v-html="item.suffixHtml || item.suffix"
+                    v-html="item.suffixHtml"
                   />
                   <span
                     v-else-if="item.suffix"

--- a/src/runtime/components/CommandPalette.vue
+++ b/src/runtime/components/CommandPalette.vue
@@ -40,6 +40,29 @@ export interface CommandPaletteItem extends Omit<LinkProps, 'type' | 'raw' | 'cu
    */
   placeholder?: string
   children?: CommandPaletteItem[]
+  /**
+   * Pre-rendered HTML for the label, used instead of `label` when present.
+   * Normally computed by the palette from the search match: everything escaped,
+   * `<mark>` around the matched run.
+   *
+   * @warning Rendered with `v-html`. Setting it yourself skips the palette's
+   * escaping entirely, so anything you put here — a CMS field, an API response —
+   * is inserted as raw HTML and must be sanitized first. `useContentSearch` is
+   * the in-house example: it routes every snippet through `sanitizeSnippet()`.
+   */
+  labelHtml?: string
+  /**
+   * Pre-rendered HTML for the suffix. Same contract as `labelHtml`.
+   *
+   * @warning Rendered with `v-html` — sanitize anything you set here yourself.
+   */
+  suffixHtml?: string
+  /**
+   * Pre-rendered HTML for the description. Same contract as `labelHtml`.
+   *
+   * @warning Rendered with `v-html` — sanitize anything you set here yourself.
+   */
+  descriptionHtml?: string
   onSelect?: (e: Event) => void
   class?: any
   b24ui?: Pick<CommandPalette['slots'], 'item' | 'itemLeadingIcon' | 'itemLeadingAvatarSize' | 'itemLeadingAvatar' | 'itemLeadingChipSize' | 'itemLeadingChip' | 'itemWrapper' | 'itemLabel' | 'itemDescription' | 'itemLabelPrefix' | 'itemLabelBase' | 'itemLabelSuffix' | 'itemTrailing' | 'itemTrailingKbds' | 'itemTrailingKbdsSize' | 'itemTrailingHighlightedIcon' | 'itemTrailingIcon'>

--- a/test/components/CommandPalette.spec.ts
+++ b/test/components/CommandPalette.spec.ts
@@ -162,15 +162,27 @@ describe('CommandPalette', () => {
   ])
 
   describe('item markup is never rendered as HTML', () => {
-    // Three `v-html` bindings render an item's label, suffix and description.
-    // They are safe only because every value that reaches them has been through
-    // `highlight()`/`sanitizeSnippet()`, which escape everything and emit
-    // `<mark>` as the sole live tag. Two of the three used to carry a fallback
-    // — `v-html="item.labelHtml || get(item, labelKey)"` — that would have put
-    // the raw, unescaped field straight into `v-html`. Unreachable in practice
-    // because of the `v-if` on the same element, but one edit to that `v-if`
-    // away from being live, so the property is asserted here rather than left
-    // resting on a guard two attributes up.
+    // Three `v-html` bindings render an item's label, suffix and description,
+    // and each is guarded by a `v-if` on the same `*Html` value. Two of them
+    // used to carry a fallback — `v-html="item.labelHtml || get(item, labelKey)"`
+    // — that would have put the raw field straight into `v-html`. It was dead
+    // code, because a `v-if` and a `v-html` reading the same scalar can never
+    // disagree, so removing it changes no rendered output and **no test here
+    // fails against the old source**. What these cases pin down is the property
+    // itself, in the two configurations a reader actually cares about:
+    //
+    //  - with no `*Html` set — the default, since the component does not enable
+    //    Fuse's `includeMatches`, so `highlight()` returns undefined — the field
+    //    goes through the `v-else` branch and Vue's `{{ }}` escaping. These also
+    //    turn red if someone widens a `v-if` to admit the raw field, which is
+    //    the realistic way the removed fallback would have come back to life.
+    //  - with `*Html` set, exercising the `v-html` sink for real.
+    //
+    // Worth stating plainly, because the sink is not unconditionally guarded:
+    // `processGroupItems` does `item.labelHtml ?? highlight(...)`, so a caller
+    // that sets `labelHtml` itself skips `highlight()` entirely and owns the
+    // escaping. `useContentSearch` is the in-house example, and it routes
+    // everything through `sanitizeSnippet()`.
     const PAYLOAD = '<img src=x onerror="alert(1)">'
 
     it('escapes a raw label rather than parsing it', async () => {
@@ -200,14 +212,19 @@ describe('CommandPalette', () => {
       expect(wrapper.html()).toContain('&lt;img')
     })
 
-    it('keeps only `<mark>` live when the highlighter produced the markup', async () => {
-      // `labelHtml` is what `highlight()` returns: everything escaped, `<mark>`
-      // inserted around the match. It must render as markup — that is the whole
-      // point of the binding — while the payload beside it stays inert.
+    // Shaped like `highlight()`/`sanitizeSnippet()` output rather than produced
+    // by calling them — everything escaped, `<mark>` around the match. `<mark>`
+    // must survive as markup, since rendering it is the entire reason these
+    // bindings use `v-html`, while the payload next to it stays inert.
+    const HIGHLIGHTED = '<mark>hit</mark>&lt;img src=x&gt;'
+
+    it.each([
+      ['labelHtml', { label: 'ignored', labelHtml: HIGHLIGHTED }],
+      ['suffixHtml', { label: 'safe', suffixHtml: HIGHLIGHTED }],
+      ['descriptionHtml', { label: 'safe', descriptionHtml: HIGHLIGHTED }]
+    ])('keeps only `<mark>` live in %s', async (_field, item) => {
       const wrapper = await mountSuspended(CommandPalette, {
-        props: {
-          groups: [{ id: 'g', items: [{ label: 'ignored', labelHtml: `<mark>hit</mark>&lt;img src=x&gt;` }] }]
-        } as any
+        props: { groups: [{ id: 'g', items: [item] }] } as any
       })
 
       expect(wrapper.find('mark').exists()).toBe(true)

--- a/test/components/CommandPalette.spec.ts
+++ b/test/components/CommandPalette.spec.ts
@@ -161,6 +161,60 @@ describe('CommandPalette', () => {
     ['with footer slot', { props, slots: { footer: () => 'Footer slot' } }]
   ])
 
+  describe('item markup is never rendered as HTML', () => {
+    // Three `v-html` bindings render an item's label, suffix and description.
+    // They are safe only because every value that reaches them has been through
+    // `highlight()`/`sanitizeSnippet()`, which escape everything and emit
+    // `<mark>` as the sole live tag. Two of the three used to carry a fallback
+    // — `v-html="item.labelHtml || get(item, labelKey)"` — that would have put
+    // the raw, unescaped field straight into `v-html`. Unreachable in practice
+    // because of the `v-if` on the same element, but one edit to that `v-if`
+    // away from being live, so the property is asserted here rather than left
+    // resting on a guard two attributes up.
+    const PAYLOAD = '<img src=x onerror="alert(1)">'
+
+    it('escapes a raw label rather than parsing it', async () => {
+      const wrapper = await mountSuspended(CommandPalette, {
+        props: { groups: [{ id: 'g', items: [{ label: PAYLOAD }] }] } as any
+      })
+
+      expect(wrapper.find('img').exists()).toBe(false)
+      expect(wrapper.html()).toContain('&lt;img')
+    })
+
+    it('escapes a raw suffix rather than parsing it', async () => {
+      const wrapper = await mountSuspended(CommandPalette, {
+        props: { groups: [{ id: 'g', items: [{ label: 'safe', suffix: PAYLOAD }] }] } as any
+      })
+
+      expect(wrapper.find('img').exists()).toBe(false)
+      expect(wrapper.html()).toContain('&lt;img')
+    })
+
+    it('escapes a raw description rather than parsing it', async () => {
+      const wrapper = await mountSuspended(CommandPalette, {
+        props: { groups: [{ id: 'g', items: [{ label: 'safe', description: PAYLOAD }] }] } as any
+      })
+
+      expect(wrapper.find('img').exists()).toBe(false)
+      expect(wrapper.html()).toContain('&lt;img')
+    })
+
+    it('keeps only `<mark>` live when the highlighter produced the markup', async () => {
+      // `labelHtml` is what `highlight()` returns: everything escaped, `<mark>`
+      // inserted around the match. It must render as markup — that is the whole
+      // point of the binding — while the payload beside it stays inert.
+      const wrapper = await mountSuspended(CommandPalette, {
+        props: {
+          groups: [{ id: 'g', items: [{ label: 'ignored', labelHtml: `<mark>hit</mark>&lt;img src=x&gt;` }] }]
+        } as any
+      })
+
+      expect(wrapper.find('mark').exists()).toBe(true)
+      expect(wrapper.find('img').exists()).toBe(false)
+    })
+  })
+
   it('hides the input icon when icon is false', async () => {
     // Use icon-less items so the only `data-slot="icon"` is the input's leading
     // icon (b24-icons render their own `data-slot="icon"`, so item icons would

--- a/test/utils/v-html-bindings.spec.ts
+++ b/test/utils/v-html-bindings.spec.ts
@@ -1,0 +1,66 @@
+import { join } from 'node:path'
+import { readFile } from 'node:fs/promises'
+import { describe, it, expect, beforeAll } from 'vitest'
+import { glob } from 'tinyglobby'
+
+/**
+ * `v-html` writes its expression into the DOM without escaping, so every one of
+ * them is a place where a mistake becomes stored XSS. There are exactly three
+ * in the runtime, all in `CommandPalette`, and two of them used to end in a
+ * fallback to the raw field:
+ *
+ *     v-html="item.labelHtml || get(item, props.labelKey as string)"
+ *
+ * That was dead code — the `v-if` on the same element tests the same scalar, so
+ * the right-hand side could never be evaluated — which is exactly why it
+ * survived a port and two years of review. It also means no render test can
+ * catch its return: removing it changes no output, so nothing goes red either
+ * way. A static check is the only thing that can, so this is that check.
+ *
+ * Deliberately also pins the *set* of bindings. A new `v-html` anywhere in the
+ * runtime is a decision worth making on purpose, not one that arrives inside an
+ * unrelated diff.
+ */
+const runtimeDir = join(process.cwd(), 'src', 'runtime')
+
+/** Every `v-html`/`v-text` style binding, as `file -> expression`. */
+async function collectVHtmlBindings() {
+  const files = await glob('**/*.vue', { cwd: runtimeDir })
+  const found: Array<{ file: string, expression: string }> = []
+
+  for (const file of files.sort()) {
+    const source = await readFile(join(runtimeDir, file), 'utf8')
+    for (const match of source.matchAll(/v-html\s*=\s*"([^"]*)"|v-html\s*=\s*'([^']*)'/g)) {
+      found.push({ file, expression: (match[1] ?? match[2] ?? '').trim() })
+    }
+  }
+
+  return found
+}
+
+describe('v-html bindings in the runtime', () => {
+  let bindings: Array<{ file: string, expression: string }>
+
+  beforeAll(async () => {
+    bindings = await collectVHtmlBindings()
+    // Every assertion below passes vacuously on an empty scan, so prove the
+    // source tree was actually found before trusting any of them.
+    expect(bindings.length).toBeGreaterThan(0)
+  })
+
+  it('are only the three CommandPalette item bindings', () => {
+    expect(bindings.map(({ file, expression }) => `${file}: ${expression}`)).toEqual([
+      'components/CommandPalette.vue: item.labelHtml',
+      'components/CommandPalette.vue: item.suffixHtml',
+      'components/CommandPalette.vue: item.descriptionHtml'
+    ])
+  })
+
+  it('never fall back to another value', () => {
+    // `||` and `??` are how a raw, unescaped field gets in: the guarded
+    // expression is fine, the thing after the operator is not.
+    const withFallback = bindings.filter(({ expression }) => /\|\||\?\?/.test(expression))
+
+    expect(withFallback).toEqual([])
+  })
+})


### PR DESCRIPTION
### Linked issue

Closes #82.

Not because this PR fixes what #82 reported — that was already fixed in July, see below — but because #82 stayed open for three weeks *after* being fixed, and leaving it open again is how that repeats.

### Type of change

- [ ] Documentation (updates to the documentation or readme)
- [x] Bug fix (a non-breaking change that fixes an issue)
- [ ] Enhancement (improving an existing functionality)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Chore (updates to the build process or auxiliary tools and libraries)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Description

**#82 as filed is already fixed — this is what was left behind it.**

The reported bug was `isAlreadyEscaped()` short-circuiting `sanitize()` in `src/runtime/utils/fuse.ts`, so any string containing a stray entity was emitted into `v-html` unescaped. That file no longer exists (renamed to `search.ts` in #111, two days after the issue was filed — which is why its path no longer resolved), and the short-circuit was removed on 2026-07-20 in #291, a port of upstream `2a172ef` (nuxt/ui#6741). It shipped to users in **v2.10.0 on 2026-08-06**.

Verified rather than assumed: `src/runtime/utils/search.ts` is **byte-identical** to nuxt/ui v4's current file, and the issue's own payload comes out inert — `Tom &amp; ``&lt;img src="x" onerror="alert(1)"&gt;'`` renders as `Tom &amp;amp; &lt;img …&gt;`. The only live tag in any output is the `<mark>` the highlighter inserts itself.

#### What this PR changes

Sweeping every raw-HTML sink in `src/runtime/` turned up three `v-html` bindings, all in `CommandPalette.vue`, two of which fell back to the **unescaped** field:

```diff
-  v-html="item.labelHtml || get(item, props.labelKey as string)"
+  v-html="item.labelHtml"
-  v-html="item.suffixHtml || item.suffix"
+  v-html="item.suffixHtml"
```

Not exploitable: each sits on an element whose `v-if` tests the same value, so a `v-if` and a `v-html` reading one scalar can never disagree. But it is a loaded gun aimed at the one place in the runtime that renders unescaped HTML.

**Where it came from.** Upstream removed these two fallbacks in `e751b374` (nuxt/ui#5433) — in the same edit that introduced the `v-if` guards. b24ui's port of that commit, `0536b294`, took the guards and left the fallbacks. This finishes a half-applied port; all three bindings now match upstream exactly.

#### After review

Six reviewers agreed the tests shipped with the first commit did not guard what their comment claimed, and two proved it: restore the fallbacks, leave the guards, and every test stays green. The diff is a strict no-op, so **no render test can catch its revert**. Corrected:

- `test/utils/v-html-bindings.spec.ts` is the check that *can* fail — it pins the runtime's `v-html` bindings to the known three and rejects any containing `||` or `??`. Restoring one fallback turns it red.
- The test comment now says what each case actually pins down, including that the sink is **not** unconditionally guarded: `processGroupItems` does `item.labelHtml ?? highlight(...)`, so a caller who sets `labelHtml` skips the palette's escaping entirely.
- All three sinks are now driven. Previously only `labelHtml` was; `suffixHtml` and `descriptionHtml` were exercised by nothing in the suite.
- `labelHtml`/`suffixHtml`/`descriptionHtml` are declared on `CommandPaletteItem` with `@warning` jsDoc, listed in `command-palette.md`, and carry a `::caution`. They previously reached consumers only through `[key: string]: any` — no declaration, no autocomplete, no mention in the docs — while being the runtime's only `v-html` sinks. This is a deliberate divergence; upstream leaves them undeclared. (Closes the `*Html` bullet of #92, whose scope is also corrected there — `InputMenu` is not part of this surface.)

#### Verification

| mutation | result |
| --- | --- |
| fallback restored, `v-if` guard intact | 4 passed — the fallback is genuinely unreachable, no live vulnerability |
| fallback restored **and** the guard widened by one term | 1 failed, `expected true to be false` — a real `<img>` in the DOM |
| fallback restored, static guard | 2 failed — the regression a render test cannot see |

Adversarial probing of `highlight()`/`sanitizeSnippet()` beyond the above — named/numeric/hex/uppercase entities decoding to `<`, unclosed `<mark`, `javascript:` text, multiple match regions, NUL-sentinel collision — all inert.

Full suite: **258 files, 5822 passed, 6 skipped**. `pnpm lint`, `pnpm typecheck` clean.

### Deviations

`.sync/PORTING.md` gains the §5 rule this PR is an instance of: when an upstream hunk pairs a new guard with a simplified sink, port both halves. Taking only the guard leaves the fallback reachable the moment anyone loosens the guard, renders identically, fails no test, and reads as safe. Plus a changelog line recording the `*Html` declaration as a deliberate divergence.

### Follow-ups filed

- #339 — `truncateHTMLFromStart` splits astral characters (confirmed **not** a security issue; present upstream verbatim).
- #340 — a custom `item-description` slot is dropped when the item has no `description`; long-standing drift, unrelated to `e751b374`.
- #86 — the `useContentSearch` → `sanitizeSnippet` → DOM path is untested end to end, and it is the one place `includeMatches` is enabled in production.

### Checklist

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LWWrBHgfqGSbeU3V6UuMF8)_