### PR TITLE
docs(rtl): position examples with logical properties

### DIFF
--- a/docs/app/components/content/examples/command-palette/CommandPaletteFooterSlotExample.vue
+++ b/docs/app/components/content/examples/command-palette/CommandPaletteFooterSlotExample.vue
@@ -66,7 +66,7 @@ const groups = [
   <B24CommandPalette :groups="groups" class="flex-1 h-80">
     <template #footer>
       <div class="flex items-center justify-between gap-2">
-        <Bitrix24Icon class="size-5 text-label ml-1" />
+        <Bitrix24Icon class="size-5 text-label ms-1" />
         <div class="flex items-center gap-1">
           <B24Button label="Open Command" size="sm">
             <template #trailing>

--- a/docs/app/components/content/examples/editor/EditorExample.vue
+++ b/docs/app/components/content/examples/editor/EditorExample.vue
@@ -718,7 +718,7 @@ const emojiItems: EditorEmojiMenuItem[] = gitHubEmojis.filter(emoji => !emoji.na
     <B24EditorToolbar
       :editor="editor"
       :items="fixedToolbarItems"
-      class="border-b border-(--ui-color-design-tinted-na-stroke) absolute top-0 inset-x-0 px-8 mr-2 sm:px-16 py-2 z-20 bg-default overflow-x-auto rounded-t-md"
+      class="border-b border-(--ui-color-design-tinted-na-stroke) absolute top-0 inset-x-0 px-8 me-2 sm:px-16 py-2 z-20 bg-default overflow-x-auto rounded-t-md"
     >
       <template #link>
         <EditorLinkPopover :editor="editor" auto-open />

--- a/docs/app/components/content/examples/editor/EditorLinkPopover.vue
+++ b/docs/app/components/content/examples/editor/EditorLinkPopover.vue
@@ -116,7 +116,7 @@ function handleKeyDown(event: KeyboardEvent) {
         placeholder="Paste a link..."
         @keydown="handleKeyDown"
       >
-        <div class="flex items-center mr-0.5">
+        <div class="flex items-center me-0.5">
           <B24Button
             :icon="LowerRightArrowIcon"
             color="air-tertiary-accent"

--- a/docs/app/components/content/examples/form/FormTaskFormExample.vue
+++ b/docs/app/components/content/examples/form/FormTaskFormExample.vue
@@ -78,7 +78,7 @@ const actionButtons: { label: string, icon: IconComponent, active?: boolean }[] 
         <div class="flex items-center gap-1 px-2 py-1.5 border-b border-(--ui-color-divider-default)">
           <B24Button :icon="FileUploadIcon" color="air-tertiary" variant="ghost" size="sm" aria-label="Attach file" />
           <B24EditorToolbar :editor="editor" :items="toolbarItems" />
-          <div class="ml-auto">
+          <div class="ms-auto">
             <B24Button :icon="GoToLIcon" color="air-tertiary" variant="ghost" size="sm" aria-label="Expand editor" />
           </div>
         </div>

--- a/docs/app/components/content/examples/index/IndexPromoV1.vue
+++ b/docs/app/components/content/examples/index/IndexPromoV1.vue
@@ -61,7 +61,7 @@ defineShortcuts({
 <template>
   <canvas
     ref="myCanvas"
-    class="absolute top-0 left-0 right-0 bottom-0 z-0 w-full h-full"
+    class="absolute top-0 start-0 end-0 bottom-0 z-0 w-full h-full"
   />
   <div class="h-[200px] flex flex-col items-center justify-center">
     <B24Advice

--- a/docs/app/components/content/examples/input/InputCopyButtonExample.vue
+++ b/docs/app/components/content/examples/input/InputCopyButtonExample.vue
@@ -12,7 +12,7 @@ const { copy, copied } = useClipboard()
 <template>
   <B24Input
     v-model="value"
-    :b24ui="{ trailing: 'pr-0.5' }"
+    :b24ui="{ trailing: 'pe-0.5' }"
   >
     <template v-if="value?.length" #trailing>
       <B24Tooltip text="Copy to clipboard" :content="{ side: 'right' }">

--- a/docs/app/components/content/examples/input/InputFieldGroupExample.vue
+++ b/docs/app/components/content/examples/input/InputFieldGroupExample.vue
@@ -10,7 +10,7 @@ const domain = ref(domains[0])
       v-model="value"
       placeholder="bitrix24"
       :b24ui="{
-        base: 'pl-[48px]',
+        base: 'ps-[48px]',
         leading: 'pointer-events-none'
       }"
     >

--- a/docs/app/components/content/examples/input/InputFloatingLabelExample.vue
+++ b/docs/app/components/content/examples/input/InputFloatingLabelExample.vue
@@ -4,7 +4,7 @@ const value = ref('')
 
 <template>
   <B24Input v-model="value" placeholder="" :b24ui="{ base: 'peer' }">
-    <label class="pointer-events-none absolute left-0 -top-[10px] text-label text-(length:--ui-font-size-xs)/(--ui-font-line-height-reset) font-(--ui-font-weight-medium) px-1.5 transition-all peer-focus:-top-[10px] peer-focus:text-label peer-focus:text-(length:--ui-font-size-xs)/(--ui-font-line-height-reset) peer-focus:font-(--ui-font-weight-medium) peer-placeholder-shown:text-(length:--ui-font-size-sm)/(--ui-font-line-height-reset) peer-placeholder-shown:text-legend peer-placeholder-shown:top-[10px] peer-placeholder-shown:font-(--ui-font-weight-normal)">
+    <label class="pointer-events-none absolute start-0 -top-[10px] text-label text-(length:--ui-font-size-xs)/(--ui-font-line-height-reset) font-(--ui-font-weight-medium) px-1.5 transition-all peer-focus:-top-[10px] peer-focus:text-label peer-focus:text-(length:--ui-font-size-xs)/(--ui-font-line-height-reset) peer-focus:font-(--ui-font-weight-medium) peer-placeholder-shown:text-(length:--ui-font-size-sm)/(--ui-font-line-height-reset) peer-placeholder-shown:text-legend peer-placeholder-shown:top-[10px] peer-placeholder-shown:font-(--ui-font-weight-normal)">
       <span class="inline-flex bg-(--ui-color-base-white-fixed) px-1">Email address</span>
     </label>
   </B24Input>

--- a/docs/app/components/content/examples/navigation-menu/NavigationMenuTrailingSlotExample.vue
+++ b/docs/app/components/content/examples/navigation-menu/NavigationMenuTrailingSlotExample.vue
@@ -68,7 +68,7 @@ const dropdownItems: DropdownMenuItem[][] = [
     </template>
 
     <template #item-trailing>
-      <div class="flex -mr-1.5 -my-0.5 translate-x-full group-hover:translate-x-0 has-data-[state=open]:translate-x-0 transition-transform">
+      <div class="flex -me-1.5 -my-0.5 translate-x-full group-hover:translate-x-0 has-data-[state=open]:translate-x-0 transition-transform">
         <B24DropdownMenu
           :items="dropdownItems"
           :content="{ align: 'start' }"
@@ -80,7 +80,7 @@ const dropdownItems: DropdownMenuItem[][] = [
             :icon="MoreMIcon"
             color="air-tertiary"
             size="xs"
-            class="text-description hover:text-label hover:bg-(--ui-color-accent-soft-element-blue)/40 data-[state=open]:bg-(--ui-color-accent-soft-element-blue)/30 mr-1.5"
+            class="text-description hover:text-label hover:bg-(--ui-color-accent-soft-element-blue)/40 data-[state=open]:bg-(--ui-color-accent-soft-element-blue)/30 me-1.5"
           />
         </B24DropdownMenu>
       </div>

--- a/docs/app/components/content/examples/scroll-area/ScrollAreaExternalScrollExample.vue
+++ b/docs/app/components/content/examples/scroll-area/ScrollAreaExternalScrollExample.vue
@@ -53,7 +53,7 @@ function scrollToStart() {
         ref="title"
         class="z-10 flex gap-4 bg-elevated/50 backdrop-blur"
         :class="isHorizontal
-          ? 'sticky left-0 w-72 shrink-0 flex-col justify-center p-6 border-r border-muted'
+          ? 'sticky start-0 w-72 shrink-0 flex-col justify-center p-6 border-e border-muted'
           : 'sticky top-0 items-end justify-between px-6 py-4 border-b border-muted'"
       >
         <div>

--- a/docs/app/components/content/examples/skeleton/SkeletonTaskExample.vue
+++ b/docs/app/components/content/examples/skeleton/SkeletonTaskExample.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="w-full flex flex-col flex-nowrap p-4 bg-base-50 dark:bg-base-dark">
     <div class="mb-4 flex flex-row flex-nowrap items-center justify-between gap-2 ">
-      <B24Skeleton class="ml-xs2 h-xs2 w-[38%] rounded-3xs" />
+      <B24Skeleton class="ms-xs2 h-xs2 w-[38%] rounded-3xs" />
       <div class="flex flex-row flex-nowrap items-center justify-between gap-4">
         <div class="border-2 border-gray-200 dark:border-gray-800 size-[40px] rounded-2xs flex items-center justify-center">
           <B24Skeleton class="h-xs2 w-[10px] rounded-3xs" />

--- a/docs/app/components/content/examples/table/TableColumnSpanExample.vue
+++ b/docs/app/components/content/examples/table/TableColumnSpanExample.vue
@@ -44,7 +44,7 @@ function getCategoryClass(cell: Cell<Product, unknown>) {
     return 'hidden'
   }
 
-  return 'font-medium align-middle border-r border-default'
+  return 'font-medium align-middle border-e border-default'
 }
 
 const columns: TableColumn<Product>[] = [{

--- a/docs/app/components/content/examples/table/TableExample.vue
+++ b/docs/app/components/content/examples/table/TableExample.vue
@@ -373,7 +373,7 @@ async function sleepAction(timeout: number = 1000): Promise<void> {
             label="Columns"
             color="air-secondary-accent-1"
             use-dropdown
-            class="ml-auto"
+            class="ms-auto"
             aria-label="Columns select dropdown"
           />
         </B24DropdownMenu>

--- a/docs/app/components/content/examples/table/TableExternalScrollExample.vue
+++ b/docs/app/components/content/examples/table/TableExternalScrollExample.vue
@@ -99,7 +99,7 @@ const columns: TableColumn<Payment>[] = [{
   >
     <div
       ref="title"
-      class="sticky left-0 z-10 flex items-end justify-between gap-4 p-6 bg-elevated/50"
+      class="sticky start-0 z-10 flex items-end justify-between gap-4 p-6 bg-elevated/50"
     >
       <div>
         <h2 class="text-2xl font-bold">

--- a/docs/app/components/content/examples/table/TableGroupedRowsExample.vue
+++ b/docs/app/components/content/examples/table/TableGroupedRowsExample.vue
@@ -186,7 +186,7 @@ const grouping_options = ref<GroupingOptions>({
         />
 
         <B24Button
-          class="mr-2"
+          class="me-2"
           size="xs"
           :icon="row.getIsExpanded() ? MinusLIcon : PlusLIcon"
           @click="row.toggleExpanded()"

--- a/docs/app/components/content/examples/use-speech-recognition/useSpeechRecognitionExample.vue
+++ b/docs/app/components/content/examples/use-speech-recognition/useSpeechRecognitionExample.vue
@@ -38,7 +38,7 @@ const stopDictation = async () => {
 </script>
 
 <template>
-  <div class="w-full relative flex items-end gap-2 bg-(--ui-color-bg-content-secondary) rounded-xs ring-1 ring-ai-250 hover:ring-ai-350 pr-2 pb-2">
+  <div class="w-full relative flex items-end gap-2 bg-(--ui-color-bg-content-secondary) rounded-xs ring-1 ring-ai-250 hover:ring-ai-350 pe-2 pb-2">
     <B24Textarea
       v-model="input"
       :rows="2"

--- a/test/utils/docs-logical-properties.spec.ts
+++ b/test/utils/docs-logical-properties.spec.ts
@@ -1,0 +1,76 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, it, expect } from 'vitest'
+import { glob } from 'tinyglobby'
+
+/**
+ * b24ui ships an `ar` locale with `dir: 'rtl'`, so the docs examples are
+ * reachable in RTL — and `src/theme/` has used logical utilities (`ps-`, `me-`,
+ * `border-s`, `start-`) throughout for a long time. The examples had not caught
+ * up: sixteen still positioned with `ml-`/`pr-`/`left-0`/`border-r`, which
+ * Tailwind does not flip.
+ *
+ * Those are the ones this guards, and only those, because for each of them the
+ * logical form is *identical* under LTR — `ms-2` and `ml-2` compile to the same
+ * rule when the direction is left-to-right. So there is no judgement in them and
+ * nothing to weigh: a physical one is simply the older spelling.
+ *
+ * Deliberately NOT guarded, because both need a decision rather than a swap:
+ *
+ *  - **`text-right`** — 34 occurrences, almost all the numeric column of a Table
+ *    example. Whether an amount column should follow the reading direction or
+ *    stay pinned right is a design call, not a mechanical one.
+ *  - **`translate-x`** — a physical axis with no logical counterpart. Flipping it
+ *    means adding an `rtl:` variant with the opposite sign, which is what
+ *    nuxt/ui@592d5b5 did for the alternating timeline; the remaining site
+ *    (`NavigationMenuTrailingSlotExample`) needs the same treatment and someone
+ *    who can look at the result.
+ *
+ * Both are tracked on the issue this spec was written alongside.
+ */
+
+const examplesDir = resolve(process.cwd(), 'docs/app/components/content/examples')
+
+/** Physical utilities whose logical form is byte-identical under LTR. */
+const PHYSICAL = [
+  { label: 'ml-/mr-', pattern: /(?<![\w:-])-?m[lr]-(?=[\w.[])/g, use: 'ms-/me-' },
+  { label: 'pl-/pr-', pattern: /(?<![\w:-])-?p[lr]-(?=[\w.[])/g, use: 'ps-/pe-' },
+  { label: 'border-l/border-r', pattern: /(?<![\w:-])border-[lr](?![\w-])/g, use: 'border-s/border-e' },
+  { label: 'left-/right-', pattern: /(?<![\w:-])-?(?:left|right)-(?=[\w.[])/g, use: 'start-/end-' }
+]
+
+const files = await glob('**/*.vue', { cwd: examplesDir })
+
+/** The theme's own spelling, used below to prove these utilities still exist. */
+const themeSource = (await glob('*.ts', { cwd: resolve(process.cwd(), 'src/theme') }))
+  .map(file => readFileSync(resolve(process.cwd(), 'src/theme', file), 'utf-8'))
+  .join('')
+
+describe('docs examples position with logical properties', () => {
+  it('finds the examples to check', () => {
+    // Every assertion below passes vacuously on an empty glob.
+    expect(files.length).toBeGreaterThan(300)
+  })
+
+  it('still contains the utilities it is looking for, somewhere in the tree', () => {
+    // If Tailwind ever renamed these, the scan above would go quiet and this
+    // file would report success while checking nothing. Anchored on `src/theme`,
+    // which uses the logical forms, so a rename breaks this rather than hiding.
+    expect(themeSource.length).toBeGreaterThan(10_000)
+    expect(themeSource).toMatch(/(?<![\w:-])m[se]-/)
+    expect(themeSource).toMatch(/(?<![\w:-])p[se]-/)
+  })
+
+  it.each(PHYSICAL)('uses $use rather than $label', ({ pattern, use }) => {
+    const offenders = files
+      .flatMap((file) => {
+        const source = readFileSync(resolve(examplesDir, file), 'utf-8')
+        return [...new Set(source.match(pattern) ?? [])].map(hit => `${file}: ${hit}… — use ${use}`)
+      })
+      .sort()
+
+    // Named rather than counted: the failure has to say which file and which
+    // utility, or the next person re-runs the audit by hand.
+    expect(offenders).toEqual([])
+  })
+})


### PR DESCRIPTION
Closes the "⚠️ Flagged, not fixed" note I left in #386, which said other docs examples using physical direction classes *may* share the problem the alternating-timeline example had. They do — this is the audit, and the half of it that needs no judgement.

Not theoretical: b24ui ships an `ar` locale with `dir: 'rtl'`, so every example is reachable in RTL.

## Audit

381 examples. **48** used a class Tailwind does not flip; exactly **one** — the timeline example from #386 — was RTL-aware.

The examples were the outlier, not a deliberate choice: `src/theme/` has used `ps-`/`me-`/`border-s`/`start-` throughout for a long time.

## What this changes

Only the subset where the logical form is **byte-identical under LTR**, so there is nothing to weigh — `ms-2` and `ml-2` compile to the same rule when direction is left-to-right:

| from | to |
|---|---|
| `ml-` / `mr-` | `ms-` / `me-` |
| `pl-` / `pr-` | `ps-` / `pe-` |
| `border-l` / `border-r` | `border-s` / `border-e` |
| `left-` / `right-` | `start-` / `end-` |

**16 files. No LTR change of any kind.** Every hunk was reviewed individually rather than trusted to the regex.

The RTL behaviour does change — a pinned column in `ScrollAreaExternalScrollExample` and `TableExternalScrollExample` now pins to the reading start, a floating label in `InputFloatingLabelExample` now sits at the start, and so on. That is the point; each was wrong in RTL before.

## What this deliberately does not change

Both need a decision rather than a swap. Filed as **#400** with the full file list.

**34 `text-right`**, essentially all the amount column of a Table example. Whether a numeric column should follow the reading direction (`text-end`, moving left under RTL) or stay pinned right is a typographic convention question with two defensible answers — which is exactly why a blind sweep is the wrong move. It should be decided once and applied to all 34.

**One `translate-x`**, in `NavigationMenuTrailingSlotExample`. A physical axis with no logical counterpart: flipping it means adding an `rtl:` variant with the *opposite sign*, the treatment `nuxt/ui@592d5b5` applied to the timeline and we ported in #386. Under RTL the trailing slot currently slides out on the wrong side. Mechanically simple, but it needs someone who can look at the result in an RTL locale — which I cannot do here, and would rather say so than guess.

## Tests

`test/utils/docs-logical-properties.spec.ts` (new) holds the converted half and explains in its own header why the other two categories are outside it, so the next audit does not re-raise them as an oversight.

It also anchors on `src/theme` for the utilities it looks for: if Tailwind ever renamed them, the scan over the examples would go quiet and the file would report success while checking nothing.

Mutations tried, **each red**: put `ml-auto` back in `TableExample`; put `border-r` back in `TableColumnSpanExample`; put `left-0` back in `ScrollAreaExternalScrollExample`.

## Verify (`CI=true`)

`lint` · `typecheck` · `test` · `build` — all green. Tests **6468 passed | 6 skipped**.
`docs:generate` — 1240 routes, with `deploy.yml`'s env. That is the one that matters here: these files are docs-only, no unit test renders them, and `ci` never builds the docs site.

Refs #400

---
_Generated by [Claude Code](https://claude.ai/code/session_01JS8ypVfQSFzYVZzkTHhURb)_