### PR TITLE
fix(Editor): ignore updates without document changes

### DIFF
--- a/.sync/log/7e615e1a0e186e8433b6b0e6fad4b02c9bb3d344.md
+++ b/.sync/log/7e615e1a0e186e8433b6b0e6fad4b02c9bb3d344.md
@@ -1,0 +1,66 @@
+# Port: fix(Editor): ignore updates without document changes
+
+**Upstream:** `7e615e1a0e186e8433b6b0e6fad4b02c9bb3d344` (nuxt/ui, #6807)
+**Decision:** port — verbatim (test content reworded)
+
+## Upstream change
+Tiptap fires `onUpdate` for **every** transaction, not only for document
+edits. Selection moves, decoration refreshes and `setEditable()` all produce
+transactions with `docChanged === false`, and each one made the editor
+re-serialize its content and emit `update:modelValue`. Two consequences:
+
+- a spurious `update:modelValue` on a merely-focused (or read-only-toggled)
+  editor, which round-trips content through the serializer and can normalise
+  the user's markup behind their back;
+- pointless `getHTML()` / `getJSON()` / `getMarkdown()` work on every caret
+  move.
+
+The fix is an early return guarding the handler:
+
+```diff
+-  onUpdate: ({ editor }) => {
++  onUpdate: ({ editor, transaction, appendedTransactions }) => {
++    if (!transaction.docChanged && !appendedTransactions.some(tr => tr.docChanged)) {
++      return
++    }
++
+     let value
+```
+
+`appendedTransactions` is checked too: an extension (e.g. the trailing-node
+plugin from StarterKit) can append a real document change to a transaction
+that was itself selection-only, and dropping those would lose edits.
+
+## b24ui port
+b24ui's `Editor.vue` `onUpdate` was byte-identical to upstream's pre-change
+version, so both hunks applied verbatim:
+
+- **`src/runtime/components/Editor.vue`** — the guard above.
+- **`test/components/Editor.spec.ts`** — upstream's new regression test,
+  with the sample content reworded to the fork's own copy
+  (`'# Building Modern Interfaces with Bitrix24 UI'`). It mounts a markdown
+  editor with a placeholder, calls `editor.setEditable(false)` — which
+  dispatches a selection-only transaction — and asserts no
+  `update:modelValue` was emitted.
+
+The placeholder matters to the test: `onCreate` dispatches
+`editor.state.tr` to force placeholder decorations to render, which is
+exactly the kind of no-op transaction the guard now filters.
+
+## Tests
+Proven meaningful rather than assumed. With the guard reverted but the test
+present, it fails in **both** projects:
+
+```
+FAIL  |vue| test/components/Editor.spec.ts > Editor > does not update the model when the document is unchanged
+FAIL  |nuxt| test/components/Editor.spec.ts > Editor > does not update the model when the document is unchanged
+Tests  2 failed | 12 passed (14)
+```
+
+With the guard restored: `Test Files 2 passed (2) / Tests 14 passed (14)`.
+
+Full suite: 5878 passed | 6 skipped across 262 files (+2 tests — the new
+case runs in both the `nuxt` and `vue` projects).
+
+## Verify (CI=true)
+`lint` · `test` · `typecheck` · `build` — all green.

--- a/.sync/nuxt-ui.json
+++ b/.sync/nuxt-ui.json
@@ -2,7 +2,7 @@
   "upstream": "nuxt/ui",
   "branch": "v4",
   "sync_enabled": false,
-  "cursor": "e7b126b7aa7cb1b91fc641edfd46022a58c5d19e",
+  "cursor": "7e615e1a0e186e8433b6b0e6fad4b02c9bb3d344",
   "_cursor_note": "cursor = last upstream commit ported into b24ui (oldest-first, manual cadence). sync_enabled stays false until Phase 2 (porter workflow #67 + CLAUDE_CODE_OAUTH_TOKEN) is wired and trusted. `processed` is maintained per port from now on (backfilled #68-#72 on 2026-06-09).",
   "stats": {
     "queue_depth": 0,
@@ -1283,6 +1283,12 @@
       "b24ui_sha": "074812954b5fd1a85e71a3b71d0b66f6dee21383",
       "decision": "port",
       "summary": "chore(deps): allow typescript v7 as peer dependency — package.json peerDependencies typescript '^5.6.3 || ^6.0.0' -> '^5.6.3 || ^6.0.0 || ^7.0.0', so consumers on the TS 7 line stop getting an unmet-peer warning. b24ui declared the identical range; applied verbatim. pnpm-lock.yaml also moves one line (the specifier echo in the root importer) — resolved version unchanged at 6.0.3; upstream's commit has no lockfile hunk but b24ui's lockfile records specifiers, so leaving it stale would desync it from the manifest. The fork's own toolchain is untouched (playgrounds still pin typescript ^6.0.3); this only widens what consumers may bring. Manifest-only, no runtime/snapshot impact. Tests 5862/260 files."
+    },
+    "7e615e1a0e186e8433b6b0e6fad4b02c9bb3d344": {
+      "pr": null,
+      "b24ui_sha": "pending-merge",
+      "decision": "port",
+      "summary": "fix(Editor): ignore updates without document changes (nuxt/ui #6807) — Tiptap fires onUpdate for every transaction, so selection moves, decoration refreshes and setEditable() (docChanged === false) made Editor re-serialize and emit update:modelValue. Added an early return guarding the handler: `if (!transaction.docChanged && !appendedTransactions.some(tr => tr.docChanged)) return`. appendedTransactions is checked too because an extension (e.g. StarterKit's trailing-node plugin) can append a real doc change to a selection-only transaction. b24ui's onUpdate was byte-identical to upstream's pre-change version, so both hunks applied verbatim; upstream's new regression test was ported with the sample content reworded to the fork's copy ('# Building Modern Interfaces with Bitrix24 UI'). Test proven meaningful: with the guard reverted it fails in both the nuxt and vue projects, with it restored Editor.spec is 14/14. Tests 5878 passed | 6 skipped / 262 files."
     }
   }
 }

