### PR TITLE
fix(icons): make the dictionary's promises true, and enforce both of them

### DIFF
--- a/.sync/PORTING.md
+++ b/.sync/PORTING.md
@@ -41,14 +41,13 @@ material. Reproduce its *intent* in b24ui by editing files under `src/` only.
 > `appConfig.ui.icons.<key>` or `icons.<key>`, **keep the key unchanged** and
 > most icon diffs come out 1:1.
 >
-> With one caveat worth knowing before you trust that: the dictionary is the
-> *declared* authority, not the only one. Roughly half the
-> `@bitrix24/b24icons-vue/…` paths under `src/` are hardcoded in components that
-> never read it — `Checkbox.vue` renders `main/CheckIcon` where the dictionary
-> says `outline/CheckLIcon`, and `Badge.vue` renders `actions/Cross20Icon` for
-> `close`. So porting a key faithfully changes what those components render only
-> if they were reading the key in the first place; check the component, not just
-> the key. #380 tracks the inconsistency.
+> With one caveat before you trust that: the dictionary is the *declared*
+> authority, not the only one. Four components pick a **sized variant** of a
+> role's glyph instead — `Checkbox` renders `main/CheckIcon` where the `check`
+> role is `outline/CheckLIcon`, `Badge` renders `actions/Cross20Icon` for
+> `close` — so porting a change to `icons.<key>` reaches the components that
+> read the key and not those four. Check the component, not just the key; the
+> §2 invariant below lists all of them and #380 holds the open question.
 >
 > [`icon-map.json`](./icon-map.json) is only for the other case: upstream
 > **hardcoding** a literal `i-lucide-*` string — which upstream does exactly once
@@ -74,6 +73,27 @@ material. Reproduce its *intent* in b24ui by editing files under `src/` only.
   with `node -e "..."` diffing nuxt vs demo (and check vue/repl), then
   regenerate the lockfile once. A dep that exists only in `nuxt` but not `demo`
   (or vice-versa) is fine; a dep present in **both** must not drift.
+- **Some components pick a sized icon variant instead of the dictionary's — do
+  not "fix" that during a port.** `dictionary/icons.ts` holds one glyph per
+  semantic role, at standalone size. Four components deliberately reach past it
+  for a variant scaled to the control they sit in: `Badge` renders
+  `actions/Cross20Icon` and `SidebarLayout` renders `actions/Cross50Icon` where
+  the `close` role is `outline/CrossMIcon`; `Checkbox` renders `main/CheckIcon`
+  and `actions/Minus20Icon` where `check`/`minus` are `outline/CheckLIcon` and
+  `actions/Minus30Icon`; `Button` renders `outline/ChevronDownSIcon` where
+  `chevronDown` is `outline/ChevronDownLIcon`. The suffixes are sizes, not
+  families — all share a `0 0 24 24` viewBox and differ in how much of it the
+  glyph fills (`Minus20Icon` spans x 7→17, `Minus30Icon` spans 6→18). So an
+  upstream commit that changes an `icons.<key>` default reaches the components
+  that read the key, and **not** these four; replaying it onto them silently
+  resizes a tick, a badge cross or a button chevron. The reverse trap is worse:
+  routing them "back" through the dictionary looks like a tidy-up in a diff and
+  changes what four components render. #380 holds the open question of whether
+  these should instead become sized roles or overridable props; until it is
+  answered, leave them. Guarded from the documentation side by
+  `test/utils/icon-claims.spec.ts`, which fails if a component's jsDoc promises
+  an `icons.<key>` that nothing it can reach actually uses — the three claims
+  that were already false are why it exists.
 - **Locales — do NOT add new ones.** b24ui maintains its own curated locale
   set and does not adopt new languages from upstream. When an upstream commit
   adds a locale (a new `src/runtime/locale/<code>.ts` + an `index.ts` export),

