### PR TITLE
chore(sync): record three upstream commits that do not apply

### DIFF
--- a/.sync/log/094fb576c343a65bbff49e8f10c6999ba8e9d046.md
+++ b/.sync/log/094fb576c343a65bbff49e8f10c6999ba8e9d046.md
@@ -1,0 +1,30 @@
+# No-op: chore(deps): release-it to v21 and @release-it/conventional-changelog to v12
+
+**Upstream:** `094fb576c343a65bbff49e8f10c6999ba8e9d046` (nuxt/ui)
+**Decision:** no-op — the tool is not used in this fork
+
+## Upstream change
+Two lines in the root `package.json` `devDependencies`, plus the lockfile:
+
+```diff
+-"@release-it/conventional-changelog": "^11.0.1",
++"@release-it/conventional-changelog": "^12.0.0",
+-"release-it": "^20.2.1",
++"release-it": "^21.0.2",
+```
+
+Nothing else — no config, no workflow, no source.
+
+## Why it does not apply
+b24ui does not release with release-it. It uses **release-please**:
+`release-please-config.json`, `.release-please-manifest.json` and
+`.github/workflows/release-please.yml`, with publishing handled by
+`npm-publish.yml`.
+
+Confirmed rather than assumed: neither `release-it` nor
+`@release-it/conventional-changelog` appears in any manifest in this repository,
+and neither is referenced by any workflow. There is no `.release-it.json`,
+no `release-it` key in `package.json`, and no `release-it` invocation to bump.
+
+Nothing to port. Recorded so the cursor advances and the next reader does not
+re-derive this.

