### PR TITLE
chore(sync): reconcile e7b126b with its merged PR

### DIFF
--- a/.sync/nuxt-ui.json
+++ b/.sync/nuxt-ui.json
@@ -1279,8 +1279,8 @@
       "summary": "chore(deps): update codspeedhq/action action to v5 — one line in .github/workflows/module.yml: CodSpeedHQ/action@v4 -> @v5. NOT APPLICABLE, as predicted when 8aa8041 (the commit introducing that job) was recorded as a no-op in PR #316: b24ui has no CodSpeed integration to bump — verified no occurrence of CodSpeed/codspeed anywhere in .github/, package.json, vitest.config.ts or pnpm-workspace.yaml, and its workflow inventory is only ci.yml/deploy.yml/npm-publish.yml. Upstream's own job is gated `if: github.repository_owner == 'nuxt'` ('Skip forks of the repo, they can't authenticate with CodSpeed'). No-op."
     },
     "e7b126b7aa7cb1b91fc641edfd46022a58c5d19e": {
-      "pr": null,
-      "b24ui_sha": "pending-merge",
+      "pr": 348,
+      "b24ui_sha": "074812954b5fd1a85e71a3b71d0b66f6dee21383",
       "decision": "port",
       "summary": "chore(deps): allow typescript v7 as peer dependency — package.json peerDependencies typescript '^5.6.3 || ^6.0.0' -> '^5.6.3 || ^6.0.0 || ^7.0.0', so consumers on the TS 7 line stop getting an unmet-peer warning. b24ui declared the identical range; applied verbatim. pnpm-lock.yaml also moves one line (the specifier echo in the root importer) — resolved version unchanged at 6.0.3; upstream's commit has no lockfile hunk but b24ui's lockfile records specifiers, so leaving it stale would desync it from the manifest. The fork's own toolchain is untouched (playgrounds still pin typescript ^6.0.3); this only widens what consumers may bring. Manifest-only, no runtime/snapshot impact. Tests 5862/260 files."
     }


### PR DESCRIPTION
Ledger bookkeeping — fills in the last placeholder.

`e7b126b` (*typescript v7 peer range*) was recorded with `b24ui_sha: "pending-merge"` when its PR was still open. Now reconciled to **PR #348**, merged as **`0748129`**.

- **`.sync/nuxt-ui.json`** — two lines: `pr: 348`, `b24ui_sha: 074812954b5fd1a85e71a3b71d0b66f6dee21383`.

Cursor unchanged at `e7b126b` (= upstream `v4` HEAD). **No `pending-merge` placeholders remain across all 212 entries.**

## Tests
Bookkeeping only — no source, docs or test changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JS8ypVfQSFzYVZzkTHhURb)_