--- a/src/runtime/components/Editor.vue
+++ b/src/runtime/components/Editor.vue
@@ -247,7 +247,11 @@ const editor = useEditor({
       editor.view.dispatch(editor.state.tr)
     }
   },
-  onUpdate: ({ editor }) => {
+  onUpdate: ({ editor, transaction, appendedTransactions }) => {
+    if (!transaction.docChanged && !appendedTransactions.some(tr => tr.docChanged)) {
+      return
+    }
+
     let value
     try {
       if (contentType.value === 'html') {

--- a/test/components/Editor.spec.ts
+++ b/test/components/Editor.spec.ts
@@ -26,4 +26,21 @@ describe('Editor', () => {
 
     wrapper.unmount()
   })
+
+  it('does not update the model when the document is unchanged', async () => {
+    const wrapper = await mountSuspended(Editor, {
+      props: {
+        contentType: 'markdown',
+        modelValue: '# Building Modern Interfaces with Bitrix24 UI',
+        placeholder: 'Write something...'
+      }
+    })
+    const editor = wrapper.vm.editor!
+
+    editor.setEditable(false)
+
+    expect(wrapper.emitted('update:modelValue')).toBeUndefined()
+
+    wrapper.unmount()
+  })
 })


### PR DESCRIPTION
Sync with `nuxt/ui` — ports [`7e615e1`](https://github.com/nuxt/ui/commit/7e615e1a0e186e8433b6b0e6fad4b02c9bb3d344) (nuxt/ui#6807).

## Problem

Tiptap fires `onUpdate` for **every** transaction, not only for document edits. Selection moves, decoration refreshes and `setEditable()` all produce transactions with `docChanged === false`, and each one made `Editor` re-serialize its content and emit `update:modelValue`. Two consequences:

- a spurious `update:modelValue` on a merely-focused (or read-only-toggled) editor, which round-trips content through the serializer and can normalise the user's markup behind their back;
- pointless `getHTML()` / `getJSON()` / `getMarkdown()` work on every caret move.

## Fix

```diff
-  onUpdate: ({ editor }) => {
+  onUpdate: ({ editor, transaction, appendedTransactions }) => {
+    if (!transaction.docChanged && !appendedTransactions.some(tr => tr.docChanged)) {
+      return
+    }
+
     let value
```

`appendedTransactions` is checked too: an extension (e.g. StarterKit's trailing-node plugin) can append a real document change to a transaction that was itself selection-only, and dropping those would lose edits.

b24ui's `onUpdate` was byte-identical to upstream's pre-change version, so both hunks applied verbatim. The new regression test carries the fork's own sample content (`'# Building Modern Interfaces with Bitrix24 UI'`).

## Tests

Proven meaningful rather than assumed — with the guard reverted but the test present, it fails in **both** projects:

```
FAIL  |vue| test/components/Editor.spec.ts > Editor > does not update the model when the document is unchanged
FAIL  |nuxt| test/components/Editor.spec.ts > Editor > does not update the model when the document is unchanged
Tests  2 failed | 12 passed (14)
```

With the guard restored: `Test Files 2 passed (2) / Tests 14 passed (14)`.

Full suite: **5878 passed | 6 skipped** across 262 files.

## Verify (`CI=true`)

`lint` · `test` · `typecheck` · `build` — all green.

Ledger: cursor → `7e615e1`, journal at `.sync/log/7e615e1a0e186e8433b6b0e6fad4b02c9bb3d344.md`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01JS8ypVfQSFzYVZzkTHhURb)_