--- a/docs/content/docs/1.getting-started/6.integrations/1.icons/1.nuxt.md
+++ b/docs/content/docs/1.getting-started/6.integrations/1.icons/1.nuxt.md
@@ -135,6 +135,7 @@ export default {
   arrowDown: ArrowDownLIcon,
   arrowUp: ArrowTopLIcon,
   stop: StopLIcon,
+  star: FavoriteIcon,
   reload: RefreshIcon,
   drag: DragLIcon,
   menu: HamburgerMenuIcon,
@@ -154,7 +155,11 @@ export default {
   MoreMIcon, // dropdown menu trigger
   AiStarsIcon, // "Explain with AI" / AI assistant entry
   EncloseTextInCodeTagIcon, // source / "View code" CTA
-  PlayLIcon // "Try it" / playground / REPL CTA
+  PlayLIcon, // "Try it" / playground / REPL CTA
+  // Defined inline in the file as small SVG components (bodies omitted here)
+  CursorIcon, // Cursor IDE — open prompt in app
+  WindsurfIcon, // Windsurf IDE — open prompt in app
+  ClaudeIcon // Claude Code — open prompt in app
 }
 ```
 

--- a/docs/content/docs/1.getting-started/6.integrations/1.icons/2.vue.md
+++ b/docs/content/docs/1.getting-started/6.integrations/1.icons/2.vue.md
@@ -133,6 +133,7 @@ export default {
   arrowDown: ArrowDownLIcon,
   arrowUp: ArrowTopLIcon,
   stop: StopLIcon,
+  star: FavoriteIcon,
   reload: RefreshIcon,
   drag: DragLIcon,
   menu: HamburgerMenuIcon,
@@ -152,7 +153,11 @@ export default {
   MoreMIcon, // dropdown menu trigger
   AiStarsIcon, // "Explain with AI" / AI assistant entry
   EncloseTextInCodeTagIcon, // source / "View code" CTA
-  PlayLIcon // "Try it" / playground / REPL CTA
+  PlayLIcon, // "Try it" / playground / REPL CTA
+  // Defined inline in the file as small SVG components (bodies omitted here)
+  CursorIcon, // Cursor IDE — open prompt in app
+  WindsurfIcon, // Windsurf IDE — open prompt in app
+  ClaudeIcon // Claude Code — open prompt in app
 }
 ```
 

--- a/src/runtime/components/Badge.vue
+++ b/src/runtime/components/Badge.vue
@@ -37,7 +37,9 @@ export interface BadgeProps extends Omit<UseComponentIconsProps, 'loading' | 'lo
    */
   useLink?: boolean
   /**
-   * Shows icons.close on the right side
+   * Shows a small close cross (`actions/Cross20Icon`) on the right side.
+   * Sized for a badge rather than taken from the dictionary's `close` role,
+   * which is the standalone size — see #380.
    * @defaultValue false
    */
   useClose?: boolean

--- a/src/runtime/components/Button.vue
+++ b/src/runtime/components/Button.vue
@@ -57,7 +57,9 @@ export interface ButtonProps extends Omit<UseComponentIconsProps, 'trailing' | '
    */
   useClock?: boolean
   /**
-   * Shows icons.ChevronDownSIcon on the right side
+   * Shows a small dropdown chevron (`outline/ChevronDownSIcon`) on the right
+   * side. Sized for a button rather than taken from the dictionary's
+   * `chevronDown` role, which is the standalone size — see #380.
    * @defaultValue false
    */
   useDropdown?: boolean

--- a/src/runtime/components/ChatTool.vue
+++ b/src/runtime/components/ChatTool.vue
@@ -40,8 +40,8 @@ export interface ChatToolProps extends Pick<CollapsibleRootProps, 'defaultOpen' 
    */
   useClock?: boolean
   /**
-   * The icon displayed when loading.
-   * @defaultValue icons.loading
+   * The icon displayed when loading. Overrides `useWait` / `useClock`.
+   * @defaultValue `specialized/SpinnerIcon`
    * @IconifyIcon
    */
   loadingIcon?: IconComponent

--- a/src/runtime/dictionary/icons.ts
+++ b/src/runtime/dictionary/icons.ts
@@ -2,6 +2,9 @@
  * Default icons
  * ---
  * @link https://bitrix24.github.io/b24icons/
+ * Both pages below inline this file's `export default` so readers can see every
+ * overridable role. Keeping them in step is enforced, not remembered — add a
+ * role here and `test/utils/icons-docs.spec.ts` fails until both list it.
  * @memo sync with docs/content/docs/1.getting-started/6.integrations/1.icons/1.nuxt.md
  * @memo sync with docs/content/docs/1.getting-started/6.integrations/1.icons/2.vue.md
  */

--- a/test/utils/icon-claims.spec.ts
+++ b/test/utils/icon-claims.spec.ts
@@ -1,0 +1,103 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, it, expect } from 'vitest'
+import { glob } from 'tinyglobby'
+
+/**
+ * Every `icons.<key>` a component's jsDoc promises must actually be reachable
+ * from that component.
+ *
+ * These promises are load-bearing: `@defaultValue icons.close` is what tells a
+ * consumer the icon is overridable through `dictionary/icons.ts`, and it is
+ * what a porter reads when an upstream commit changes that key. Three of them
+ * were false — `Badge` documented `icons.close` while rendering a hardcoded
+ * `actions/Cross20Icon`, `Button` documented a component name as if it were a
+ * key, and `ChatTool` documented `icons.loading` for a prop that defaults to
+ * `specialized/SpinnerIcon`. Nothing failed, because a comment cannot.
+ *
+ * Reachability, not locality: `DropdownMenu` legitimately documents
+ * `@defaultValue icons.check` for a prop it forwards to
+ * `DropdownMenuContent.vue`, which is where the dictionary is read. So a claim
+ * counts as honoured if the key is used in the component itself or in any
+ * component it renders.
+ */
+
+const componentsDir = resolve(process.cwd(), 'src/runtime/components')
+
+const files = await glob('**/*.vue', { cwd: componentsDir })
+
+/**
+ * Keyed by path, not by basename: eight components have a same-named twin under
+ * `prose/` (`Badge`, `Card`, `Accordion`, `Table`, `Collapsible`, `Kbd`,
+ * `FieldGroup`, `Tabs`). Keying by basename silently drops one of each pair,
+ * and a check that skips half its input still passes.
+ */
+const sources = new Map(files.map(file => [file, readFileSync(resolve(componentsDir, file), 'utf-8')]))
+
+/** Basename -> every source with that name, for resolving a `<B24Foo` tag. */
+const byName = new Map<string, string[]>()
+for (const [file, source] of sources) {
+  const name = file.split('/').pop()!.replace('.vue', '')
+  byName.set(name, [...(byName.get(name) ?? []), source])
+}
+
+/** Splits a SFC into its comment lines and everything else. */
+function partition(source: string) {
+  const comments: string[] = []
+  const code: string[] = []
+  for (const line of source.split('\n')) {
+    ;(line.trim().startsWith('*') || line.trim().startsWith('//') ? comments : code).push(line)
+  }
+  return { comments: comments.join('\n'), code: code.join('\n') }
+}
+
+/**
+ * `icons.<key>` written in prose. `icons.ts` is excluded because
+ * `prose/Prompt.vue` refers to the dictionary *file* — a filename, not a key.
+ */
+const claimed = (comments: string) =>
+  new Set([...comments.matchAll(/\bicons\.(\w+)/g)].map(match => match[1]!).filter(key => key !== 'ts'))
+
+const used = (code: string) => new Set([...code.matchAll(/\bicons\.(\w+)/g)].map(match => match[1]!))
+
+/** Child components this one renders, as `<B24Foo` / `<Foo` tag names. */
+const rendered = (code: string) =>
+  new Set([...code.matchAll(/<(?:B24)?([A-Z]\w+)/g)].map(match => match[1]!))
+
+describe('icon claims in component jsDoc', () => {
+  it('finds the components to check', () => {
+    // Every assertion below passes vacuously on an empty glob.
+    expect(sources.size).toBeGreaterThan(50)
+  })
+
+  it('finds jsDoc claims to check', () => {
+    const total = [...sources.values()].reduce((sum, source) => sum + claimed(partition(source).comments).size, 0)
+    expect(total).toBeGreaterThan(10)
+  })
+
+  it('honours every `icons.<key>` its jsDoc promises', () => {
+    const broken: string[] = []
+
+    for (const [file, source] of sources) {
+      const { comments, code } = partition(source)
+      const promises = claimed(comments)
+      if (!promises.size) continue
+
+      // The component itself, plus anything it renders — one hop is enough for
+      // the forwarding pattern and keeps this from becoming a graph walk.
+      const reachable = new Set(used(code))
+      for (const child of rendered(code)) {
+        for (const childSource of byName.get(child) ?? []) {
+          for (const key of used(partition(childSource).code)) reachable.add(key)
+        }
+      }
+
+      for (const key of [...promises].sort()) {
+        if (!reachable.has(key)) broken.push(`${file}: jsDoc promises icons.${key}, nothing reachable uses it`)
+      }
+    }
+
+    // Named rather than counted — the failure has to say which promise is empty.
+    expect(broken.sort()).toEqual([])
+  })
+})