--- a/.sync/log/10ec237623bc8f4b8cf6b9d45ab4ae24105e0fd8.md
+++ b/.sync/log/10ec237623bc8f4b8cf6b9d45ab4ae24105e0fd8.md
@@ -1,0 +1,48 @@
+# No-op: fix(locale): correct slide placeholder casing in lb
+
+**Upstream:** `10ec237623bc8f4b8cf6b9d45ab4ae24105e0fd8` (nuxt/ui, #6822)
+**Decision:** no-op — locale absent; the same bug class audited and absent too
+
+## Upstream change
+One character in `src/runtime/locale/lb.ts` (Luxembourgish):
+
+```diff
+     carousel: {
+       dots: 'Wielt Dia fir ze weisen',
+-      goto: 'Gitt op d\'Slide {Slide}',
++      goto: 'Gitt op d\'Slide {slide}',
+```
+
+The interpolation key is case-sensitive: `{Slide}` never matched the `slide`
+value the component passes, so Luxembourgish users saw the literal `{Slide}`
+in the carousel's go-to-slide label instead of a number.
+
+## Why it does not apply
+b24ui ships its own locale set — `ar, br, de, en, fr, id, in, it, ja, kz, la,
+ms, pl, ru, sc, tc, th, tr, ua, vn` — and has no `lb.ts`. The file upstream
+edits does not exist here.
+
+## Audited rather than just skipped
+The interesting part of this fix is not the language, it is the *bug class*: a
+placeholder whose casing does not match the key the component interpolates
+fails silently — no error, no test failure, just a literal `{Slide}` on screen.
+Since b24ui maintains 20 locales of its own, the same mistake could exist here
+independently of upstream. It does not:
+
+```
+$ grep -ohE "\{[A-Za-z_][A-Za-z0-9_]*\}" src/runtime/locale/*.ts | sort | uniq -c
+     40 {label}
+     20 {slide}
+     20 {name}
+     20 {filename}
+     20 {duration}
+
+$ grep -nE "\{[A-Z]" src/runtime/locale/*.ts
+(none)
+```
+
+Every placeholder in every b24ui locale is lower-case, and the counts line up
+exactly with 20 locale files (`{label}` twice per file, the rest once), so no
+locale is missing or mis-spelling one either.
+
+Nothing to port.

--- a/.sync/log/795c3538bba124d5a2d9832b59c92c3347a5f59d.md
+++ b/.sync/log/795c3538bba124d5a2d9832b59c92c3347a5f59d.md
@@ -1,0 +1,44 @@
+# No-op: fix(AuthForm): type submit payload with the schema output
+
+**Upstream:** `795c3538bba124d5a2d9832b59c92c3347a5f59d` (nuxt/ui, #6816)
+**Decision:** no-op — component absent; the same bug class audited and absent too
+
+## Upstream change
+`src/runtime/components/AuthForm.vue` typed its `submit` emit from the
+component's own reactive state object:
+
+```diff
+-defineEmits<AuthFormEmits<typeof state>>()
++defineEmits<AuthFormEmits<FormData<T>>>()
+```
+
+`state` is assembled from the `fields` prop, so it describes what the form
+*renders*, not what the schema *produces*. Anything the schema adds — a
+`.default()`, a transform, a coerced type — was missing from or wrong in the
+emitted payload's type. `FormData<T>` is the schema output, which is what
+actually arrives in the handler.
+
+The commit also adds a type-level regression test using `expectEmitPayloadType`
+with a `z.boolean().default(false)` field — the exact case `typeof state` got
+wrong.
+
+## Why it does not apply
+b24ui has no `AuthForm` component. There is no
+`src/runtime/components/AuthForm.vue` and no `test/components/AuthForm.spec.ts`
+here; the file upstream edits does not exist.
+
+## Audited rather than just skipped
+The building blocks the fix uses *do* exist in this fork — `FormData<S, T>` in
+`src/runtime/types/form.ts` and the `expectEmitPayloadType` helper in
+`test/utils/types.ts` (already used by `Listbox`, `Select`, `SelectMenu` and
+`InputMenu` specs) — so the same mistake could have been made independently in
+whichever component emits a form submit here. Checked: the only one is
+`Form.vue`, and it is already correct:
+
+```ts
+export interface FormEmits<S extends FormSchema, T extends boolean = true> {
+  submit: [event: FormSubmitEvent<FormData<S, T>>]
+}
+```
+
+Schema-derived, not `typeof state`. Nothing to port.

--- a/.sync/nuxt-ui.json
+++ b/.sync/nuxt-ui.json
@@ -2,7 +2,7 @@
   "upstream": "nuxt/ui",
   "branch": "v4",
   "sync_enabled": false,
-  "cursor": "18c231a57f18956aa62f0bf7b12812c3121ff5ec",
+  "cursor": "795c3538bba124d5a2d9832b59c92c3347a5f59d",
   "_cursor_note": "cursor = last upstream commit ported into b24ui (oldest-first, manual cadence). sync_enabled stays false until Phase 2 (porter workflow #67 + CLAUDE_CODE_OAUTH_TOKEN) is wired and trusted. `processed` is maintained per port from now on (backfilled #68-#72 on 2026-06-09).",
   "stats": {
     "queue_depth": 0,
@@ -1309,10 +1309,28 @@
       "summary": "chore(deps): update nuxt framework to ^4.5.2 (nuxt/ui #6801) — §2 mirror with complete overlap: @nuxt/kit + @nuxt/schema ^4.5.1->^4.5.2 in root package.json, nuxt ^4.5.1->^4.5.2 in root devDependencies + docs + playgrounds/nuxt + the fork-only playgrounds/demo, and the '@nuxt/kit': ^4.5.2 override in pnpm-workspace.yaml. One comment touched: the vite override is introduced by 'nuxt 4.5.1 requires vite ^8...', written when 4.5.1 was current and now naming a version the repo no longer installs — reworded to 'nuxt 4.5.x' since the constraint is the major, not the patch; the override itself is unchanged. Checked what 4.5.2 actually contains: vite (client manifest path, vite-node environment-API sourcemaps, worker build asset filenames), nuxt (client-side navigation for links inside islands, definePageMeta route-param types, island payload serialization for components with underscores, build output caching after Vue cache restoration, route rules matched against decoded paths, asyncData status settling when bailing), kit (nested apply/applyToEnvironment honoured in vite, plugin enforce handling in the vite wrappers, config cloning), nitro (island renders deduped during prerendering, import.meta.test for server code). The nitro prerender dedupe and the vite manifest fix touch the docs build path this fork exercises out-of-band; nothing needed a source change here. Tests 5878 passed | 6 skipped / 262 files, unchanged."
     },
     "18c231a57f18956aa62f0bf7b12812c3121ff5ec": {
-      "pr": null,
-      "b24ui_sha": "pending-merge",
+      "pr": 360,
+      "b24ui_sha": "27b4db3001e96605ffa6fdfb2ee242b80fe78c87",
       "decision": "port",
       "summary": "chore(deps): update @nuxtjs/mdc to ^0.23.1 (nuxt/ui) — docs @nuxtjs/mdc ^0.22.2 -> ^0.23.1 plus upstream's new transitive override '@nuxt/content>@nuxtjs/mdc': ^0.23.1. Verified the premise rather than trusting the comment: @nuxt/content@3.15.2 does declare '@nuxtjs/mdc': '^0.22.2' in its dependencies, and b24ui docs sits on the same pairing, so bumping only docs would install a second mdc copy and component-meta would read different components than the ones the module registers. Ported verbatim, comment included; after install @nuxtjs/mdc resolves to a single copy at 0.23.1. MINIMUM-RELEASE-AGE NOTE SUPERSEDES d7284f3's: that entry recorded that b24ui has no minimumReleaseAgeExclude block, so upstream's entries were treated as n/a — but pnpm 11.20.0 applies a release-age cooldown by default and on this install created the block itself, appending @nuxtjs/mdc@0.23.1, the same entry upstream added by hand. Kept. (@nuxt/icon@2.5.0 from 229b64f stays correctly skipped — that package is not in this tree at all.) renovate.json skipped consistently with 229b64f: no renovate here, dependabot.yml is deliberately github-actions-only, and the allowedVersions rule upstream is deleting ('<0.23.0 || >0.23.0', which had blocked exactly 0.23.0) is one this fork never had. Tests 5878 passed | 6 skipped / 262 files, unchanged. docs:generate run out-of-band since mdc is the docs markdown pipeline and the ci gate never builds the docs site: Prerendered 1240 routes, exit 0 — same route count as before the bump, which is the check that matters (a second mdc copy would surface as components resolving differently, not as a build error)."
+    },
+    "094fb576c343a65bbff49e8f10c6999ba8e9d046": {
+      "pr": null,
+      "b24ui_sha": "pending-merge",
+      "decision": "no-op",
+      "summary": "chore(deps): release-it to v21 and @release-it/conventional-changelog to v12 (nuxt/ui) — NO-OP: two lines in upstream's root devDependencies (@release-it/conventional-changelog ^11.0.1 -> ^12.0.0, release-it ^20.2.1 -> ^21.0.2) plus the lockfile; no config, workflow or source. b24ui does not release with release-it — it uses release-please (release-please-config.json, .release-please-manifest.json, .github/workflows/release-please.yml) with publishing in npm-publish.yml. Confirmed rather than assumed: neither package appears in any manifest in this repository, neither is referenced by any workflow, there is no .release-it.json and no release-it key in package.json. Nothing to bump."
+    },
+    "10ec237623bc8f4b8cf6b9d45ab4ae24105e0fd8": {
+      "pr": null,
+      "b24ui_sha": "pending-merge",
+      "decision": "no-op",
+      "summary": "fix(locale): correct slide placeholder casing in lb (nuxt/ui #6822) — NO-OP: one character in src/runtime/locale/lb.ts, carousel.goto 'Gitt op d\\'Slide {Slide}' -> '{slide}'. The interpolation key is case-sensitive, so {Slide} never matched the value the component passes and Luxembourgish users saw the literal {Slide} instead of a number. b24ui ships its own locale set (ar, br, de, en, fr, id, in, it, ja, kz, la, ms, pl, ru, sc, tc, th, tr, ua, vn) and has no lb.ts. AUDITED rather than just skipped, because the interesting part is the bug class — a placeholder whose casing does not match the interpolated key fails silently, with no error and no test failure — and b24ui maintains 20 locales of its own where the same mistake could exist independently. It does not: grep over src/runtime/locale/*.ts yields only {label} x40, {slide} x20, {name} x20, {filename} x20, {duration} x20, and zero placeholders starting with an uppercase letter. Counts line up exactly with 20 locale files ({label} twice per file, the rest once), so no locale is missing or mis-spelling one either."
+    },
+    "795c3538bba124d5a2d9832b59c92c3347a5f59d": {
+      "pr": null,
+      "b24ui_sha": "pending-merge",
+      "decision": "no-op",
+      "summary": "fix(AuthForm): type submit payload with the schema output (nuxt/ui #6816) — NO-OP: AuthForm.vue typed its submit emit from the component's own reactive state (defineEmits<AuthFormEmits<typeof state>>() -> <AuthFormEmits<FormData<T>>>()). state is assembled from the fields prop, so it describes what the form renders rather than what the schema produces — anything the schema adds (a .default(), a transform, a coerced type) was missing or wrong in the emitted payload's type. The commit also adds a type-level regression test via expectEmitPayloadType with a z.boolean().default(false) field, the exact case typeof state got wrong. b24ui has no AuthForm component (no src/runtime/components/AuthForm.vue, no test/components/AuthForm.spec.ts). AUDITED rather than just skipped, because the building blocks do exist here — FormData<S, T> in src/runtime/types/form.ts and the expectEmitPayloadType helper in test/utils/types.ts, already used by the Listbox/Select/SelectMenu/InputMenu specs — so the same mistake could have been made independently in whichever component emits a form submit. The only one is Form.vue, and it is already correct: FormEmits declares submit: [event: FormSubmitEvent<FormData<S, T>>], schema-derived rather than typeof state."
     }
   }
 }


