### PR TITLE
fix(CommandPalette): cut search highlights on grapheme clusters, not code points

### DIFF
--- a/.sync/PORTING.md
+++ b/.sync/PORTING.md
@@ -187,6 +187,72 @@ material. Reproduce its *intent* in b24ui by editing files under `src/` only.
   `test/components/CommandPalette.spec.ts`, which fails if the fifth argument
   stops being forwarded from `processGroupItems`. Port the intent and keep the
   fifth argument; trust those two specs over this paragraph.
+- **`utils/search.ts` cuts on grapheme clusters, at both boundaries.** Fuse
+  reports `indices` as UTF-16 code-unit offsets and the truncation counter walks
+  code points, so either boundary can land inside a character the reader sees as
+  one. Two failure modes, and the second is worse: splitting a surrogate pair
+  orphans both halves and renders as `�` (#362 — reproduced with real fuse.js at
+  `ContentSearch`'s options, 8 of 66 live matches over emoji-bearing labels),
+  while splitting a *cluster* yields a **different** character with nothing to
+  signal the loss (#364 — 🇺🇸 cut by one code point re-pairs into 🇸🇺, a
+  different country). `createClusterSnapper(value)` moves each boundary off the
+  straddled cluster before the slice: `generateHighlightedText` uses both ends of
+  it, `truncateHTMLFromStart` only `.toEnd()`, since a cut has one side. Four
+  details are load-bearing and easy to drop as noise:
+  - **The bookkeeping around the snap** — the clamps on `start` and `end`, the
+    `end > start` test, the integer filter and the sort. Every one of them
+    exists because `substring()` reports no errors: it swaps a range it finds
+    reversed and clamps one it finds out of range, so an ordering mistake here
+    surfaces as duplicated text rather than a throw. Snapping alone produces
+    all four mistakes — adjacent regions meeting inside one cluster snap past
+    each other; a region nested in an earlier one ends behind the cursor; a
+    region past the end of the value slices to nothing while still comparing
+    as non-empty, giving a bare `<mark></mark>`; and a region the clamps leave
+    empty does the same. The sort keeps regions in order (unordered, the
+    clamps swallow each one that arrives after a later one) and puts the
+    longest of an equal-start pair first, so the outer region is marked whole.
+    The filter drops non-integer bounds, which `Fuse` never emits but
+    `postFilter` may: `NaN` compares false against everything, including
+    `end > start`, and then lands in the cursor where `substring(NaN)` reads as
+    `substring(0)` and repeats the whole value.
+  - **The `< U+0300` screen.** Nothing below it can continue a cluster (CRLF
+    aside, handled explicitly), so ASCII and Latin-1 boundaries never reach
+    `Intl.Segmenter`. It buys nothing above the floor, which includes Cyrillic
+    (U+0430) and CJK — measured at 979 characters, ASCII is +1% against the
+    pre-fix cost while both of those are +2.5-2.9 µs. For a product localised
+    into Russian, treat the screen as covering markup and Latin identifiers, not
+    the body text.
+  - **One segmenter view per value.** Building `segment(value)` per boundary
+    instead of once made a value carrying many match regions linear in the
+    number of regions rather than paid once: 8.1 ms against 0.6 ms over 1600
+    boundaries.
+  - **The 8192-character guard.** `Segments.containing()` scans: a few µs up to
+    ~8k, two orders of magnitude worse at 100k. Past the guard only the
+    surrogate snap applies: `�` is still prevented, but **every** multi-code-point
+    cluster loses protection, not just flags — the same degradation as a runtime
+    without `Intl.Segmenter`. What the guard measures is the *marked-up* string,
+    not the value: truncation runs after the tags are inserted, so the threshold
+    is crossed 13 characters earlier than a reading of `value.length` suggests.
+
+  Upstream has no equivalent — inferred from this file's history, not
+  re-inspected — so replaying upstream's `generateHighlightedText` or
+  `truncateHTMLFromStart` verbatim reverts it, and the failure is quiet: the
+  output stays well-formed HTML and only the glyph changes. Note this sits
+  directly below the `useTokenSearch` divergence and shares the same
+  `indices.forEach` body; one careless port reverts both. Guarded by
+  `describe('mark insertion')`, `describe('grapheme clusters')` and
+  `describe('degraded paths')` in `test/utils/search.spec.ts` — every constant
+  and every branch above was verified by removing it and watching a named test
+  fail. Two of those fixtures look pointless and are not: the CRLF pair is the
+  only cluster rule `Intl.Segmenter` never sees, since the fast-path screen
+  answers it first; and the unpaired-surrogate strings are the only input that
+  can catch a surrogate range constant being *widened* — every other fixture
+  holds a real pair, which only pins the narrowing direction.
+  `test/bench/search.bench.ts` covers the two constants no unit test can observe
+  — advisory only, it asserts nothing and CI does not run it. Beware the fixture
+  trap those tests document: a run of bare emoji modifiers is **one** cluster,
+  not many, so counting characters with `'\u{1F3FF}'.repeat(n)` asserts the wrong
+  thing.
 - **`skills/` is b24ui-authored — never replay upstream skill or doc prose into
   it.** The package was seeded from nuxt/ui's skill, and every defect the #93
   audit found was an inherited upstream idiom rather than an ordinary typo:
@@ -362,3 +428,4 @@ forward, since every commit between the two would then never be judged.
 - 2026-08-12 — the sync is manual by decision; the automation is removed. Deleted `.sync/PLAN.md` (the dispatcher/porter/on-merge design, its phase plan and its cron) and `.sync/RUNBOOK.md` (an incident playbook whose every row diagnosed one of those workflows). Dropped `sync_enabled` from the ledger — a kill-switch for a dispatcher that will not exist reads as "the sync is off" to anyone who finds it, which was already misleading while this file's own procedure ran twelve ports past it — and `stats`, Phase-4 telemetry that was never written to (`noop_ratio: 0` against an actual 47/226). Folded the one runbook row that survives manual work into §6: a cursor SHA that vanishes under an upstream force-push must be moved to the nearest surviving ancestor with a tracking issue, never skipped forward. §6 now spells out the procedure that was previously only implied by the workflows — parent-order reconstruction, verbatim diffs, the gate order with `docs:generate` and `deploy.yml`'s env, ledger reconciliation including the last-entry case, and the `behind` rebase. Also corrected `color-map.json`: `warning` mapped to `air-primary-alert`, the same token as `error`, so the table said the two upstream colors were interchangeable; `air-primary-warning` exists and is used 50 times in `src/theme/`. Last reviewed: 2026-08-12.
 - 2026-08-12 — rebuilt `icon-map.json` and gave it a guard (the content of the closed PR #67, verified rather than imported). The map is now *derived*: for every icon key both sides define — `src/theme/icons.ts` upstream, `src/runtime/dictionary/icons.ts` here — the row is (upstream's lucide name → whatever our dictionary maps that key to), 37 pairs from a 43×39 key intersection at cursor `3dbca02`. Beware the obvious shortcut when re-checking this: the installed `@nuxt/ui@4.8.2` in `node_modules` (pulled in transitively by `nuxtseo-layer-devtools`) is **older than the sync cursor** and is missing keys — three separate reviewers read it and concluded `star` was fabricated and the intersection was 36. Read the raw file at the cursor SHA instead. The derivation turned up three errors in the values #67 proposed, each of which resolves to a real icon and so would have failed no import: `i-lucide-rotate-cw` for what upstream calls `i-lucide-rotate-ccw` (`reload`), `i-lucide-circle-check` for `copyCheck`'s `i-lucide-copy-check`, and `i-lucide-refresh-cw`, which no upstream key uses. It also surfaced seven derivable pairs #67 missed — `drag`, `panelClose`, `panelOpen`, `star`, `stop`, `copyCheck`, `reload` — and, separately, `i-lucide-terminal`, the **only** `i-lucide-*` literal upstream hardcodes under `src/` (`src/theme/prose/code-icon.ts`), which neither the old map nor #67 had even though `prose/CodeIcon.vue` has answered it all along. `error` and `success` gained judgement rows rather than staying unmapped: our `caution` carries a `// this for error` comment, and `copyCheck` already owns the glyph `success` would want. The five entries #67 dropped (`activity`, `arrow-up-to-line`, `house`, `settings`, `user`) are kept — they match no key on either side, which is the hardcoded-literal case the map exists for. **Correcting the record on the five values #67 changed** (`check`, `chevronDown`, `chevronUp`, `minus`, `x`): they are wrong because the map must agree with the dictionary, *not* — as an earlier draft of this entry claimed — because the library never renders them. It does. `Checkbox.vue` renders `main/CheckIcon` and `actions/Minus20Icon`, `Badge.vue` renders `actions/Cross20Icon`, `Button.vue` renders `outline/ChevronDownSIcon`; roughly half of the icon paths under `src/` are hardcoded in components that never read the dictionary, which is #380. That discovery also reshaped the guard: `test/utils/icon-map.spec.ts` allows any icon used anywhere in `src/` rather than only the dictionary's — the narrower rule rejected `terminal`, a correct row — while separately requiring every *derived* row to equal what its semantic key resolves to. That last check is the one with teeth: without it, pointing `i-lucide-check` at another icon the dictionary genuinely uses passed every other assertion. It guards wrong rows, not stale ones; nothing here notices if upstream renames a default. No `.sync/log/` or ledger entry, since this is not a port of an upstream commit — same as #343, #346, #351 and #377. Last reviewed: 2026-08-12.
 - 2026-08-12 — coverage for #363: gave the §2 **`highlight()` takes a fifth `useTokenSearch` argument** invariant a guard. It was recorded during the review of #347 but left untested, and the bullet said so. The parameter and the token-search logic around it are b24ui-only — `c502157b` added `tokens`/`minTokenLength` and `6743f793` the parameter itself, both against the file's old name `src/runtime/utils/fuse.ts`, both shipped in v2.8.0. Immediately before `c502157b` the function took four parameters and computed no `minTokenLength` at all, which is what marks it as locally authored; the `Upstream:` trailer convention is too sparse (16 of ~3200 commits) to carry an inference either way. The later port `557a5178` renamed `fuse.ts` to `search.ts` and carried the divergence across, so a pickaxe on the current path returns only that port — pass `--follow` to see the two commits that introduced it. Until now it had no test at all, so replaying upstream's four-parameter signature would have dropped a shipped feature with nothing going red. Upstream itself has not been re-inspected; treat "upstream has no such parameter" as an inference from b24ui's own history. Last reviewed: 2026-08-12.
+- 2026-08-13 — fix of #364: the §2 **`utils/search.ts` cuts on grapheme clusters** invariant. Cutting by code point is not enough — a flag is two regional indicators, a family emoji several joined by ZWJ — and slicing inside one yields a *different* character rather than a broken one, with nothing to signal the loss. `Intl.Segmenter`'s `containing()` was chosen on measurement: segmenting the whole string costs 455 µs at 979 characters and 52 ms at 100k, and a fixed ±64 window is constant-time but wrong — a run of flags is longer than the window, so it starts mid-run and re-pairs the indicators, reproducing the very bug (28 disagreements in 1044 probes). Worth recording that the *snap* was the easy half: every defect review turned up was in the bookkeeping around it, and each one reached the user as duplicated or vanished text rather than as an error, because `substring()` swaps a reversed range and clamps an out-of-range one instead of throwing. Four, in the order they were found — a region the clamps left empty emitted a bare `<mark></mark>` with the highlight lost; a region past the end of the value bypassed that guard, since the comparison did not clamp where `substring()` did; a region nested inside an earlier one ended behind the cursor and had its overlap emitted three times; and a non-integer bound (`NaN` in particular, which compares false against every guard including `end > start`) landed in the cursor, where `substring(NaN)` reads as `substring(0)` and repeats the whole value. All four are guarded, each by a test verified to fail when its guard is removed. That verification is worth repeating whenever this code is touched: it is what showed the CRLF carve-out and the widening direction of all four surrogate range constants to be uncovered — nine mutations passing the whole file — and both are now fixtured. `indices` are sorted before use — a no-op for Fuse, which sorts, merges and integer-bounds them itself, but `highlight()` is a published export and `postFilter` lets a caller supply its own; the tie-break puts the longest of an equal-start pair first so the outer region is marked whole rather than split across two `<mark>`s. One clamp went the other way: mutation testing showed `Math.min(…, value.length)` on `start` was unreachable — `start` can only exceed the value by exceeding `end`, which is checked — so it was removed rather than left as an untested guard. Last reviewed: 2026-08-13.

--- a/src/runtime/utils/search.ts
+++ b/src/runtime/utils/search.ts
@@ -13,10 +13,134 @@ function escapeHTML(str: string): string {
   return str.replace(/[&<>"']/g, char => htmlEscapes[char]!)
 }
 
+const HIGH_SURROGATE_START = 0xD800
+const HIGH_SURROGATE_END = 0xDBFF
+const LOW_SURROGATE_START = 0xDC00
+const LOW_SURROGATE_END = 0xDFFF
+
+// Nothing below U+0300 can continue a grapheme cluster: the range holds no
+// combining marks, no joiners, no surrogates and no regional indicators. CRLF is
+// the one pair that lives there, and UAX #29 keeps it together. Screening on this
+// keeps ASCII and Latin-1 boundaries — the overwhelming majority — from ever
+// reaching the segmenter.
+const CLUSTER_CONTINUATION_FLOOR = 0x0300
+const CARRIAGE_RETURN = 0x000D
+const LINE_FEED = 0x000A
+
+// `Segments.containing()` scans, so its cost grows with the value: a few
+// microseconds up to ~8k, two orders of magnitude worse at 100k. Search snippets
+// are short. Past this length the grapheme snap is skipped and only the
+// surrogate-pair snap applies: `�` is still prevented, but every
+// multi-code-point cluster loses protection — flags, ZWJ sequences, combining
+// marks alike — the same degradation as a runtime without `Intl.Segmenter`.
+const GRAPHEME_SNAP_MAX_LENGTH = 8192
+
+// True when `index` points at the low half of a surrogate pair — i.e. cutting
+// the string there would slice an astral character in two.
+function splitsSurrogatePair(value: string, index: number): boolean {
+  if (index <= 0 || index >= value.length) {
+    return false
+  }
+
+  const low = value.charCodeAt(index)
+
+  if (low < LOW_SURROGATE_START || low > LOW_SURROGATE_END) {
+    return false
+  }
+
+  const high = value.charCodeAt(index - 1)
+
+  return high >= HIGH_SURROGATE_START && high <= HIGH_SURROGATE_END
+}
+
+let graphemeSegmenter: Intl.Segmenter | null | undefined
+
+function getGraphemeSegmenter(): Intl.Segmenter | null {
+  if (graphemeSegmenter === undefined) {
+    graphemeSegmenter = typeof Intl !== 'undefined' && typeof Intl.Segmenter === 'function'
+      // Grapheme segmentation does not vary by locale; leaving it undefined
+      // avoids depending on whatever the host default happens to be.
+      ? new Intl.Segmenter(undefined, { granularity: 'grapheme' })
+      : null
+  }
+
+  return graphemeSegmenter
+}
+
+interface ClusterSpan {
+  index: number
+  length: number
+}
+
+/**
+ * Moves string offsets off the middle of a character.
+ *
+ * Code points are not the unit a reader sees: a flag is two regional
+ * indicators, a family emoji several code points joined by ZWJ, and `कि` a
+ * consonant plus a vowel sign. Cutting inside one yields a *different* visible
+ * character rather than a broken one — 🇺🇸 cut by one code point re-pairs into
+ * 🇸🇺, a different country (#364) — so the cut has to move to a cluster edge.
+ *
+ * Bound to one `value` because segmenting it is the expensive part.
+ * `Segments.containing()` is called once per boundary, and a value can carry
+ * hundreds of match regions: rebuilding the segmenter view for each of them
+ * cost 8.1 ms over 1600 boundaries, against 0.6 ms when it is built once.
+ */
+function createClusterSnapper(value: string) {
+  // `null` once resolved to "no segmenter for this value"; `undefined` while
+  // still unresolved, so a value that never needs snapping never builds one.
+  let segments: Intl.Segments | null | undefined
+
+  function straddling(index: number): ClusterSpan | undefined {
+    if (index <= 0 || index >= value.length) {
+      return undefined
+    }
+
+    const current = value.charCodeAt(index)
+    const previous = value.charCodeAt(index - 1)
+
+    if (current < CLUSTER_CONTINUATION_FLOOR && previous < CLUSTER_CONTINUATION_FLOOR) {
+      return previous === CARRIAGE_RETURN && current === LINE_FEED
+        ? { index: index - 1, length: 2 }
+        : undefined
+    }
+
+    if (segments === undefined) {
+      const segmenter = value.length <= GRAPHEME_SNAP_MAX_LENGTH ? getGraphemeSegmenter() : null
+
+      segments = segmenter ? segmenter.segment(value) : null
+    }
+
+    if (!segments) {
+      return splitsSurrogatePair(value, index) ? { index: index - 1, length: 2 } : undefined
+    }
+
+    const segment = segments.containing(index)
+
+    return segment && segment.index !== index
+      ? { index: segment.index, length: segment.segment.length }
+      : undefined
+  }
+
+  return {
+    /** The start of the cluster straddling `index`, or `index` if it is already on an edge. */
+    toStart(index: number): number {
+      return straddling(index)?.index ?? index
+    },
+    /** The end of the cluster straddling `index`, or `index` if it is already on an edge. */
+    toEnd(index: number): number {
+      const cluster = straddling(index)
+
+      return cluster ? cluster.index + cluster.length : index
+    }
+  }
+}
+
 function truncateHTMLFromStart(html: string, maxLength: number) {
-  let truncated = ''
+  let keptLength = 0
   let totalLength = 0
   let insideTag = false
+  let didTruncate = false
 
   // Iterate through the HTML string in reverse order, one code point at a time.
   // Indexing by UTF-16 code unit would slice an astral character (emoji, most
@@ -25,6 +149,11 @@ function truncateHTMLFromStart(html: string, maxLength: number) {
   // `<` and `>` are always single code units, so tag tracking is unaffected.
   const chars = Array.from(html)
 
+  // Characters are retained until the one that overruns the budget, which is
+  // dropped along with everything the scan has not reached — so the result is
+  // always a suffix of `html`. Counting the retained code units rather than
+  // building the string up front leaves an index to snap, and drops the
+  // quadratic prepend on the way.
   for (let i = chars.length - 1; i >= 0; i--) {
     const char = chars[i]!
 
@@ -32,7 +161,7 @@ function truncateHTMLFromStart(html: string, maxLength: number) {
       insideTag = true
     } else if (char === '<') {
       insideTag = false
-      truncated = char + truncated
+      keptLength += char.length
       continue
     }
 
@@ -41,22 +170,36 @@ function truncateHTMLFromStart(html: string, maxLength: number) {
     }
 
     if (totalLength <= maxLength) {
-      truncated = char + truncated
+      keptLength += char.length
     } else {
       // If we've reached the max length, we break out of the loop
       // to prevent further processing of the string
-      truncated = '...' + truncated
+      didTruncate = true
       break
     }
   }
 
-  return truncated
+  if (!didTruncate) {
+    return html
+  }
+
+  // A code point is not what the reader sees. Snap the cut past any grapheme
+  // cluster it lands inside, so the visible character after the ellipsis is the
+  // one the author wrote rather than its tail.
+  return '...' + html.slice(createClusterSnapper(html).toEnd(html.length - keptLength))
 }
 
-// Escape an FTS snippet to safe HTML while preserving the `<mark>` highlight tags.
-// The tag is intentionally hardcoded — exposing it as a parameter would let a
-// caller smuggle through arbitrary tags (e.g. `<script>`) since `v-html` is
-// used to render the result downstream.
+/**
+ * Escapes a full-text-search snippet to safe HTML, keeping its `<mark>` tags.
+ *
+ * Everything else in `snippet` is escaped, so a value carrying `<script>`
+ * renders as text. The preserved tag is hardcoded on purpose: taking it as a
+ * parameter would let a caller pass any tag through to the `v-html` that renders
+ * the result.
+ *
+ * @param snippet Snippet from the search index, with `<mark>` marking the hits.
+ * @returns HTML safe to render, with the highlight tags intact.
+ */
 export function sanitizeSnippet(snippet: string): string {
   const tagOpen = '\0markO\0'
   const tagClose = '\0markC\0'
@@ -70,6 +213,31 @@ export function sanitizeSnippet(snippet: string): string {
     .replaceAll(tagClose, '</mark>')
 }
 
+/**
+ * Wraps a Fuse match in `<mark>` and trims the text before it, as HTML.
+ *
+ * Returns `undefined` when nothing here applies to the item: when it carries no
+ * matches at all — Fuse only populates them when `includeMatches` is set, which
+ * `ContentSearch` does by default and `CommandPalette` leaves to the caller —
+ * and equally when `forceKey` names a key none of the matches is on, or
+ * `omitKeys` covers every one of them. Callers render the plain value in that
+ * case. Everything except the inserted tags is escaped; the result is rendered
+ * with `v-html`.
+ *
+ * Text before the match is dropped when it does not fit, leaving an ellipsis, so
+ * the highlight stays visible in a narrow row. Both boundaries land on whole
+ * characters as a reader counts them, never inside an emoji or a flag.
+ *
+ * @param item Search result; its `matches` come from Fuse.
+ * @param searchTerm The query, used as the length threshold a match must reach.
+ * @param forceKey Consider only the match on this key.
+ * @param omitKeys Skip matches on these keys — used to keep a hit from being
+ * highlighted twice across label, suffix and description.
+ * @param useTokenSearch Measure the threshold against the shortest word of the
+ * query instead of the whole of it, so multi-word queries highlight each word.
+ * b24ui-only, and not present upstream — see `.sync/PORTING.md` §2.
+ * @returns The escaped HTML, or `undefined` when there is nothing to highlight.
+ */
 export function highlight<T>(item: T & { matches?: FuseResult<T>['matches'] }, searchTerm: string, forceKey?: GetItemKeys<T>, omitKeys?: GetItemKeys<T>[], useTokenSearch?: boolean) {
   const tokens = useTokenSearch ? (searchTerm.match(/[\p{L}\p{M}\p{N}_]+/gu) || []) : []
   const minTokenLength = tokens.length > 0 ? Math.min(...tokens.map(t => t.length)) : searchTerm.length
@@ -79,23 +247,71 @@ export function highlight<T>(item: T & { matches?: FuseResult<T>['matches'] }, s
     let content = ''
     let nextUnhighlightedRegionStartingIndex = 0
 
-    indices.forEach((region) => {
+    const snap = createClusterSnapper(value)
+
+    // Fuse merges, sorts and integer-bounds `indices` itself, so this is a no-op
+    // for the search path. It matters because `highlight()` is a published
+    // export and `CommandPaletteGroup.postFilter` lets a caller supply its own
+    // matches.
+    //
+    // Non-integer bounds are dropped rather than snapped: `NaN` survives every
+    // `Math.min`/`Math.max` below and lands in
+    // `nextUnhighlightedRegionStartingIndex`, where `substring(NaN)` reads as
+    // `substring(0)` and re-emits the whole value after the part already
+    // written — the tail duplicates and every later region is lost.
+    //
+    // Ordering matters for the same reason: unordered, the clamps swallow every
+    // region that arrives after a later one, and out-of-order boundaries make
+    // `Segments.containing()` walk a long run of regional indicators from its
+    // start each time, which costs as much as the per-boundary segmenter this
+    // snapper exists to avoid. Equal starts put the longest first, so the outer
+    // region is marked whole instead of the clamps splitting it in two.
+    const orderedIndices = indices
+      .filter(region => Number.isInteger(region[0]) && Number.isInteger(region[1]))
+      .sort((a, b) => a[0] - b[0] || b[1] - a[1])
+
+    orderedIndices.forEach((region) => {
       // skip if region is a single character
       if (region.length === 2 && region[0] === region[1]) {
         return
       }
 
       const lastIndiceNextIndex = region[1] + 1
-      const isMatched = (lastIndiceNextIndex - region[0]) >= minTokenLength
+
+      // Fuse reports `indices` as UTF-16 code-unit offsets, so a region boundary
+      // can land inside a character the reader sees as one — between the
+      // surrogates of an emoji (#362), or between the parts of a grapheme cluster
+      // (#364). Slicing there puts `<mark>` inside the character. Snap each
+      // boundary outward so a mark always wraps whole clusters.
+      //
+      // Then clamp, because `substring()` swaps arguments it finds reversed and
+      // clamps ones it finds out of range — turning every ordering mistake here
+      // into duplicated text rather than an error. `start` never moves behind
+      // the cursor, since two adjacent regions meeting inside one cluster snap
+      // past each other; `end` never moves behind `start`, since a region nested
+      // inside an earlier one ends before the cursor already stands; and `end`
+      // never leaves the value, which is what keeps a region wholly past its end
+      // from slicing to nothing while still comparing as non-empty below,
+      // emitting a bare `<mark></mark>` and freezing the cursor past every region
+      // after it. `start` needs no ceiling of its own: it can only exceed the
+      // value by exceeding `end`, which is checked.
+      const start = Math.max(nextUnhighlightedRegionStartingIndex, snap.toStart(region[0]))
+      const end = Math.min(Math.max(start, snap.toEnd(lastIndiceNextIndex)), value.length)
+
+      // `end > start` is not redundant with the length test: when a preceding
+      // region's end snaps past this one's start, the clamps leave the region
+      // empty, and emitting the tags anyway produces a bare `<mark></mark>` with
+      // the highlight lost entirely.
+      const isMatched = (lastIndiceNextIndex - region[0]) >= minTokenLength && end > start
 
       content += [
-        escapeHTML(value.substring(nextUnhighlightedRegionStartingIndex, region[0])),
+        escapeHTML(value.substring(nextUnhighlightedRegionStartingIndex, start)),
         isMatched && `<mark>`,
-        escapeHTML(value.substring(region[0], lastIndiceNextIndex)),
+        escapeHTML(value.substring(start, end)),
         isMatched && '</mark>'
       ].filter(Boolean).join('')
 
-      nextUnhighlightedRegionStartingIndex = lastIndiceNextIndex
+      nextUnhighlightedRegionStartingIndex = end
     })
 
     content += escapeHTML(value.substring(nextUnhighlightedRegionStartingIndex))

--- a/test/bench/search.bench.ts
+++ b/test/bench/search.bench.ts
@@ -1,0 +1,92 @@
+import { bench, describe } from 'vitest'
+import { highlight } from '../../src/runtime/utils/search'
+
+// `highlight()` runs on every keystroke — three times per result (label, suffix,
+// description) for every item, before virtualization decides what is visible.
+// The grapheme snapping it does is guarded by two constants whose values were
+// chosen by measurement, and neither is observable from a unit test:
+//
+//   - the `< U+0300` screen, which keeps ASCII and Latin-1 boundaries away from
+//     `Intl.Segmenter` entirely. It does nothing for Cyrillic, CJK, Devanagari
+//     or anything else above the floor — those pay for the segmenter.
+//   - the 8192-character ceiling, past which segmentation is skipped.
+//
+// The scripts that produced the numbers in `.sync/PORTING.md` were throwaway.
+// These cases are the durable version: run `pnpm run bench` before changing
+// either constant, or the alternatives already rejected once — segmenting the
+// whole string, or segmenting a fixed window — will look attractive again.
+
+const MATCH = 'match'
+
+function itemFor(value: string) {
+  const index = value.indexOf(MATCH)
+
+  return { label: value, matches: [{ key: 'label', value, indices: [[index, index + MATCH.length - 1]] as [number, number][] }] }
+}
+
+// ~979 characters of prefix, with the match at the end — the shape truncation
+// exists for, and the one where the snap actually fires.
+function prefixed(filler: string) {
+  return itemFor(filler.repeat(Math.ceil(979 / filler.length)) + MATCH)
+}
+
+const ascii = prefixed('a')
+const cyrillic = prefixed('ф')
+const cjk = prefixed('漢')
+const emoji = prefixed('\u{1F600}')
+
+// Regional indicators are the worst case: `Segments.containing()` has to walk
+// the run to work out how the flags pair up.
+const flags = prefixed('\u{1F1FA}\u{1F1F8}')
+
+// Either side of the ceiling, same content, so the pair shows what skipping the
+// segmenter buys and what it costs.
+const underCeiling = itemFor(`${'a'.repeat(8000)}${'\u{1F1FA}\u{1F1F8}'.repeat(10)}${MATCH}`)
+const overCeiling = itemFor(`${'a'.repeat(9000)}${'\u{1F1FA}\u{1F1F8}'.repeat(10)}${MATCH}`)
+
+// A value carrying many match regions: snapping is bound to one segmenter view
+// per value, and this is the case that regresses hardest if that is undone.
+const manyRegions = (() => {
+  const value = '\u{1F1FA}\u{1F1F8}'.repeat(400) + MATCH
+  const indices: [number, number][] = []
+
+  for (let index = 0; index + 5 < value.length - MATCH.length; index += 4) {
+    indices.push([index, index + 4])
+  }
+
+  return { label: value, matches: [{ key: 'label', value, indices }] }
+})()
+
+describe('highlight', () => {
+  bench('ascii', () => {
+    highlight(ascii, MATCH, 'label')
+  })
+
+  bench('cyrillic', () => {
+    highlight(cyrillic, MATCH, 'label')
+  })
+
+  bench('cjk', () => {
+    highlight(cjk, MATCH, 'label')
+  })
+
+  bench('emoji', () => {
+    highlight(emoji, MATCH, 'label')
+  })
+
+  bench('flags', () => {
+    highlight(flags, MATCH, 'label')
+  })
+
+  bench('under the segmentation ceiling', () => {
+    highlight(underCeiling, MATCH, 'label')
+  })
+
+  bench('over the segmentation ceiling', () => {
+    highlight(overCeiling, MATCH, 'label')
+  })
+
+  bench('many match regions', () => {
+    highlight(manyRegions, MATCH, 'label')
+  })
+})

--- a/test/components/CommandPalette.spec.ts
+++ b/test/components/CommandPalette.spec.ts
@@ -232,6 +232,54 @@ describe('CommandPalette', () => {
     })
   })
 
+  describe('highlighting through fuse', () => {
+    // Everything above sets `labelHtml`/`suffixHtml`/`descriptionHtml` by hand,
+    // which is exactly the path that skips `highlight()`. These mount the real
+    // wiring instead: `processGroupItems` forwards
+    // `fuse.fuseOptions.useTokenSearch` as the fifth argument, and Fuse only
+    // populates `matches` when `includeMatches` is set — which this component
+    // leaves to the caller, so no other case in this file reaches `highlight()`
+    // at all.
+    function paletteWith(label: string, searchTerm: string, useTokenSearch?: boolean, threshold = 0.1) {
+      return mountSuspended(CommandPalette, {
+        props: {
+          groups: [{ id: 'g', items: [{ label }] }],
+          searchTerm,
+          fuse: { fuseOptions: { includeMatches: true, useTokenSearch, threshold, ignoreLocation: true } }
+        } as any
+      })
+    }
+
+    it('marks the match', async () => {
+      const wrapper = await paletteWith('alpha beta', 'alpha')
+
+      expect(wrapper.find('mark').exists()).toBe(true)
+      expect(wrapper.find('mark').text()).toContain('alpha')
+    })
+
+    it('marks each word of a multi-word query only when token search is on', async () => {
+      // Fuse returns the two words as separate regions, six and four characters
+      // long. Off, the threshold is the whole query — ten — and neither reaches
+      // it, so nothing is marked; on, it drops to the shortest word and both do.
+      // An exact-match fixture would not show the difference: Fuse then returns
+      // one region as long as the query, which clears either threshold.
+      const off = await paletteWith('alpha xxxx beta', 'alpha beta', false, 0.4)
+      const on = await paletteWith('alpha xxxx beta', 'alpha beta', true, 0.4)
+
+      expect(off.find('mark').exists()).toBe(false)
+      expect(on.find('mark').exists()).toBe(true)
+    })
+
+    it('never splits an emoji across the mark', async () => {
+      // The end-to-end version of #362: real Fuse indices, real component, and
+      // the replacement character must not appear in the rendered output.
+      const wrapper = await paletteWith('deployment \u{1F600}\u{1F600} pipeline', 'zployment \u{1F600}')
+
+      expect(wrapper.html()).not.toContain('�')
+      expect(wrapper.find('mark').text()).not.toMatch(/[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?:[^\uD800-\uDBFF]|^)[\uDC00-\uDFFF]/)
+    })
+  })
+
   it('renders an `item-description` slot for an item that has no description', async () => {
     // The description span was gated on the item's own `description` field alone,
     // so a description supplied purely by a slot — a computed string, a badge,
@@ -316,44 +364,5 @@ describe('CommandPalette', () => {
     } finally {
       window.HTMLElement.prototype.scrollIntoView = original
     }
-  })
-
-  describe('highlighting through fuse', () => {
-    // Everything above sets `labelHtml`/`suffixHtml`/`descriptionHtml` by hand,
-    // which is exactly the path that skips `highlight()`. These mount the real
-    // wiring instead: `processGroupItems` forwards
-    // `fuse.fuseOptions.useTokenSearch` as the fifth argument, and Fuse only
-    // populates `matches` when `includeMatches` is set — which this component
-    // leaves to the caller, so no other case in this file reaches `highlight()`
-    // at all.
-    function paletteWith(label: string, searchTerm: string, useTokenSearch?: boolean, threshold = 0.1) {
-      return mountSuspended(CommandPalette, {
-        props: {
-          groups: [{ id: 'g', items: [{ label }] }],
-          searchTerm,
-          fuse: { fuseOptions: { includeMatches: true, useTokenSearch, threshold, ignoreLocation: true } }
-        } as any
-      })
-    }
-
-    it('marks the match', async () => {
-      const wrapper = await paletteWith('alpha beta', 'alpha')
-
-      expect(wrapper.find('mark').exists()).toBe(true)
-      expect(wrapper.find('mark').text()).toContain('alpha')
-    })
-
-    it('marks each word of a multi-word query only when token search is on', async () => {
-      // Fuse returns the two words as separate regions, six and four characters
-      // long. Off, the threshold is the whole query — ten — and neither reaches
-      // it, so nothing is marked; on, it drops to the shortest word and both do.
-      // An exact-match fixture would not show the difference: Fuse then returns
-      // one region as long as the query, which clears either threshold.
-      const off = await paletteWith('alpha xxxx beta', 'alpha beta', false, 0.4)
-      const on = await paletteWith('alpha xxxx beta', 'alpha beta', true, 0.4)
-
-      expect(off.find('mark').exists()).toBe(false)
-      expect(on.find('mark').exists()).toBe(true)
-    })
   })
 })

--- a/test/utils/search.spec.ts
+++ b/test/utils/search.spec.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
 import { highlight, sanitizeSnippet } from '../../src/runtime/utils/search'
 
 describe('sanitizeSnippet', () => {
@@ -31,6 +31,22 @@ describe('sanitizeSnippet', () => {
 })
 
 describe('highlight', () => {
+  // Matches a high surrogate not followed by a low one, or a low surrogate not
+  // preceded by a high one — i.e. half of an astral character.
+  const LONE_SURROGATE = /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?:[^\uD800-\uDBFF]|^)[\uDC00-\uDFFF]/
+
+  // One character from each corner of the surrogate ranges. A fixture built only
+  // from characters sitting comfortably inside them hides an implementation whose
+  // range bounds are off by one: U+20000 encodes to a low surrogate of U+DC00 and
+  // U+1F3FF to U+DFFF — the two edges — while U+1F600 sits between them.
+  const ASTRAL = ['\u{10000}', '\u{10FFFF}', '\u{1F600}', '\u{1F3FF}', '\u{20000}']
+
+  // The subset where one code point is also one grapheme cluster, so a run of N
+  // is N characters. U+1F3FF is an emoji modifier: UAX #29 glues a run of bare
+  // modifiers into a single cluster, so it is excluded wherever a test counts
+  // retained characters.
+  const ASTRAL_STANDALONE = ASTRAL.filter(char => char !== '\u{1F3FF}')
+
   it('escapes an injected tag in the unmatched tail while keeping the match highlighted', () => {
     const value = 'zzzzz &<img src=x onerror=alert(1)>'
     const result = highlight({ label: value, matches: [{ key: 'label', value, indices: [[0, 4]] }] }, 'zzzzz', 'label')
@@ -107,22 +123,369 @@ describe('highlight', () => {
     })
   })
 
-  describe('truncation from the start', () => {
-    // Matches a high surrogate not followed by a low one, or a low surrogate not
-    // preceded by a high one — i.e. half of an astral character.
-    const LONE_SURROGATE = /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?:[^\uD800-\uDBFF]|^)[\uDC00-\uDFFF]/
+  describe('mark insertion', () => {
+    function highlightRegions(value: string, indices: [number, number][]) {
+      // A one-character term keeps `minTokenLength` at 1, so every region here is
+      // long enough to be marked and the fixtures isolate the boundary logic.
+      return highlight({ label: value, matches: [{ key: 'label', value, indices }] }, 'x', 'label')
+    }
 
+    it('never places a mark inside an astral character', () => {
+      // The fixture from #362, reproduced from real fuse.js output: searching
+      // "zployment 😀" against this label returns [[1, 13]], and 13 falls between
+      // the surrogates of the second emoji.
+      const value = 'deployment \u{1F600}\u{1F600} pipeline'
+      const result = highlightRegions(value, [[1, 13]])
+
+      expect(result).not.toMatch(LONE_SURROGATE)
+      expect(result).toBe('d<mark>eployment \u{1F600}\u{1F600}</mark> pipeline')
+    })
+
+    it('snaps a region that starts inside an astral character', () => {
+      const value = '\u{1F600}\u{1F600}abc'
+
+      // Index 1 is the low half of the first emoji.
+      expect(highlightRegions(value, [[1, 4]])).toBe('<mark>\u{1F600}\u{1F600}a</mark>bc')
+    })
+
+    it('does not duplicate text when adjacent regions meet inside one character', () => {
+      // Both boundaries land on index 2, the low half of the emoji: the first
+      // region's end snaps forward and the second region's start snaps back, so
+      // without clamping they cross and `substring()` silently swaps its
+      // arguments, emitting the overlap twice.
+      const value = 'a\u{1F600}b'
+      const result = highlightRegions(value, [[0, 1], [2, 3]])
+
+      expect(result).not.toMatch(LONE_SURROGATE)
+      expect(result?.replace(/<\/?mark>/g, '')).toBe(value)
+    })
+
+    it('drops the mark when a preceding region snaps past this one', () => {
+      // The first region is too short to be marked, but its end still snaps
+      // forward off the family emoji — past the second region's start. The
+      // clamps then leave nothing between `start` and `end`, and emitting the
+      // tags around that produced a bare `<mark></mark>` with the highlight lost
+      // entirely. Found by review of the first revision of this PR.
+      const value = '\u{1F468}‍\u{1F469}‍\u{1F467}tail'
+      const result = highlight({ label: value, matches: [{ key: 'label', value, indices: [[0, 1], [2, 7]] }] }, 'xxxxx', 'label')
+
+      expect(result).not.toContain('<mark></mark>')
+      expect(result).toBe(value)
+    })
+
+    it('ignores a region that lies past the end of the value', () => {
+      // `substring()` clamps its own arguments, so a region beyond the value
+      // slices to nothing while still comparing as non-empty. That emitted a bare
+      // `<mark></mark>`, froze the cursor past every later region, and the empty
+      // mark then drove truncation into eating the text before it.
+      // A single region, so ordering cannot mask it: sorting moves an
+      // out-of-range region to the end, where it does no harm.
+      const value = 'The quarterly revenue report is available'
+      const result = highlight({ label: value, matches: [{ key: 'label', value, indices: [[126, 132]] }] }, 'abc', 'label')
+
+      expect(result).not.toContain('<mark>')
+      expect(result).toBe(value)
+    })
+
+    it('orders regions before snapping, whatever order they arrive in', () => {
+      // Fuse sorts and merges `indices` itself, so this never varies on the search
+      // path — but `highlight()` is a published export and `postFilter` lets a
+      // caller supply its own matches. Unordered, the clamps swallow every region
+      // that arrives after a later one.
+      const value = 'alpha beta gamma'
+      const ordered = highlight({ label: value, matches: [{ key: 'label', value, indices: [[0, 4], [11, 15]] }] }, 'aaa', 'label')
+      const reversed = highlight({ label: value, matches: [{ key: 'label', value, indices: [[11, 15], [0, 4]] }] }, 'aaa', 'label')
+
+      expect(ordered).toBe('<mark>alpha</mark> beta <mark>gamma</mark>')
+      expect(reversed).toBe(ordered)
+    })
+
+    it('does not duplicate text when a region is nested inside an earlier one', () => {
+      // `[1, 2]` lies wholly inside `[0, 5]`, so its end falls *behind* the
+      // cursor the previous region left — and `substring()` swaps arguments it
+      // finds reversed rather than returning empty, so the overlap is emitted
+      // once for the gap slice, once for the region slice, and a third time by
+      // the tail after the cursor rewinds: `<mark>abcdef</mark>defdefgh`.
+      //
+      // Plain ASCII on purpose. This is the clamp of `end` against `start`, not
+      // the cluster snap; every other fixture in this file reaches it only
+      // through a cluster, which is why the clamp could be deleted outright with
+      // the whole suite still green.
+      const value = 'abcdefgh'
+      const result = highlight({ label: value, matches: [{ key: 'label', value, indices: [[0, 5], [1, 2]] }] }, 'abc', 'label')
+
+      expect(result).toBe('<mark>abcdef</mark>gh')
+    })
+
+    it('marks the longer of two regions that share a start', () => {
+      // A tie on `region[0]` is broken by length, longest first. Shortest-first,
+      // the clamps cut the longer region down to whatever the shorter one left
+      // and emit the remainder as a second mark — `<mark>alp</mark><mark>ha
+      // beta</mark>`, the same characters split across two highlights.
+      const value = 'alpha beta gamma'
+      const result = highlight({ label: value, matches: [{ key: 'label', value, indices: [[0, 2], [0, 9]] }] }, 'abc', 'label')
+
+      expect(result).toBe('<mark>alpha beta</mark> gamma')
+    })
+
+    it('drops a region whose bounds are not integers', () => {
+      // Fuse only ever reports integer offsets; `postFilter` is under no such
+      // obligation. `NaN` compares false against everything — `end > start`
+      // included, so no mark is emitted and nothing looks wrong — and then lands
+      // in the cursor, where `substring(NaN)` reads as `substring(0)` and repeats
+      // the entire value after the part already written. `Infinity` clamps to the
+      // end of the value and marks all of it.
+      const value = 'alpha beta gamma'
+
+      function withExtra(extra: [number, number]) {
+        return highlight({ label: value, matches: [{ key: 'label', value, indices: [[0, 4], extra] }] }, 'alpha', 'label')
+      }
+
+      expect(withExtra([Number.NaN, Number.NaN])).toBe('<mark>alpha</mark> beta gamma')
+      expect(withExtra([6, Number.POSITIVE_INFINITY])).toBe('<mark>alpha</mark> beta gamma')
+      expect(withExtra([6.5, 9.5])).toBe('<mark>alpha</mark> beta gamma')
+    })
+
+    it('skips a region covering a single code unit', () => {
+      // Upstream's rule, kept verbatim: a one-unit region is dropped before any
+      // of the boundary logic runs. It is the reason a lone surrogate index can
+      // never reach the snapper as `region[0] === region[1]`.
+      const value = 'alpha beta'
+
+      expect(highlight({ label: value, matches: [{ key: 'label', value, indices: [[2, 2]] }] }, 'a', 'label')).toBe(value)
+    })
+
+    it.each(ASTRAL)('wraps %s wholly, wherever the region boundary falls', (astral) => {
+      const value = `${astral.repeat(3)}tail`
+
+      // Every code-unit offset across the astral run, including the three that
+      // split a pair.
+      const results = Array.from({ length: 7 }, (_, end) => highlightRegions(value, [[0, end]]))
+
+      expect(results.filter(result => LONE_SURROGATE.test(result ?? ''))).toEqual([])
+      expect(results.map(result => result?.replace(/<\/?mark>/g, ''))).toEqual(Array.from({ length: 7 }, () => value))
+    })
+  })
+
+  describe('grapheme clusters', () => {
+    // Cutting a cluster is worse than cutting a surrogate pair: the result is a
+    // *different* visible character rather than a broken one, so nothing signals
+    // that anything was lost.
+    const CLUSTERS: [string, string][] = [
+      ['a flag', '\u{1F1FA}\u{1F1F8}'],
+      ['a ZWJ family', '\u{1F468}‍\u{1F469}‍\u{1F467}'],
+      ['an emoji with a skin-tone modifier', '\u{1F44D}\u{1F3FF}'],
+      ['a Devanagari consonant with a vowel sign', 'कि'],
+      ['a combining accent', 'é']
+    ]
+
+    const segmenter = new Intl.Segmenter(undefined, { granularity: 'grapheme' })
+
+    function highlightAfter(cluster: string, count: number) {
+      const value = cluster.repeat(count) + 'match'
+      const index = value.indexOf('match')
+
+      return highlight({ label: value, matches: [{ key: 'label', value, indices: [[index, index + 4]] }] }, 'match', 'label') ?? ''
+    }
+
+    it('never places a mark inside a cluster from the left either', () => {
+      // The mirror of the case below. Every other exhaustive fixture moves the
+      // *right* boundary, so a regression that dropped the start snap alone
+      // would show up in one non-parametrised test on a plain surrogate pair —
+      // never on a multi-code-point cluster. Offset 2 is between the two
+      // regional indicators of the first flag.
+      const value = `${'\u{1F1FA}\u{1F1F8}'.repeat(3)}tail`
+      const result = highlight({ label: value, matches: [{ key: 'label', value, indices: [[2, 11]] }] }, 'x', 'label')
+
+      expect(result).toBe(`<mark>${'\u{1F1FA}\u{1F1F8}'.repeat(3)}</mark>tail`)
+    })
+
+    // 20 repetitions: the truncation budget saturates at 13 characters, so every
+    // fixture here is long enough to force a cut with room to spare, and the
+    // sweep starts below it to cover the un-truncated cases too.
+    it.each(CLUSTERS)('never truncates inside %s', (_name, cluster) => {
+      for (let count = 1; count <= 20; count++) {
+        const kept = highlightAfter(cluster, count)
+          .replace(/^\.\.\./, '')
+          .replace('<mark>match</mark>', '')
+
+        // Re-segmenting what survived must yield whole copies of the fixture and
+        // nothing else — a fragment would segment into something different.
+        expect([...segmenter.segment(kept)].map(entry => entry.segment).filter(entry => entry !== cluster)).toEqual([])
+      }
+    })
+
+    it('does not let a truncated flag re-pair into a different country', () => {
+      // A flag is two regional indicators. Dropping one shifts the whole run by a
+      // code point, so every following pair re-pairs — 🇺🇸🇺🇸… becomes 🇸🇺🇸🇺…,
+      // a different country, with nothing to signal the loss. This is the case
+      // that motivated #364.
+      //
+      // Asserted on the first retained cluster rather than with `toContain`: a
+      // correct run of 🇺🇸🇺🇸 does contain the code units of 🇸🇺 between its
+      // flags, since `String.includes` knows nothing about cluster boundaries.
+      const flag = '\u{1F1FA}\u{1F1F8}'
+      const kept = highlightAfter(flag, 20).replace(/^\.\.\./, '').replace('<mark>match</mark>', '')
+
+      expect([...segmenter.segment(kept)][0]?.segment).toBe(flag)
+    })
+
+    it('never places a mark inside a cluster', () => {
+      // Offset 2 sits between the two regional indicators of the first flag.
+      const value = `${'\u{1F1FA}\u{1F1F8}'.repeat(3)}tail`
+      const result = highlight({ label: value, matches: [{ key: 'label', value, indices: [[0, 1]] }] }, 'x', 'label')
+
+      expect(result).toBe(`<mark>\u{1F1FA}\u{1F1F8}</mark>${'\u{1F1FA}\u{1F1F8}'.repeat(2)}tail`)
+    })
+
+    it('keeps CRLF together — the one cluster below the fast-path floor', () => {
+      // The `< U+0300` screen sends a boundary between two low characters
+      // straight past the segmenter, which is right for every pair below the
+      // floor but this one: UAX #29 keeps CR LF together. So the carve-out is
+      // the only cluster rule in the file that `Intl.Segmenter` never gets to
+      // enforce, and nothing else here reaches it — remove it and the mark
+      // closes after the CR, splitting the pair.
+      const value = 'a\r\nb'
+      const result = highlight({ label: value, matches: [{ key: 'label', value, indices: [[0, 1]] }] }, 'x', 'label')
+
+      expect(result).toBe('<mark>a\r\n</mark>b')
+    })
+
+    it('leaves a bare run of emoji modifiers whole — UAX #29 makes it one cluster', () => {
+      // Not a realistic label, but it pins the behaviour that made the earlier
+      // fixture wrong: 20 bare U+1F3FF are one character, not twenty, so the
+      // budget cannot fit any of it and the whole run is dropped.
+      expect(highlightAfter('\u{1F3FF}', 20)).toBe('...<mark>match</mark>')
+    })
+  })
+
+  describe('degraded paths', () => {
+    // Both branches below skip the segmenter and fall back to the surrogate-pair
+    // check alone. Without these cases that check — and the four surrogate range
+    // constants behind it — are unreachable from the suite: every runtime under
+    // test ships `Intl.Segmenter`, and no other fixture comes near the length
+    // ceiling. Eight off-by-one mutations of those constants survived the whole
+    // file before this block existed.
+    const GRAPHEME_SNAP_MAX_LENGTH = 8192
+    const FLAG = '\u{1F1FA}\u{1F1F8}'
+
+    // What the ceiling is measured against is the *marked-up* string, not the
+    // value: truncation runs on `content`, after the tags are inserted, so it is
+    // 13 characters longer. A fixture sized against `value.length` sits under the
+    // ceiling and degrades anyway.
+    const MARKUP = '<mark></mark>'.length
+
+    // Captured before the stub below replaces the global, since this helper has
+    // to keep segmenting while the module under test cannot.
+    const RealSegmenter = Intl.Segmenter
+
+    function firstCluster(result: string) {
+      const kept = result.replace(/^\.\.\./, '').replace('<mark>match</mark>', '')
+
+      return [...new RealSegmenter(undefined, { granularity: 'grapheme' }).segment(kept)][0]?.segment
+    }
+
+    function matchAfter(value: string) {
+      const index = value.indexOf('match')
+
+      return { label: value, matches: [{ key: 'label', value, indices: [[index, index + 4]] as [number, number][] }] }
+    }
+
+    it('keeps surrogate pairs whole when `Intl.Segmenter` is missing', async () => {
+      // The segmenter is resolved once and cached, so the stub only takes effect
+      // on a freshly imported module.
+      vi.stubGlobal('Intl', new Proxy(Intl, {
+        get: (target, property) => property === 'Segmenter' ? undefined : Reflect.get(target, property)
+      }))
+      vi.resetModules()
+
+      try {
+        const { highlight: degraded } = await import('../../src/runtime/utils/search')
+
+        // Mark insertion, not truncation, is what exercises the surrogate check
+        // here: the truncation loop walks by code point via `Array.from`, so its
+        // cut index is aligned by construction and can never split a pair. Fuse's
+        // `indices` carry no such guarantee, and index 1 below is the low half of
+        // the first character. Each fixture also pins one corner of the four
+        // surrogate range constants — U+10000 and U+20000 encode a low surrogate
+        // of U+DC00, U+10FFFF and U+1F3FF one of U+DFFF, and U+10FFFF a high
+        // surrogate of U+DBFF.
+        const marked = ASTRAL.map((astral) => {
+          const value = `${astral.repeat(2)}x`
+
+          return degraded({ label: value, matches: [{ key: 'label', value, indices: [[1, 3]] }] }, 'x', 'label') ?? ''
+        })
+
+        expect(marked.filter(result => LONE_SURROGATE.test(result))).toEqual([])
+        expect(marked).toEqual(ASTRAL.map(astral => `<mark>${astral.repeat(2)}</mark>x`))
+
+        const results = ASTRAL.map(astral => degraded(matchAfter(`${astral.repeat(20)}match`), 'match', 'label') ?? '')
+
+        expect(results.filter(result => LONE_SURROGATE.test(result))).toEqual([])
+        expect(results.every(result => result.includes('<mark>match</mark>'))).toBe(true)
+
+        // And the documented cost of the fallback: clusters are no longer whole.
+        // It is every multi-code-point cluster that loses protection here, not
+        // only flags.
+        expect(firstCluster(degraded(matchAfter(`${FLAG.repeat(20)}match`), 'match', 'label') ?? '')).not.toBe(FLAG)
+
+        // The four constants above are pinned only in the narrowing direction:
+        // every fixture so far is a *real* pair, so shrinking a range stops it
+        // being recognised and fails, while widening one changes nothing. What
+        // widening breaks is the opposite input — two units that are not a pair
+        // — which only malformed UTF-16 has, and which reaches `highlight()`
+        // through any label built from a byte-truncated field. Each fixture
+        // widens exactly one bound if the boundary at index 1 is snapped:
+        // two low surrogates for `HIGH_SURROGATE_END`, two high ones for
+        // `LOW_SURROGATE_START`, a BMP character before a lone low surrogate
+        // for `HIGH_SURROGATE_START`, and a lone high surrogate before a
+        // private-use character for `LOW_SURROGATE_END`.
+        const unpaired = ['\uDC00\uDC01', '\uD800\uDB00', '\uD700\uDC00', '\uD800\uE000']
+
+        expect(unpaired.map((prefix) => {
+          const value = `${prefix}zz`
+
+          return degraded({ label: value, matches: [{ key: 'label', value, indices: [[1, 2]] }] }, 'x', 'label')
+        })).toEqual(unpaired.map(prefix => `${prefix[0]}<mark>${prefix[1]}z</mark>z`))
+      } finally {
+        vi.unstubAllGlobals()
+        vi.resetModules()
+      }
+    })
+
+    it('skips the segmenter one character past the length ceiling', () => {
+      const value = `${'a'.repeat(GRAPHEME_SNAP_MAX_LENGTH - 57)}${FLAG.repeat(10)}match`
+      const result = highlight(matchAfter(value), 'match', 'label') ?? ''
+
+      expect(value.length + MARKUP).toBe(GRAPHEME_SNAP_MAX_LENGTH + 1)
+
+      // The surrogate fallback still holds — that is the whole point of the
+      // degradation being partial.
+      expect(result).not.toMatch(LONE_SURROGATE)
+
+      // And the documented cost: the flag re-pairs. Raise the ceiling by one and
+      // the segmenter runs here, making this assertion fail.
+      expect(firstCluster(result)).not.toBe(FLAG)
+    })
+
+    it('snaps clusters exactly at the ceiling', () => {
+      // The mirror of the case above, one character shorter, so the pair fences
+      // the constant to a single value: lower it by one and this fails, raise it
+      // by one and the other does.
+      const value = `${'a'.repeat(GRAPHEME_SNAP_MAX_LENGTH - 58)}${FLAG.repeat(10)}match`
+      const result = highlight(matchAfter(value), 'match', 'label') ?? ''
+
+      expect(value.length + MARKUP).toBe(GRAPHEME_SNAP_MAX_LENGTH)
+      expect(firstCluster(result)).toBe(FLAG)
+    })
+  })
+
+  describe('truncation from the start', () => {
     // `maxLength` counts the tag characters that the counter inside
     // `truncateHTMLFromStart` skips, so the two cancel and the surviving prefix is
     // always `'<mark>'.length + '</mark>'.length` characters — whatever the match
     // is, and whether the content is BMP or astral.
     const RETAINED = '<mark>'.length + '</mark>'.length
-
-    // One character from each corner of the surrogate ranges. A fixture built only
-    // from characters sitting comfortably inside them hides an implementation whose
-    // range bounds are off by one: U+20000 encodes to a low surrogate of U+DC00 and
-    // U+1F3FF to U+DFFF — the two edges — while U+1F600 sits between them.
-    const ASTRAL = ['\u{10000}', '\u{10FFFF}', '\u{1F600}', '\u{1F3FF}', '\u{20000}']
 
     function highlightAfterFiller(filler: string, count: number) {
       const value = filler.repeat(count) + 'match'
@@ -131,7 +494,7 @@ describe('highlight', () => {
       return highlight({ label: value, matches: [{ key: 'label', value, indices: [[index, index + 4]] }] }, 'match', 'label')
     }
 
-    it.each(ASTRAL)('never splits %s, at any truncation boundary', (astral) => {
+    it.each(ASTRAL_STANDALONE)('never splits %s, at any truncation boundary', (astral) => {
       // Truncating by UTF-16 code unit sliced the pair in half whenever the
       // boundary landed between its surrogates — from 7 characters onward, and
       // every length after that.
@@ -148,7 +511,7 @@ describe('highlight', () => {
       expect(results.filter(result => LONE_SURROGATE.test(result ?? ''))).toEqual([])
     })
 
-    it.each(ASTRAL)('keeps %s before the match intact, truncating to the budget', (astral) => {
+    it.each(ASTRAL_STANDALONE)('keeps %s before the match intact, truncating to the budget', (astral) => {
       // Pinned exactly: counting by code unit kept six characters and half of a
       // seventh here, and a "fix" that stopped truncating astral content entirely
       // would keep all 20.


### PR DESCRIPTION
### Linked issue

Closes #364.

> **Now targets `main`** — #369 has landed (`531921ad`), so this is a single commit and CI runs on it for the first time. #362 and #375 are covered by @arsalan507's #379, not here — the overlapping work was dropped. This PR will need a rebase once #379 lands, since the grapheme snap subsumes its surrogate snap.
>
> **Authorship — please read before reviewing.** This branch, its three review rounds and every revision were produced by a single Claude Code session. Nothing here has had an independent reader. The measurements are reproducible but unaudited, and self-review does not substitute for review: each round found real defects in what the previous round had signed off, which is evidence that the process is not converging on its own. This is not only about the `v-html`-adjacent parts — the correctness argument, the benchmark methodology and the invariant text all carry the same caveat.

### Type of change

- [ ] Documentation (updates to the documentation or readme)
- [x] Bug fix (a non-breaking change that fixes an issue)
- [ ] Enhancement (improving an existing functionality)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Chore (updates to the build process or auxiliary tools and libraries)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Description

Code points are not what a reader sees. A flag is two regional indicators, a family emoji several joined by ZWJ, `कि` a consonant plus a vowel sign. Cutting inside one produces a **different** character rather than a broken one — 🇺🇸 truncated by a single code point re-pairs into 🇸🇺, a different country, with nothing to signal the loss. That is worse than a `�`, which at least looks wrong.

Both boundaries snap off the straddled cluster: mark insertion in `generateHighlightedText`, truncation in `truncateHTMLFromStart`.

**Chosen on measurement.**

| approach | cost | correct? |
|---|---|---|
| segment the whole string | 455 µs at 979 chars, 52 ms at 100k | yes, unusable |
| fixed ±64 window | constant 3.2 µs | **no** |
| `Segments.containing()` | see below | yes |

The window is worth knowing about, because it is the obvious optimisation and looks ideal. A run of flags is longer than the window, so segmentation starts mid-run and re-pairs the indicators — **reproducing the exact bug being fixed**, 28 disagreements in 1044 probes.

So `containing()` ships, behind three guards:

- **A `< U+0300` screen**, keeping ASCII and Latin-1 off the segmenter. It does nothing for Cyrillic (U+0430) or CJK — both above the floor. For a product localised into Russian this covers markup and Latin identifiers, not body text. #376 tracks widening it.
- **One segmenter view per value**, built lazily: 8.1 ms → 0.6 ms over 1600 boundaries.
- **An 8192-character ceiling**, past which only the surrogate snap applies and every multi-code-point cluster loses protection — not just flags. Note it measures the *marked-up* string, so the threshold arrives 13 characters earlier than a reading of `value.length` suggests.

`pnpm run bench` (`test/bench/search.bench.ts`): ASCII baseline, Cyrillic and CJK 2.3×, emoji 2.0×, an all-flag run 6.1×.

### The snap was the easy half

Every defect review found was in the bookkeeping around it, not in the segmentation — and each one reached the user as duplicated or vanished text rather than as an error, because `substring()` swaps a range it finds reversed and clamps one it finds out of range instead of throwing.

Four, in the order they were found:

| defect | symptom | found in |
|---|---|---|
| a region the clamps left empty still emitted its tags | bare `<mark></mark>`, highlight lost | round 1 |
| a region past the end of the value bypassed that guard — the comparison did not clamp where `substring()` did | same empty mark, frozen cursor swallowing every later region, and a trailing mark that drove truncation into eating the text before it | round 2 |
| a region nested inside an earlier one ends *behind* the cursor | `[[0,5],[1,2]]` on `abcdefgh` gave `<mark>abcdef</mark>defdefgh` — the overlap emitted three times | round 3 |
| a non-integer bound | `NaN` compares false against every guard including `end > start`, then lands in the cursor, where `substring(NaN)` reads as `substring(0)` and repeats the whole value | round 3 |

All four are guarded, each by a test verified to fail with its guard removed. Both round-3 defects are reachable through `CommandPaletteGroup.postFilter`, which lets a caller supply its own `matches` — Fuse itself always emits sorted, merged, integer-bounded regions.

`indices` are now filtered to integer bounds and sorted before use. The sort's tie-break puts the longest of an equal-start pair first, so the outer region is marked whole instead of being split across two `<mark>`s.

**One clamp went the other way.** Mutation testing showed `Math.min(…, value.length)` on `start` was unreachable — `start` can only exceed the value by exceeding `end`, which is checked — so it was removed rather than left as an untested guard.

### Coverage

Every constant and branch was verified by removing it and watching a named test fail. That is what closed the two gaps this PR previously listed as known-and-unfixed:

- **The CRLF carve-out had no fixture.** It is the only cluster rule `Intl.Segmenter` never sees, because the `< U+0300` screen answers that boundary first — so all three of its mutations passed the whole file.
- **The four surrogate range constants were pinned in one direction only.** Every fixture held a *real* pair, which catches a range being narrowed and not one being widened; widening needs two units that are *not* a pair, i.e. malformed UTF-16, which reaches `highlight()` through any label built from a byte-truncated field. All four widening mutations passed.

One mutation still survives by design: removing the `< U+0300` screen entirely. It is a performance guard and changes no output — the bench is what measures it.

### Remaining caveat

The bench is advisory: no assertions, not in CI.

### Notes

`truncateHTMLFromStart` counts retained code units and slices once, because the snap needs an index to move. Verified equivalent over 400,078 fuzzed inputs, including strings beginning with `...`.

A fixture trap is recorded in the tests: UAX #29 glues a run of bare emoji modifiers into a *single* cluster, so `'\u{1F3FF}'.repeat(20)` is one character, not twenty.

### Checklist

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.

Full suite green on the rebase — 6304 passed, 6 skipped, 270 files. Each new case was verified failing against the unpatched version first. `eslint .`, `vue-tsc --noEmit` and `pnpm build` clean.