--- a/test/utils/icons-docs.spec.ts
+++ b/test/utils/icons-docs.spec.ts
@@ -1,0 +1,66 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, it, expect } from 'vitest'
+
+/**
+ * `src/runtime/dictionary/icons.ts` asks, in its own header, to be kept in sync
+ * with two documentation pages:
+ *
+ *     @memo sync with docs/.../6.integrations/1.icons/1.nuxt.md
+ *     @memo sync with docs/.../6.integrations/1.icons/2.vue.md
+ *
+ * Both inline a copy of its `export default { … }` so a reader can see every
+ * overridable role. Hand-copying is what let them drift: `star` and the three
+ * IDE brand icons were added to the dictionary and never reached the pages, so
+ * anyone building icon overrides from the docs silently got an incomplete map
+ * (#381).
+ *
+ * A `@memo` cannot fail, so this does. It compares the key sets, not the file
+ * text — the pages deliberately omit the inline SVG bodies of `CursorIcon`,
+ * `WindsurfIcon` and `ClaudeIcon`, and pinning the exact characters would make
+ * every unrelated reformat of the dictionary a docs failure.
+ */
+
+const PAGES = [
+  'docs/content/docs/1.getting-started/6.integrations/1.icons/1.nuxt.md',
+  'docs/content/docs/1.getting-started/6.integrations/1.icons/2.vue.md'
+]
+
+const read = (path: string) => readFileSync(resolve(process.cwd(), path), 'utf-8')
+
+/** The keys of the first `export default { … }` block in a file. */
+function exportedKeys(source: string, label: string): string[] {
+  const start = source.indexOf('export default {')
+  expect(start, `${label}: no \`export default {\` block`).toBeGreaterThan(-1)
+  const end = source.indexOf('\n}\n', start)
+  expect(end, `${label}: unterminated \`export default {\` block`).toBeGreaterThan(start)
+
+  // Matches both forms the dictionary uses: `key: Component,` and the
+  // shorthand `Component,` for the named icons.
+  return [...source.slice(start, end).matchAll(/^ {2}(\w+)(?::[ \t]*[\w.]+)?,?[ \t]*(?:\/\/.*)?$/gm)]
+    .map(match => match[1]!)
+    .sort()
+}
+
+const dictionaryKeys = exportedKeys(read('src/runtime/dictionary/icons.ts'), 'dictionary')
+
+describe('icons dictionary is mirrored in the docs', () => {
+  it('reads a non-trivial dictionary', () => {
+    // Every comparison below is vacuous against an empty key set.
+    expect(dictionaryKeys.length).toBeGreaterThan(40)
+  })
+
+  it.each(PAGES)('%s lists exactly the dictionary roles', (page) => {
+    const documented = exportedKeys(read(page), page)
+
+    // Compared as sorted arrays so the diff names the missing or extra role
+    // rather than reporting two sizes.
+    expect(documented).toEqual(dictionaryKeys)
+  })
+
+  it.each(PAGES)('%s still points at the dictionary it copies', (page) => {
+    // The code fence carries the source path; if the block is ever moved or
+    // renamed, the comparison above would start checking the wrong thing.
+    expect(read(page)).toContain('```ts [src/runtime/dictionary/icons.ts]')
+  })
+})