### PR DESCRIPTION
Bookkeeping only — **no source, manifest or lockfile change**. Advances the ledger cursor past three `nuxt/ui` commits with nothing to port, and records *why*, so the next reader does not re-derive it. Batched into one PR rather than three near-empty ones, as with #201, #209, #210 and #216.

Each one was checked against the actual upstream diff, not the commit title.

---

### [`094fb57`](https://github.com/nuxt/ui/commit/094fb576c343a65bbff49e8f10c6999ba8e9d046) — `chore(deps): release-it to v21 and @release-it/conventional-changelog to v12`

Two lines in upstream's root `devDependencies` plus the lockfile. No config, no workflow, no source.

We do not release with release-it — we use **release-please** (`release-please-config.json`, `.release-please-manifest.json`, `.github/workflows/release-please.yml`), with publishing in `npm-publish.yml`. Confirmed rather than assumed: neither package appears in any manifest here, neither is referenced by any workflow, and there is no `.release-it.json` or `release-it` key in `package.json`.

---

### [`10ec237`](https://github.com/nuxt/ui/commit/10ec237623bc8f4b8cf6b9d45ab4ae24105e0fd8) — `fix(locale): correct slide placeholder casing in lb` (nuxt/ui#6822)

One character in `src/runtime/locale/lb.ts`: `'Gitt op d\'Slide {Slide}'` → `{slide}`. The interpolation key is case-sensitive, so `{Slide}` never matched and Luxembourgish users saw the literal `{Slide}` instead of a number.

