### PR TITLE
chore(deps): allow `typescript` v7 as peer dependency (e7b126b)

### DIFF
--- a/.sync/log/e7b126b7aa7cb1b91fc641edfd46022a58c5d19e.md
+++ b/.sync/log/e7b126b7aa7cb1b91fc641edfd46022a58c5d19e.md
@@ -1,0 +1,34 @@
+# Port: chore(deps): allow `typescript` v7 as peer dependency
+
+**Upstream:** `e7b126b7aa7cb1b91fc641edfd46022a58c5d19e` (nuxt/ui, #6813)
+**Decision:** port — verbatim
+
+## Upstream change
+One line in `package.json` `peerDependencies`:
+
+```diff
+-"typescript": "^5.6.3 || ^6.0.0",
++"typescript": "^5.6.3 || ^6.0.0 || ^7.0.0",
+```
+
+Consumers already on the TypeScript 7 line stop getting an unmet-peer warning.
+Nothing else — no source, no toolchain move.
+
+## b24ui port
+- **`package.json`** — b24ui declared the identical range, so the widening
+  applied verbatim.
+- **`pnpm-lock.yaml`** — one line, the specifier echo in the root importer;
+  the resolved version is unchanged (`6.0.3`). Upstream's commit doesn't carry
+  a lockfile hunk, but b24ui's lockfile records specifiers, so leaving it stale
+  would desync it from the manifest.
+
+The fork's own toolchain is untouched: the playgrounds still pin
+`typescript: ^6.0.3` in their dev dependencies, and nothing installs TS 7 here.
+This only widens what consumers are allowed to bring.
+
+## Tests
+Manifest-only peer-range change — no runtime, theme or snapshot impact. Suite
+unchanged.
+
+## Verify (CI=true)
+`lint` · `typecheck` · `test` · `build` — all green.

--- a/.sync/nuxt-ui.json
+++ b/.sync/nuxt-ui.json
@@ -2,7 +2,7 @@
   "upstream": "nuxt/ui",
   "branch": "v4",
   "sync_enabled": false,
-  "cursor": "6add5fb7d8a1280dcbe2c4675e78d8f45f61e7fd",
+  "cursor": "e7b126b7aa7cb1b91fc641edfd46022a58c5d19e",
   "_cursor_note": "cursor = last upstream commit ported into b24ui (oldest-first, manual cadence). sync_enabled stays false until Phase 2 (porter workflow #67 + CLAUDE_CODE_OAUTH_TOKEN) is wired and trusted. `processed` is maintained per port from now on (backfilled #68-#72 on 2026-06-09).",
   "stats": {
     "queue_depth": 0,
@@ -1277,6 +1277,12 @@
       "b24ui_sha": "ec16d9c98b6597e3d7b611f24a8e601f4424eec9",
       "decision": "no-op",
       "summary": "chore(deps): update codspeedhq/action action to v5 — one line in .github/workflows/module.yml: CodSpeedHQ/action@v4 -> @v5. NOT APPLICABLE, as predicted when 8aa8041 (the commit introducing that job) was recorded as a no-op in PR #316: b24ui has no CodSpeed integration to bump — verified no occurrence of CodSpeed/codspeed anywhere in .github/, package.json, vitest.config.ts or pnpm-workspace.yaml, and its workflow inventory is only ci.yml/deploy.yml/npm-publish.yml. Upstream's own job is gated `if: github.repository_owner == 'nuxt'` ('Skip forks of the repo, they can't authenticate with CodSpeed'). No-op."
+    },
+    "e7b126b7aa7cb1b91fc641edfd46022a58c5d19e": {
+      "pr": null,
+      "b24ui_sha": "pending-merge",
+      "decision": "port",
+      "summary": "chore(deps): allow typescript v7 as peer dependency — package.json peerDependencies typescript '^5.6.3 || ^6.0.0' -> '^5.6.3 || ^6.0.0 || ^7.0.0', so consumers on the TS 7 line stop getting an unmet-peer warning. b24ui declared the identical range; applied verbatim. pnpm-lock.yaml also moves one line (the specifier echo in the root importer) — resolved version unchanged at 6.0.3; upstream's commit has no lockfile hunk but b24ui's lockfile records specifiers, so leaving it stale would desync it from the manifest. The fork's own toolchain is untouched (playgrounds still pin typescript ^6.0.3); this only widens what consumers may bring. Manifest-only, no runtime/snapshot impact. Tests 5862/260 files."
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -238,7 +238,7 @@
     "joi": "^18.0.0",
     "superstruct": "^2.0.0",
     "tailwindcss": "^4.0.0",
-    "typescript": "^5.6.3 || ^6.0.0",
+    "typescript": "^5.6.3 || ^6.0.0 || ^7.0.0",
     "valibot": "^1.0.0",
     "vue-router": "^4.5.0 || ^5.0.0",
     "yup": "^1.7.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -209,7 +209,7 @@ importers:
         specifier: ^0.2.17
         version: 0.2.17
       typescript:
-        specifier: ^5.6.3 || ^6.0.0
+        specifier: ^5.6.3 || ^6.0.0 || ^7.0.0
         version: 6.0.3
       ufo:
         specifier: ^1.6.4


### PR DESCRIPTION
Syncs upstream nuxt/ui commit [`e7b126b`](https://github.com/nuxt/ui/commit/e7b126b7aa7cb1b91fc641edfd46022a58c5d19e) — *chore(deps): allow `typescript` v7 as peer dependency* (#6813).

## What
One line in `package.json` `peerDependencies`:

```diff
-"typescript": "^5.6.3 || ^6.0.0",
+"typescript": "^5.6.3 || ^6.0.0 || ^7.0.0",
```

Consumers already on the TypeScript 7 line stop getting an unmet-peer warning.

## b24ui port
- **`package.json`** — b24ui declared the identical range, so the widening applied **verbatim**.
- **`pnpm-lock.yaml`** — moves by one line: the specifier echo in the root importer. The **resolved version is unchanged (`6.0.3`)**. Upstream's commit carries no lockfile hunk, but b24ui's lockfile records specifiers, so leaving it stale would desync it from the manifest.

The fork's own toolchain is untouched — the playgrounds still pin `typescript: ^6.0.3` and nothing installs TS 7 here. This only widens what **consumers** are allowed to bring.

## Tests
Manifest-only peer-range change — no runtime, theme or snapshot impact. Suite: **5862 passed / 6 skipped across 260 files**.

## Verify (`CI=true`)
`lint` · `typecheck` · `test` · `build` — all green.

Ledger: cursor advanced to `e7b126b` (upstream `v4` HEAD).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JS8ypVfQSFzYVZzkTHhURb)_