### PR TITLE
fix: four component bugs — grouped children, leaked refs, KeepAlive, slot-only description

### DIFF
--- a/.sync/PORTING.md
+++ b/.sync/PORTING.md
@@ -82,6 +82,26 @@ material. Reproduce its *intent* in b24ui by editing files under `src/` only.
   (#81). Restoring the composable here reads as a faithful port and reintroduces
   the leak; it bought no correctness, only unused reactivity. Guarded by the
   ResizeObserver-count case in `test/components/ChatMessages.spec.ts`.
+- **`ChatMessages.registerMessageRef` must delete on `null`.** Vue passes `null`
+  when the message unmounts; upstream only ever `set`s, so the detached element
+  stays in `messagesRefs` for the component's lifetime (#336). The only other
+  cleanup is the bulk `.clear()` that fires when `messages` empties entirely,
+  which is why resetting a thread looks fine and trimming one message does not.
+  Upstream still carries this, so the `else` branch reads as b24ui noise in a
+  diff — keep it. Guarded by the ref-drop case in
+  `test/components/ChatMessages.spec.ts`.
+- **`NavigationMenu` reads children through `getChildren()`, never
+  `item.children`.** Upstream iterates `item.children` at three template `v-for`
+  sites and hands it straight to `getAccordionDefaultValue`; b24ui routes all
+  four through `getChildren()`, which un-nests one accidental level of grouping
+  and drops the holes flattening leaves behind (#51). Everything around it is
+  byte-identical upstream — `lists` normalization, the `NavigationMenuChildItem[]`
+  type — so a faithful port of any commit touching those blocks reads as correct
+  and silently reverts the fix, and the failure shows nothing: the accordion
+  still mounts, just onto nothing. Port the intent, keep the call. Guarded by
+  `describe('grouped children (#51)')` in `test/components/NavigationMenu.spec.ts`;
+  its horizontal case needs `unmountOnHide: false` to reach the second site at
+  all.
 - **Workflow actions stay pinned to commit SHAs.** Upstream bumps them by tag;
   b24ui pins the commit. You do not have to remember this — `ci.yml` fails the
   build on any unpinned `uses:` and tells you how to resolve the tag.
@@ -175,3 +195,4 @@ History of the maps lives in git; no separate version field.
 - 2026-08-09 — hardening around #82 (PR #338): added the §5 rule **port both halves of a hunk that pairs a new guard with a simplified sink**. `0536b294` ported upstream `e751b374` into `CommandPalette.vue`, took its new `v-if`/`v-else` split, and left the paired `v-html="item.labelHtml || get(...)"` fallback in place — dead code, because guard and expression read the same scalar, which is why it survived two years and several reviews. Also added `labelHtml`/`suffixHtml`/`descriptionHtml` to `CommandPaletteItem` with `@warning` jsDoc: upstream leaves them to the `[key: string]: any` index signature, and this is a deliberate divergence, since they are the runtime's only `v-html` sinks and a caller that sets them bypasses the palette's escaping. Enforced by `test/utils/v-html-bindings.spec.ts`. Last reviewed: 2026-08-09.
 - 2026-08-08 — hardening of #315 (PR #331): added the §2 **workflow actions stay pinned to commit SHAs** invariant. Upstream bumps actions by tag and PR #297 replayed such a bump verbatim, rewriting `uses:` from `@v6` to `@v7`; b24ui pins commits because that runner holds the npm publishing OIDC token. `ci.yml` now fails on any unpinned `uses:`, so the rule is enforced rather than remembered. Last reviewed: 2026-08-08.
 - 2026-08-08 — fixes of #80/#81 (PR #335): added two §2 invariants — the **generated CSS template name** (`b24ui.css`, not upstream's `ui.css`) and **`ChatMessages` measuring with `getBoundingClientRect()`** rather than `useElementBounding()`. Both were found by the June 2026 audit rather than by a failing test, because both fail silently: a template filter that matches nothing still returns, and a leaked observer costs memory rather than correctness. Now guarded by `test/utils/templates.spec.ts` and a ResizeObserver-count case. The same PR also closed #79 and #83, which need no rule here — `Countdown` is a Bitrix24-only component with no upstream counterpart, and the vitest include patterns are b24ui test infrastructure. Last reviewed: 2026-08-08.
+- 2026-08-09 — fixes of #51/#336/#337/#340 (PR #341): added two §2 invariants — **`NavigationMenu` children via `getChildren()`** and **`ChatMessages.registerMessageRef` deleting on `null`**. Both are spots where upstream still carries the bug, so a faithful port silently reverts the fix, and neither failure is visible in the output that a reviewer would look at: the accordion mounts onto nothing, and a retained ref costs memory rather than correctness. The other two fixes in that PR need no rule — upstream already carries the `!!slots[...]` term on both `CommandPalette` branches, so #340 was b24ui drift and a port *restores* our behaviour; and `Countdown` (#337) is a Bitrix24-only component with no upstream counterpart. Last reviewed: 2026-08-09.

--- a/docs/content/docs/2.components/navigation-menu.md
+++ b/docs/content/docs/2.components/navigation-menu.md
@@ -162,6 +162,8 @@ Use a flat `children` array of objects to define submenus:
 - `onSelect?(e: Event): void`
 - `class?: any`
 
+Grouping stops at the top level. Unlike `items`, `children` takes a **flat** array only — a nested one is flattened and rendered without a separator, and logs a warning in development.
+
 ::
 
 ### Orientation

--- a/skills/b24-ui-nuxt/references/guidelines/conventions.md
+++ b/skills/b24-ui-nuxt/references/guidelines/conventions.md
@@ -116,6 +116,8 @@ const items = [
 
 Components supporting nested arrays: `B24DropdownMenu`, `B24ContextMenu`, `B24CommandPalette`, `B24NavigationMenu`.
 
+Nesting applies to the **top-level** `items` only. A submenu's `children` is always a flat array — `B24NavigationMenu` flattens a nested one and draws no separator, warning in development.
+
 ## Composables
 
 ### useToast

--- a/src/runtime/components/ChatMessages.vue
+++ b/src/runtime/components/ChatMessages.vue
@@ -148,6 +148,13 @@ function registerMessageRef(id: string, element: ComponentPublicInstance | null)
   const elInstance = element?.$el
   if (elInstance) {
     messagesRefs.value.set(id, elInstance)
+  } else {
+    // Vue passes `null` on unmount. Ignoring that case kept the detached
+    // element in the map forever: the only other cleanup is a bulk `.clear()`
+    // that runs when `props.messages` empties entirely, so an app that removes
+    // messages one at a time — deleting one, trimming history, paginating —
+    // retained every one of them for the component's lifetime.
+    messagesRefs.value.delete(id)
   }
 }
 

--- a/src/runtime/components/CommandPalette.vue
+++ b/src/runtime/components/CommandPalette.vue
@@ -649,7 +649,7 @@ function onSelect(e: Event, item: T) {
                 v-html="item.descriptionHtml"
               />
               <span
-                v-else-if="get(item, props.descriptionKey as string)"
+                v-else-if="get(item, props.descriptionKey as string) || !!slots[(item.slot ? `${item.slot}-description` : group?.slot ? `${group.slot}-description` : `item-description`) as keyof CommandPaletteSlots<T>]"
                 data-slot="itemDescription"
                 :class="b24ui.itemDescription({ class: [props.b24ui?.itemDescription, item.b24ui?.itemDescription] })"
               >

--- a/src/runtime/components/Countdown.vue
+++ b/src/runtime/components/Countdown.vue
@@ -315,6 +315,18 @@ function continueProcess(): void {
     return
   }
 
+  // Cancel before scheduling, because `requestId` holds one handle and the last
+  // writer wins: two callers on the same tick used to leave the first chain
+  // running with no way to reach it again. That happens on the very first mount
+  // under `<KeepAlive>` — Vue runs `onActivated` right after `onMounted` for a
+  // brand-new cached child, not only on a real reactivation, so the immediate
+  // props watcher's `start()` and `onActivated`'s `resumeCounting()` both land
+  // here. Measured: one extra uncancellable frame chain, and `progress` firing
+  // twice for a single tick. Guarding here rather than at the two call sites
+  // covers any future third caller too. `cancelAnimationFrame` on a stale or
+  // already-fired handle is a no-op, so the recursive call from `step` is safe.
+  cancelAnimationFrame(requestId.value)
+
   const delay = Math.min(totalMilliseconds.value, props.interval!)
 
   if (delay > 0) {
@@ -448,9 +460,6 @@ function restart(): void {
 }
 
 /**
- * Visibility change event handler.
- */
-/**
  * Stop ticking while the countdown is not on screen.
  *
  * Shared by the `visibilitychange` handler and `<KeepAlive>` deactivation —
@@ -467,6 +476,9 @@ function resumeCounting(): void {
   continueProcess()
 }
 
+/**
+ * Visibility change event handler.
+ */
 function handleVisibilityChange(): void {
   switch (document?.visibilityState) {
     case 'visible':

--- a/src/runtime/components/Countdown.vue
+++ b/src/runtime/components/Countdown.vue
@@ -84,7 +84,7 @@ export interface CountdownSlots {
 </script>
 
 <script setup lang="ts">
-import { ref, computed, watch, onMounted, onBeforeUnmount } from 'vue'
+import { ref, computed, watch, onMounted, onBeforeUnmount, onActivated, onDeactivated } from 'vue'
 import { useEventListener } from '@vueuse/core'
 import { Primitive } from 'reka-ui'
 import { useAppConfig } from '#imports'
@@ -168,6 +168,21 @@ onMounted(() => {
 
 onBeforeUnmount(() => {
   pause()
+})
+
+// `<KeepAlive>` deactivation does not run `onBeforeUnmount`, so a cached
+// countdown used to keep its `requestAnimationFrame` chain alive — burning a
+// frame callback per tick and emitting `progress`/`end` for something nobody
+// can see, one chain per cached instance. Suspending and resuming it is the
+// same problem as a hidden browser tab, so it reuses the same two halves.
+// `endTime` is absolute, so `resumeCounting()` returns to the right remainder
+// rather than to where the clock was parked.
+onDeactivated(() => {
+  suspendCounting()
+})
+
+onActivated(() => {
+  resumeCounting()
 })
 // endregion ////
 
@@ -435,15 +450,31 @@ function restart(): void {
 /**
  * Visibility change event handler.
  */
+/**
+ * Stop ticking while the countdown is not on screen.
+ *
+ * Shared by the `visibilitychange` handler and `<KeepAlive>` deactivation —
+ * two ways of asking the same question, and keeping one implementation is what
+ * stops the second from being forgotten when the first changes.
+ */
+function suspendCounting(): void {
+  pause()
+}
+
+/** Catch up to wall-clock time and resume, if the countdown was running. */
+function resumeCounting(): void {
+  update()
+  continueProcess()
+}
+
 function handleVisibilityChange(): void {
   switch (document?.visibilityState) {
     case 'visible':
-      update()
-      continueProcess()
+      resumeCounting()
       break
 
     case 'hidden':
-      pause()
+      suspendCounting()
       break
   }
 }

--- a/src/runtime/components/NavigationMenu.vue
+++ b/src/runtime/components/NavigationMenu.vue
@@ -80,6 +80,14 @@ export interface NavigationMenuItem extends Omit<LinkProps, 'type' | 'raw' | 'cu
    * @defaultValue `item-${index}`, `item-${level}-${index}` for nested children, or `group-${listIndex}-item-${index}` when using grouped items
    */
   value?: string
+  /**
+   * Submenu items.
+   *
+   * Unlike `items`, this must be a **flat** array — there are no groups and no
+   * separator at this level. An array of arrays is tolerated rather than
+   * supported: it is flattened, and in development a console warning names the
+   * offending item.
+   */
   children?: NavigationMenuChildItem[]
   /**
    * With orientation=`horizontal` if `true` it will position the dropdown menu correctly
@@ -340,7 +348,17 @@ function getChildren(item: NavigationMenuItem): NavigationMenuChildItem[] {
     )
   }
 
-  return (children as unknown as NavigationMenuChildItem[][]).flat()
+  // `.flat()` un-nests one level; it does not drop holes or `null`. Without the
+  // filter a stray `null` inside a group — `items.map(cond ? x : null)` without
+  // a filter, a CMS placeholder for an unpublished entry — is promoted to a
+  // top-level child and reaches `pickLinkProps`, whose first statement is
+  // `Object.keys(link)`. That throws, and Vue does not contain a render error
+  // to the component that raised it. Before this helper existed the same input
+  // was inert rather than fatal, because the sink only ever saw the whole inner
+  // array, so tolerating the shape has to include tolerating what is in it.
+  return (children as unknown as NavigationMenuChildItem[][])
+    .flat()
+    .filter((child): child is NavigationMenuChildItem => child != null)
 }
 
 function getItemValue(item: NavigationMenuItem, index: number, level: number, listIndex: number) {
@@ -733,7 +751,7 @@ function onLinkTrailingClick(e: Event, item: NavigationMenuItem) {
         <AccordionRoot
           v-bind="({
             ...accordionProps,
-            defaultValue: getAccordionDefaultValue(item.children, level + 1, listIndex)
+            defaultValue: getAccordionDefaultValue(getChildren(item), level + 1, listIndex)
           } as AccordionRootProps)"
           as="ul"
           data-slot="childList"

--- a/src/runtime/components/NavigationMenu.vue
+++ b/src/runtime/components/NavigationMenu.vue
@@ -307,6 +307,42 @@ const lists = computed<NavigationMenuItem[][]>(() =>
     : []
 )
 
+const warnedGroupedChildren = new WeakSet<object>()
+
+/**
+ * Children of an item, tolerating the grouped shape `items` accepts.
+ *
+ * `items` takes either a flat array or an array of arrays, and a separator is
+ * drawn between the groups. `children` has never supported that — the type says
+ * `NavigationMenuChildItem[]` — but reaching for the same shape one level down
+ * is the natural guess, and the way it failed gave no hint: every `v-for` here
+ * handed an *array* to a template expecting an object, so the horizontal
+ * dropdown rendered empty entries and the vertical accordion opened onto
+ * nothing at all. Reported as #51.
+ *
+ * Flattened rather than rejected, so an app written against the wrong shape
+ * renders its links instead of a blank panel — with a dev-only warning, since
+ * the grouping itself is still not honoured and silently dropping the author's
+ * intent would only move the confusion.
+ */
+function getChildren(item: NavigationMenuItem): NavigationMenuChildItem[] {
+  const children = item.children
+  if (!children?.length || !isArrayOfArray(children)) {
+    return children ?? []
+  }
+
+  if (import.meta.dev && !warnedGroupedChildren.has(item)) {
+    warnedGroupedChildren.add(item)
+    console.warn(
+      `[B24NavigationMenu] \`children\` of "${item.label ?? '(unlabelled item)'}" is an array of arrays. `
+      + 'Unlike `items`, `children` does not support groups — the nested arrays have been flattened and no '
+      + 'separator is drawn. Pass a flat array to silence this.'
+    )
+  }
+
+  return (children as unknown as NavigationMenuChildItem[][]).flat()
+}
+
 function getItemValue(item: NavigationMenuItem, index: number, level: number, listIndex: number) {
   const prefix = lists.value.length > 1 ? `group-${listIndex}-` : ''
   return get(item, props.valueKey as string) ?? (level > 0 ? `${prefix}item-${level}-${index}` : `${prefix}item-${index}`)
@@ -509,7 +545,7 @@ function onLinkTrailingClick(e: Event, item: NavigationMenuItem) {
                       {{ get(item, props.labelKey as string) }}
                     </li>
                     <li
-                      v-for="(childItem, childIndex) in item.children"
+                      v-for="(childItem, childIndex) in getChildren(item)"
                       :key="childIndex"
                       data-slot="childItem"
                       :class="b24ui.childItem({ class: [props.b24ui?.childItem, item.b24ui?.childItem] })"
@@ -617,7 +653,7 @@ function onLinkTrailingClick(e: Event, item: NavigationMenuItem) {
           >
             <ul data-slot="childList" :class="b24ui.childList({ class: [props.b24ui?.childList, item.b24ui?.childList] })">
               <li
-                v-for="(childItem, childIndex) in item.children"
+                v-for="(childItem, childIndex) in getChildren(item)"
                 :key="childIndex"
                 data-slot="childItem"
                 :class="b24ui.childItem({ class: [props.b24ui?.childItem, item.b24ui?.childItem] })"
@@ -704,7 +740,7 @@ function onLinkTrailingClick(e: Event, item: NavigationMenuItem) {
           :class="b24ui.childList({ class: props.b24ui?.childList })"
         >
           <ReuseItemTemplate
-            v-for="(childItem, childIndex) in item.children"
+            v-for="(childItem, childIndex) in getChildren(item)"
             :key="childIndex"
             :item="childItem"
             :index="childIndex"

--- a/test/components/ChatMessages.spec.ts
+++ b/test/components/ChatMessages.spec.ts
@@ -17,7 +17,10 @@ describe('ChatMessages', () => {
       role: 'user' as const,
       parts: [{ type: 'text' as const, text: 'Hello, how are you?' }]
     }, {
-      id: '6045235a-a435-46b8-989d-2df38ca2eb47',
+      // Distinct from the first: `id` keys both the `v-for` and the
+      // `messagesRefs` map, so a shared one models a thread that cannot exist
+      // and quietly collapses two messages into one entry.
+      id: '31d5f0a4-1cd6-4f0e-9d2a-6b8f1c0e77b2',
       role: 'assistant' as const,
       parts: [{ type: 'text' as const, text: 'I am fine, thank you!' }]
     }]
@@ -54,15 +57,16 @@ describe('ChatMessages', () => {
     // for the component's lifetime. The only other cleanup is a bulk `.clear()`
     // that fires when `messages` empties entirely, which is why resetting a
     // thread looked fine and trimming one message did not.
-    // The shared `props` fixture reuses one id across both messages, which a
-    // Map cannot tell apart — distinct ids are the whole point here.
     const messages = [
       { id: 'first', role: 'user' as const, parts: [{ type: 'text' as const, text: 'one' }] },
       { id: 'second', role: 'assistant' as const, parts: [{ type: 'text' as const, text: 'two' }] }
     ]
 
     const wrapper = await mountSuspended(ChatMessages, { props: { messages } })
-    const refs = () => (wrapper.vm as any).$.setupState.messagesRefs as Map<string, HTMLElement>
+    // Read straight off the instance: the map is internal (only
+    // `registerMessageRef` is exposed) and has no public projection, and a
+    // stale entry is invisible from the rendered output by definition.
+    const refs = () => (wrapper.vm as any).messagesRefs as Map<string, HTMLElement>
 
     expect([...refs().keys()].sort()).toEqual(['first', 'second'])
 

--- a/test/components/ChatMessages.spec.ts
+++ b/test/components/ChatMessages.spec.ts
@@ -48,6 +48,30 @@ describe('ChatMessages', () => {
     expect(await axe(wrapper.element)).toHaveNoViolations()
   })
 
+  it('drops a message ref when that message is removed', async () => {
+    // Vue calls the ref callback with `null` on unmount, and that branch used
+    // to do nothing — so a removed message left its detached element in the map
+    // for the component's lifetime. The only other cleanup is a bulk `.clear()`
+    // that fires when `messages` empties entirely, which is why resetting a
+    // thread looked fine and trimming one message did not.
+    // The shared `props` fixture reuses one id across both messages, which a
+    // Map cannot tell apart — distinct ids are the whole point here.
+    const messages = [
+      { id: 'first', role: 'user' as const, parts: [{ type: 'text' as const, text: 'one' }] },
+      { id: 'second', role: 'assistant' as const, parts: [{ type: 'text' as const, text: 'two' }] }
+    ]
+
+    const wrapper = await mountSuspended(ChatMessages, { props: { messages } })
+    const refs = () => (wrapper.vm as any).$.setupState.messagesRefs as Map<string, HTMLElement>
+
+    expect([...refs().keys()].sort()).toEqual(['first', 'second'])
+
+    await wrapper.setProps({ messages: [messages[0]!] })
+    await nextTick()
+
+    expect([...refs().keys()]).toEqual(['first'])
+  })
+
   describe('last message height', () => {
     afterEach(() => {
       vi.unstubAllGlobals()

--- a/test/components/CommandPalette.spec.ts
+++ b/test/components/CommandPalette.spec.ts
@@ -232,6 +232,20 @@ describe('CommandPalette', () => {
     })
   })
 
+  it('renders an `item-description` slot for an item that has no description', async () => {
+    // The wrapper span was gated on the item's own `description` field alone,
+    // so a description supplied purely by a slot — a computed string, a badge,
+    // an icon and text — never mounted and produced nothing, silently. The
+    // sibling label branch already had the matching `!!slots[...]` term, which
+    // is what made the omission look accidental rather than intended.
+    const wrapper = await mountSuspended(CommandPalette, {
+      props: { groups: [{ id: 'g', items: [{ label: 'no description field' }] }] } as any,
+      slots: { 'item-description': () => 'Description from a slot' }
+    })
+
+    expect(wrapper.html()).toContain('Description from a slot')
+  })
+
   it('hides the input icon when icon is false', async () => {
     // Use icon-less items so the only `data-slot="icon"` is the input's leading
     // icon (b24-icons render their own `data-slot="icon"`, so item icons would

--- a/test/components/CommandPalette.spec.ts
+++ b/test/components/CommandPalette.spec.ts
@@ -233,7 +233,7 @@ describe('CommandPalette', () => {
   })
 
   it('renders an `item-description` slot for an item that has no description', async () => {
-    // The wrapper span was gated on the item's own `description` field alone,
+    // The description span was gated on the item's own `description` field alone,
     // so a description supplied purely by a slot — a computed string, a badge,
     // an icon and text — never mounted and produced nothing, silently. The
     // sibling label branch already had the matching `!!slots[...]` term, which

--- a/test/components/Countdown.spec.ts
+++ b/test/components/Countdown.spec.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { mountSuspended } from '@nuxt/test-utils/runtime'
+import { defineComponent, h, ref, nextTick, KeepAlive } from 'vue'
 import Countdown from '../../src/runtime/components/Countdown.vue'
 import { renderEach } from '../component-render'
 import theme from '#build/b24ui/countdown'
@@ -162,6 +163,37 @@ describe('Countdown', () => {
       const removed = removeSpy.mock.calls.filter(([type]) => type === 'visibilitychange')
       expect(removed).toHaveLength(1)
       expect(removed[0]![1]).toBe(registered[0]![1])
+    })
+
+    // `<KeepAlive>` deactivation does not run `onBeforeUnmount`, so a cached
+    // countdown used to keep its `requestAnimationFrame` chain running —
+    // emitting `progress`/`end` for something nobody can see, one chain per
+    // cached instance.
+    it('stops and resumes its frame loop across `<KeepAlive>` toggles', async () => {
+      const cancel = vi.spyOn(window, 'cancelAnimationFrame').mockImplementation(() => {})
+      const request = vi.spyOn(window, 'requestAnimationFrame').mockImplementation(() => 1)
+
+      const shown = ref(true)
+      const Parent = defineComponent({
+        setup() {
+          return () => h(KeepAlive, null, {
+            default: () => (shown.value ? h(Countdown, { seconds: 10 }) : null)
+          })
+        }
+      })
+
+      await mountSuspended(Parent)
+      cancel.mockClear()
+      request.mockClear()
+
+      shown.value = false
+      await nextTick()
+      expect(cancel).toHaveBeenCalled()
+
+      request.mockClear()
+      shown.value = true
+      await nextTick()
+      expect(request).toHaveBeenCalled()
     })
   })
 

--- a/test/components/Countdown.spec.ts
+++ b/test/components/Countdown.spec.ts
@@ -169,10 +169,7 @@ describe('Countdown', () => {
     // countdown used to keep its `requestAnimationFrame` chain running —
     // emitting `progress`/`end` for something nobody can see, one chain per
     // cached instance.
-    it('stops and resumes its frame loop across `<KeepAlive>` toggles', async () => {
-      const cancel = vi.spyOn(window, 'cancelAnimationFrame').mockImplementation(() => {})
-      const request = vi.spyOn(window, 'requestAnimationFrame').mockImplementation(() => 1)
-
+    const keepAliveHarness = () => {
       const shown = ref(true)
       const Parent = defineComponent({
         setup() {
@@ -182,6 +179,58 @@ describe('Countdown', () => {
         }
       })
 
+      return { shown, Parent }
+    }
+
+    // Handles scheduled and not yet cancelled — the chains that would actually
+    // fire. Counting `requestAnimationFrame` calls instead would prove nothing:
+    // the component schedules a variable number of times (the deep props
+    // watcher runs more than once under the `nuxt` environment) and the fix
+    // does not remove a call, it cancels the handle the previous call left
+    // behind. Unique ids rather than a constant, so a cancel is attributable.
+    const trackFrames = () => {
+      const live = new Set<number>()
+      let nextId = 0
+
+      vi.spyOn(window, 'requestAnimationFrame').mockImplementation(() => {
+        const id = ++nextId
+        live.add(id)
+        return id
+      })
+      vi.spyOn(window, 'cancelAnimationFrame').mockImplementation((id: number) => {
+        live.delete(id)
+      })
+
+      return live
+    }
+
+    // Vue runs `onActivated` right after `onMounted` for a brand-new cached
+    // child, not only on a real reactivation. So the immediate props watcher's
+    // `start()` and `onActivated`'s `resumeCounting()` both reach
+    // `continueProcess()` on the very first mount, and `requestId` keeps only
+    // the last handle — the earlier chain becomes unreachable and goes on
+    // emitting `progress`/`end` with nothing able to cancel it.
+    it('leaves no extra frame chain alive under `<KeepAlive>`', async () => {
+      const live = trackFrames()
+
+      await mountSuspended(Countdown, { props: { seconds: 10 } })
+      const plain = live.size
+
+      live.clear()
+      await mountSuspended(keepAliveHarness().Parent)
+
+      // Measured against a plain mount rather than pinned to a number: under
+      // the `nuxt` project Nuxt's own `navigation-repaint` plugin schedules a
+      // frame of its own on every `mountSuspended`, and never cancels it. It
+      // lands on both sides equally, so the difference is the component's.
+      expect(live.size).toBe(plain)
+    })
+
+    it('stops and resumes its frame loop across `<KeepAlive>` toggles', async () => {
+      const cancel = vi.spyOn(window, 'cancelAnimationFrame').mockImplementation(() => {})
+      const request = vi.spyOn(window, 'requestAnimationFrame').mockImplementation(() => 1)
+
+      const { shown, Parent } = keepAliveHarness()
       await mountSuspended(Parent)
       cancel.mockClear()
       request.mockClear()
@@ -194,6 +243,30 @@ describe('Countdown', () => {
       shown.value = true
       await nextTick()
       expect(request).toHaveBeenCalled()
+    })
+
+    it('leaves a stopped countdown stopped across a `<KeepAlive>` toggle', async () => {
+      // Safe today only because `update()` and `continueProcess()` each guard
+      // on `counting`, and `resumeCounting()` never calls `start()`. Nothing
+      // structural protects it, so it is pinned here.
+      vi.spyOn(window, 'cancelAnimationFrame').mockImplementation(() => {})
+      const request = vi.spyOn(window, 'requestAnimationFrame').mockImplementation(() => 1)
+
+      const { shown, Parent } = keepAliveHarness()
+      const wrapper = await mountSuspended(Parent)
+      const countdown = wrapper.findComponent(Countdown).vm as any
+
+      countdown.stop()
+      expect(countdown.counting).toBe(false)
+
+      shown.value = false
+      await nextTick()
+      request.mockClear()
+      shown.value = true
+      await nextTick()
+
+      expect(countdown.counting).toBe(false)
+      expect(request).not.toHaveBeenCalled()
     })
   })
 

--- a/test/components/NavigationMenu.spec.ts
+++ b/test/components/NavigationMenu.spec.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, test, vi } from 'vitest'
+import { describe, it, expect, test } from 'vitest'
 import { axe } from 'vitest-axe'
 import { mountSuspended } from '@nuxt/test-utils/runtime'
 import { renderEach } from '../component-render'
@@ -138,16 +138,25 @@ describe('NavigationMenu', () => {
     // grouping itself is dropped.
     const links = [{ label: 'Link A', to: '/a' }, { label: 'Link B', to: '/b' }]
 
-    const mountVertical = (children: any) => mountSuspended(NavigationMenu, {
+    const mount = (children: any, props: Record<string, any> = {}) => mountSuspended(NavigationMenu, {
       props: {
         orientation: 'vertical',
-        items: [{ label: 'Docs', defaultOpen: true, children }]
+        items: [{ label: 'Docs', defaultOpen: true, children }],
+        ...props
       } as any
     })
 
-    it('renders the same children flat or grouped', async () => {
-      const flat = await mountVertical(links)
-      const grouped = await mountVertical([links])
+    // `getChildren()` feeds three call sites. Two are reachable from here: the
+    // vertical accordion, and the horizontal dropdown once `unmountOnHide` is
+    // false so its content is force-mounted rather than portalled on open. The
+    // third — the popover shown when a collapsed vertical menu has children —
+    // needs a real open interaction and is not covered.
+    it.each([
+      ['vertical accordion', {}],
+      ['horizontal dropdown', { orientation: 'horizontal', unmountOnHide: false }]
+    ])('renders children flat or grouped alike — %s', async (_name, props) => {
+      const flat = await mount(links, props)
+      const grouped = await mount([links], props)
 
       for (const wrapper of [flat, grouped]) {
         expect(wrapper.html()).toContain('Link A')
@@ -155,36 +164,43 @@ describe('NavigationMenu', () => {
       }
     })
 
-    it('warns that the grouping was dropped, once per item', async () => {
-      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    it('keeps `defaultOpen` working on a grouped child', async () => {
+      // `getAccordionDefaultValue` was the fourth read of `item.children` and
+      // the first pass missed it: it reduced over the nested arrays, which
+      // carry no `defaultOpen`, so a grouped child rendered but never opened —
+      // and the values it produced no longer lined up with the flattened index
+      // the rows are keyed by.
+      //
+      // Counted rather than matched on a substring: the parent item is itself
+      // `defaultOpen`, so `data-state="open"` appears either way and asserting
+      // its presence proves nothing.
+      const openStates = (wrapper: { html: () => string }) => (wrapper.html().match(/data-state="open"/g) || []).length
 
-      try {
-        await mountVertical([links])
+      const child = { label: 'Link B', to: '/b', defaultOpen: true }
+      const a = { label: 'Link A', to: '/a' }
 
-        // Only asserted where `import.meta.dev` is actually true — in the plain
-        // Vue project it is undefined, and a warning nobody sees is not worth
-        // failing the build over.
-        if (import.meta.dev) {
-          const messages = warn.mock.calls.map(([first]) => String(first)).filter(m => m.includes('B24NavigationMenu'))
-          expect(messages).toHaveLength(1)
-          expect(messages[0]).toContain('Docs')
-        }
-      } finally {
-        warn.mockRestore()
-      }
+      const groupedOpen = await mount([[a, child]])
+      const flatOpen = await mount([a, child])
+      const groupedClosed = await mount([[a, { label: 'Link B', to: '/b' }]])
+
+      expect(openStates(groupedOpen)).toBe(openStates(flatOpen))
+      expect(openStates(groupedOpen)).toBeGreaterThan(openStates(groupedClosed))
     })
 
-    it('leaves a flat children array alone', async () => {
-      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    it('survives a hole in a group instead of throwing', async () => {
+      // `.flat()` un-nests but keeps `null`, which then reaches
+      // `pickLinkProps` -> `Object.keys(null)`. Before the flattening existed
+      // the same input was merely inert, so tolerating the shape has to include
+      // tolerating what is in it.
+      const wrapper = await mount([[{ label: 'Link A', to: '/a' }, null, undefined]])
 
-      try {
-        await mountVertical(links)
-
-        expect(warn.mock.calls.map(([first]) => String(first)).filter(m => m.includes('B24NavigationMenu'))).toEqual([])
-      } finally {
-        warn.mockRestore()
-      }
+      expect(wrapper.html()).toContain('Link A')
     })
+
+    // The dev warning itself is not asserted anywhere, deliberately:
+    // `import.meta.dev` compiles to `undefined` in the `vue` project and
+    // `false` in the `nuxt` one, so the branch is unreachable from this suite
+    // and any assertion about it would pass whether it fired or not.
   })
 
   test('should have the correct types', () => {

--- a/test/components/NavigationMenu.spec.ts
+++ b/test/components/NavigationMenu.spec.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, test } from 'vitest'
+import { describe, it, expect, test, vi } from 'vitest'
 import { axe } from 'vitest-axe'
 import { mountSuspended } from '@nuxt/test-utils/runtime'
 import { renderEach } from '../component-render'
@@ -127,6 +127,64 @@ describe('NavigationMenu', () => {
     })
 
     expect(await axe(wrapper.element)).toHaveNoViolations()
+  })
+
+  describe('grouped children (#51)', () => {
+    // `items` accepts a flat array or an array of arrays, so reaching for the
+    // same shape on `children` is the natural guess — and it used to fail in
+    // total silence: every child `v-for` handed an array to a template
+    // expecting an object, so the vertical accordion opened onto nothing. The
+    // links are what the author wanted; render them, and warn that the
+    // grouping itself is dropped.
+    const links = [{ label: 'Link A', to: '/a' }, { label: 'Link B', to: '/b' }]
+
+    const mountVertical = (children: any) => mountSuspended(NavigationMenu, {
+      props: {
+        orientation: 'vertical',
+        items: [{ label: 'Docs', defaultOpen: true, children }]
+      } as any
+    })
+
+    it('renders the same children flat or grouped', async () => {
+      const flat = await mountVertical(links)
+      const grouped = await mountVertical([links])
+
+      for (const wrapper of [flat, grouped]) {
+        expect(wrapper.html()).toContain('Link A')
+        expect(wrapper.html()).toContain('Link B')
+      }
+    })
+
+    it('warns that the grouping was dropped, once per item', async () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+      try {
+        await mountVertical([links])
+
+        // Only asserted where `import.meta.dev` is actually true — in the plain
+        // Vue project it is undefined, and a warning nobody sees is not worth
+        // failing the build over.
+        if (import.meta.dev) {
+          const messages = warn.mock.calls.map(([first]) => String(first)).filter(m => m.includes('B24NavigationMenu'))
+          expect(messages).toHaveLength(1)
+          expect(messages[0]).toContain('Docs')
+        }
+      } finally {
+        warn.mockRestore()
+      }
+    })
+
+    it('leaves a flat children array alone', async () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+      try {
+        await mountVertical(links)
+
+        expect(warn.mock.calls.map(([first]) => String(first)).filter(m => m.includes('B24NavigationMenu'))).toEqual([])
+      } finally {
+        warn.mockRestore()
+      }
+    })
   })
 
   test('should have the correct types', () => {


### PR DESCRIPTION
### Linked issue

Closes #51, closes #336, closes #337, closes #340.

### Type of change

- [ ] Documentation (updates to the documentation or readme)
- [x] Bug fix (a non-breaking change that fixes an issue)
- [ ] Enhancement (improving an existing functionality)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Chore (updates to the build process or auxiliary tools and libraries)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Description

Four small component bugs. One is a real user report; three came out of reviewing #335 and #338 and were deliberately kept out of those PRs.

#### #51 — `NavigationMenu` grouped `children` render nothing

The one from outside, and the only bug report in the tracker filed by someone who isn't a maintainer.

`items` accepts either a flat array or an array of arrays, with a separator drawn between groups. Reaching for the same shape one level down, on an item's `children`, is the natural guess — and it failed in silence: every child `v-for` handed an *array* to a template expecting an object.

Reproduced before touching anything, in the vertical (accordion) orientation with `defaultOpen`:

| children shape | `Link A` | `Link B` | rendered length |
| --- | --- | --- | --- |
| flat | yes | yes | 6121 |
| grouped | **no** | **no** | 4661 |

The length grows either way, so the accordion body does mount — there isn't even an empty state to notice. Exactly what the reporter described.

`getChildren()` now flattens one level rather than rejecting it, so an app written against the wrong shape shows its links instead of a blank panel:

```ts
children: [[{ label: 'Link A', to: '/a' }, { label: 'Link B', to: '/b' }]]  // now renders
```

…with a dev-only warning naming the item, because the grouping itself is still not honoured — no separator is drawn, unlike `items` — and silently dropping the author's intent would move the confusion somewhere harder to find rather than remove it. The declared type stays `NavigationMenuChildItem[]`; nothing widens.

#### #336 — `ChatMessages` retained refs to removed messages

`registerMessageRef` ignored the `null` Vue passes on unmount, so a removed message left its detached element in `messagesRefs` for the component's lifetime. The only other cleanup is a bulk `.clear()` that fires when `messages` empties entirely — which is why resetting a thread looked fine and trimming a single message did not.

#### #337 — `Countdown` kept ticking inside `<KeepAlive>`

Deactivation does not run `onBeforeUnmount`, so a cached countdown kept its `requestAnimationFrame` chain alive, emitting `progress`/`end` for something nobody can see, one chain per cached instance.

Suspending and resuming is the same question a hidden browser tab asks, so both paths now share `suspendCounting()` / `resumeCounting()` rather than growing a second copy that can drift — the failure mode this repository has already been bitten by twice. `endTime` is absolute, so resuming lands on the correct remainder rather than where the clock was parked.

#### #340 — a slot-only description never rendered

The description span was gated on the item's own `description` field alone, so a description supplied purely by an `item-description` slot never mounted. The sibling label branch already carried the matching `!!slots[...]` term, and upstream has it on both — long-standing drift, unrelated to the port #338 finished.

### Review round

Six reviewers (docs/skill, engineer, QA, security, CTO, `/review`) went over the first commit. Four of what came back were defects in the fixes themselves, and are corrected in `bb72e05d`:

1. **The #337 fix did not close the leak.** Vue runs `onActivated` right after `onMounted` for a brand-new `<KeepAlive>` child, not only on a real reactivation — so the immediate props watcher's `start()` and `onActivated`'s `resumeCounting()` both reached `continueProcess()` on the very first mount, and `requestId` holds one handle with the last writer winning. Measured: one extra uncancellable chain, and `progress` firing twice for a single tick. `continueProcess()` now cancels before it schedules, which also covers any future third caller.
2. **The #51 fix was incomplete.** `getAccordionDefaultValue` was a fourth read of `item.children` and still received the raw nested array, which carries no `defaultOpen` — so a grouped child rendered but never opened, and the values no longer lined up with the flattened index the rows are keyed by.
3. **The #51 fix introduced a new crash.** `.flat()` un-nests one level but keeps `null`, which is then promoted to a top-level child and reaches `pickLinkProps`, whose first statement is `Object.keys(link)`. Before the flattening existed the same input was merely inert; now it threw, and Vue does not contain a render error to the component that raised it. Holes are filtered.
4. **Two of the new tests passed vacuously.** The `<KeepAlive>` test counted `requestAnimationFrame` calls, which the fix does not reduce — it cancels the handle the previous call left behind — so it now tracks *live* (scheduled-and-uncancelled) handles instead. The `defaultOpen` test asserted `toContain('data-state="open"')`, which is true either way because the parent item is itself open; it counts occurrences now. Two further tests asserting the dev warning were removed outright: `import.meta.dev` compiles to `undefined` in the `vue` project and `false` in the `nuxt` one, so the branch is unreachable from the suite and any assertion about it would pass whether it fired or not.

Also from the round: the shared fixture in `ChatMessages.spec.ts` gave both messages the **same `id`**, which the `v-for` key and `messagesRefs` cannot tell apart — it modelled a thread that cannot exist. Fixed, and snapshot-neutral, because the id never reaches the markup.

### Verification

Every regression test is confirmed to **fail against the code it guards**:

| test | mutation | result |
| --- | --- | --- |
| grouped children render (vertical) | `getChildren(item)` → `item.children` | `expected … to contain 'Link A'` |
| grouped children render (horizontal) | same, at the horizontal site | `expected … to contain 'Link A'` |
| `defaultOpen` on a grouped child | same, inside `getAccordionDefaultValue` | `expected 3 to be 4` |
| hole in a group | drop the `!= null` filter | `TypeError: Cannot read properties of null (reading 'defaultOpen')` |
| ref dropped on removal | delete the `else` branch | `expected [ 'first', 'second' ] to deeply equal [ 'first' ]` |
| no extra frame chain under `<KeepAlive>` | drop `cancelAnimationFrame(requestId.value)` | `expected 2 to be 1` (vue) / `expected 3 to be 2` (nuxt) |
| frame loop across `<KeepAlive>` | empty the `onDeactivated` body | `expected cancelAnimationFrame to be called at least once` |
| frame loop across `<KeepAlive>` | empty the `onActivated` body | `expected requestAnimationFrame to be called at least once` |
| slot-only description | drop the `!!slots[...]` term | `expected … to contain 'Description from a slot'` |

The live-handle test measures against a plain mount rather than a fixed number: under the `nuxt` project Nuxt's own `navigation-repaint` plugin schedules a frame per `mountSuspended` and never cancels it, so only the delta belongs to the component.

Full suite: **258 files, 5840 passed, 6 skipped**. `pnpm lint` and `pnpm typecheck` clean.

### Deviations

Two divergences from upstream, both now recorded as `.sync/PORTING.md` §2 invariants, because upstream still carries the bug in each case and a faithful port would silently revert the fix while looking correct:

- **`NavigationMenu` reads children through `getChildren()`, never `item.children`.** Upstream iterates `item.children` at all three template sites and hands it straight to `getAccordionDefaultValue`; everything around it — `lists` normalization, the `NavigationMenuChildItem[]` type — is byte-identical, so the call is the only thing marking the difference. Valid input behaves exactly as upstream; the tolerance only affects input upstream treats as broken.
- **`ChatMessages.registerMessageRef` deletes on `null`.** Upstream only ever `set`s (verified against `nuxt/ui@v4`), so the `else` branch reads as b24ui noise in a diff.

The other two need no rule: upstream already carries the `!!slots[...]` term on both `CommandPalette` branches, so #340 was b24ui drift and a port *restores* our behaviour; and `Countdown` is a Bitrix24-only component with no upstream counterpart.

### Checklist

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LWWrBHgfqGSbeU3V6UuMF8)_