b24ui ships its own locale set (`ar, br, de, en, fr, id, in, it, ja, kz, la, ms, pl, ru, sc, tc, th, tr, ua, vn`) — there is no `lb.ts`.

**Audited rather than shrugged off**, because the interesting part is the bug class: a placeholder whose casing does not match the interpolated key fails *silently* — no error, no test failure — and we maintain 20 locales of our own where the same mistake could exist independently.

```
$ grep -ohE "\{[A-Za-z_][A-Za-z0-9_]*\}" src/runtime/locale/*.ts | sort | uniq -c
     40 {label}
     20 {slide}
     20 {name}
     20 {filename}
     20 {duration}

$ grep -nE "\{[A-Z]" src/runtime/locale/*.ts
(none)
```

Every placeholder is lower-case, and the counts line up exactly with 20 locale files (`{label}` twice per file, the rest once) — so no locale is missing or mis-spelling one either.

---

### [`795c353`](https://github.com/nuxt/ui/commit/795c3538bba124d5a2d9832b59c92c3347a5f59d) — `fix(AuthForm): type submit payload with the schema output` (nuxt/ui#6816)

```diff
-defineEmits<AuthFormEmits<typeof state>>()
+defineEmits<AuthFormEmits<FormData<T>>>()
```

`state` is assembled from the `fields` prop, so it describes what the form *renders*, not what the schema *produces* — anything the schema adds (a `.default()`, a transform, a coerced type) was missing or wrong in the emitted payload's type.

We have no `AuthForm` component. **Audited rather than shrugged off**, because the building blocks do exist here — `FormData<S, T>` in `src/runtime/types/form.ts` and the `expectEmitPayloadType` helper in `test/utils/types.ts` (already used by the `Listbox`, `Select`, `SelectMenu` and `InputMenu` specs) — so the same mistake could have been made independently. The only component that emits a form submit is `Form.vue`, and it is already correct:

```ts
export interface FormEmits<S extends FormSchema, T extends boolean = true> {
  submit: [event: FormSubmitEvent<FormData<S, T>>]
}
```

Schema-derived, not `typeof state`.

---

## Verify

`lint` green. Nothing else runs differently — the diff is three journal files under `.sync/log/` and three ledger entries.

Ledger: cursor → `795c353`; the `18c231a` entry is reconciled to PR #360 / `27b4db3`. **This brings the fork level with `nuxt/ui@v4` HEAD.**


---
_Generated by [Claude Code](https://claude.ai/code/session_01JS8ypVfQSFzYVZzkTHhURb)_