### PR DESCRIPTION
Closes #381, and resolves the answerable half of #380.

## #380 — the "conflicts" are deliberate sizes; the documentation of them was false

The issue reported that half the icon paths under `src/` bypass `dictionary/icons.ts`. True by count, misleading in substance: **42 of the 49** are file-type icons in `prose/CodeIcon.vue`, which have no semantic role and never should. Five remain.

Those five are **size variants, not mistakes**. Every one shares a `0 0 24 24` viewBox and differs only in how much of it the glyph fills:

| role | dictionary (standalone) | component (sized) | evidence |
|---|---|---|---|
| `minus` | `actions/Minus30Icon` — spans x 6→18 | `Checkbox` → `Minus20Icon` — spans 7→17 | narrower bar |
| `chevronDown` | `ChevronDownLIcon` — 12 units | `Button` → `ChevronDownSIcon` — 8 units | smaller chevron |
| `close` | `outline/CrossMIcon` | `Badge` → `Cross20Icon`, `SidebarLayout` → `Cross50Icon` | three sizes of one cross |
| `check` | `outline/CheckLIcon` | `Checkbox` → `main/CheckIcon` | heavier tick |

A checkbox tick, a badge cross and a button chevron are deliberately smaller than a standalone icon. **Left exactly as they render** — nothing visual changes in this PR.

What *was* broken is how that is documented. Three components promised behaviour they do not have:

- **`Badge`** — `Shows icons.close on the right side`, while rendering a hardcoded `actions/Cross20Icon`;
- **`Button`** — `Shows icons.ChevronDownSIcon`, which is a component name dressed as a dictionary key; no such key exists;
- **`ChatTool`** — `@defaultValue icons.loading` for a prop that actually defaults to `specialized/SpinnerIcon`.

`@defaultValue icons.X` is what tells a consumer the icon is overridable through the dictionary, and what a porter reads when an upstream commit changes that key. Not cosmetic.

### The guard

`test/utils/icon-claims.spec.ts` fails when a component's jsDoc promises an `icons.<key>` that nothing it can reach actually uses. **Reachability, not locality** — `DropdownMenu` legitimately documents `@defaultValue icons.check` for a prop it forwards to `DropdownMenuContent.vue`, where the dictionary is read.

Verified by reintroducing all three defects:

```
+ "Badge.vue: jsDoc promises icons.close, nothing reachable uses it",
+ "Button.vue: jsDoc promises icons.chevronDown, nothing reachable uses it",
+ "ChatTool.vue: jsDoc promises icons.loading, nothing reachable uses it",
```

It also caught this PR's own first draft, where the replacement comments named `icons.chevronDown` in prose while explaining that it is *not* used.

### `PORTING.md` §2

Both directions are traps for a port, so the invariant is written down: an upstream change to `icons.<key>` **does not** reach those four components, and routing them "back" through the dictionary reads as a tidy-up in a diff while silently resizing three glyphs. #380 stays open for the remaining design question — whether these should become sized roles (`checkS`/`checkL`) or overridable props like `Alert`/`Banner` already have.

## #381 — the docs were four roles behind

Both icons integration pages inline the dictionary's `export default` so a reader can see every overridable role. `star`, `CursorIcon`, `WindsurfIcon` and `ClaudeIcon` never reached them, so anyone building overrides from the docs got an incomplete map.

Patched from the source. `test/utils/icons-docs.spec.ts` compares the **key sets**, not the file text — the pages deliberately omit the inline SVG bodies of the three IDE brand icons, and pinning characters would make every unrelated reformat a docs failure. Proven by removing `star` from one page:

```
× 1.nuxt.md lists exactly the dictionary roles
-   "star",
```

The dictionary's `@memo sync with` lines now say the sync is enforced rather than remembered.

## A bug I made, worth reading

The first version of the claims guard keyed components by **basename**, and silently skipped eight of them — `Badge`, `Card`, `Accordion`, `Table`, `Collapsible`, `Kbd`, `FieldGroup` and `Tabs` each have a same-named twin under `prose/`, and the Map kept only one of each pair. The test passed while checking half its input, including the very `Badge.vue` it was written for.

It surfaced only because I re-injected the original defect and got a green run instead of a red one. It is now keyed by path, with the reason in a comment. Same class of bug as the one `test/utils/vitest-include.spec.ts` exists to prevent.

## Verify (`CI=true`)

`lint` · `typecheck` · `test` · `build` — all green. Tests **6233 passed | 6 skipped** across 270 files.

One flake on the way: `DropdownMenu > passes accessibility tests` timed out at 5000ms under full-suite contention, then passed 34/34 in isolation. Same spec flaked earlier in the sync run; this diff touches no `DropdownMenu` runtime code.


---
_Generated by [Claude Code](https://claude.ai/code/session_01JS8ypVfQSFzYVZzkTHhURb)_