### PR TITLE
test(CommandPalette): pin the CRLF conjunction and the malformed-region guard

### DIFF
--- a/test/utils/search.spec.ts
+++ b/test/utils/search.spec.ts
@@ -421,15 +421,24 @@ describe('highlight', () => {
 
     it('does not treat a malformed region as degenerate just because its first two bounds match', () => {
       // The skip is guarded on `region.length === 2` as well as on the bounds
-      // being equal, and that half had no fixture: every region reaching it from
-      // a well-typed caller is a real 2-tuple, so dropping the length check
-      // changed nothing observable (#411).
+      // being equal, and that half had no fixture: every region the suite builds
+      // is a real 2-tuple, so dropping the length check changed nothing (#411).
       //
-      // `RangeTuple` is what the type says; `CommandPaletteGroup.postFilter`
-      // takes whatever the application hands it, which is the same reason the
-      // integer filter below exists. A longer array is not a one-character
-      // region and must not be skipped as one — the cast is how a loosely-typed
-      // caller reaches this, deliberately.
+      // Reachable without any cast from application code: `postFilter` is typed
+      // `(term, items: T[]) => T[]`, and `CommandPaletteItem` carries a
+      // `[key: string]: any` index signature, so `items[i].matches` is `any`
+      // inside that callback. `unknown` appears here only because this test
+      // calls `highlight()` directly, against its stricter signature.
+      //
+      // Worth being exact about what the guard is and is not. It does not
+      // sanitize: nothing downstream reads past `region[1]`, so a three-element
+      // region slices identically either way. It decides one thing only —
+      // whether a malformed region gets the one-character skip. It should not,
+      // because a longer array is out of contract rather than degenerate, and
+      // silently treating it as a single character drops a highlight the caller
+      // asked for. That is a smaller claim than the integer filter above, which
+      // removes a region whose `NaN` would otherwise reach the cursor and repeat
+      // the whole value.
       const value = 'alpha beta'
       const malformed = [[2, 2, 999]] as unknown as [number, number][]
 
@@ -560,22 +569,38 @@ describe('highlight', () => {
       expect(result).toBe('<mark>a\r\n</mark>b')
     })
 
-    it('keeps a lone CR or LF apart — the carve-out is the pair, not either half', () => {
-      // The case above cannot tell `previous === CR && current === LF` from
-      // `previous === CR || current === LF`: on a real pair both are true. So
-      // the conjunction went unpinned while its two constants were guarded, and
-      // widening it to `||` made a mark swallow the character after a lone CR,
-      // or the LF after any character (#410).
+    it('joins CR and LF in that order only, never either one alone', () => {
+      // Every pair here is one the segmenter breaks, so a correct
+      // implementation snaps none of them. That is the point: the case above
+      // holds the only pair the carve-out *does* join, and on a real CR+LF
+      // `previous === CR && current === LF` and `previous === CR || current
+      // === LF` agree. So the conjunction went unpinned while both its
+      // constants were guarded (#410).
       //
-      // Both fixtures sit entirely below the fast-path floor, which is what
-      // routes them into the carve-out rather than to the segmenter.
-      const afterLoneCR = 'a\rXb'
-      const beforeLoneLF = 'aX\nb'
+      // Two shapes of over-joining, and the second is why one fixture is not
+      // enough: `||` fires when either side matches, `(CR|LF) && (CR|LF)` fires
+      // when both sides are line breaks in any order. The first is caught by a
+      // lone CR or LF beside a letter; the second survives that and needs a
+      // reversed or doubled pair.
+      //
+      // Under-joining — failing to keep a real CR+LF together — is what the
+      // case above pins. These add nothing there, deliberately; do not read
+      // them as covering it.
+      //
+      // Every fixture sits entirely below the fast-path floor, which is what
+      // routes it into the carve-out rather than to the segmenter.
+      const pairs: [string, string][] = [
+        ['a\rXb', '<mark>a\r</mark>Xb'],
+        ['aX\nb', '<mark>aX</mark>\nb'],
+        ['a\n\rb', '<mark>a\n</mark>\rb'],
+        ['a\r\rb', '<mark>a\r</mark>\rb'],
+        ['a\n\nb', '<mark>a\n</mark>\nb']
+      ]
 
-      expect(highlight({ label: afterLoneCR, matches: [{ key: 'label', value: afterLoneCR, indices: [[0, 1]] }] }, 'x', 'label'))
-        .toBe('<mark>a\r</mark>Xb')
-      expect(highlight({ label: beforeLoneLF, matches: [{ key: 'label', value: beforeLoneLF, indices: [[0, 1]] }] }, 'x', 'label'))
-        .toBe('<mark>aX</mark>\nb')
+      for (const [value, expected] of pairs) {
+        expect(highlight({ label: value, matches: [{ key: 'label', value, indices: [[0, 1]] }] }, 'x', 'label'))
+          .toBe(expected)
+      }
     })
 
     it('leaves a bare run of emoji modifiers whole — UAX #29 makes it one cluster', () => {

--- a/test/utils/search.spec.ts
+++ b/test/utils/search.spec.ts
@@ -419,6 +419,24 @@ describe('highlight', () => {
       expect(highlight({ label: value, matches: [{ key: 'label', value, indices: [[2, 2]] }] }, 'a', 'label')).toBe(value)
     })
 
+    it('does not treat a malformed region as degenerate just because its first two bounds match', () => {
+      // The skip is guarded on `region.length === 2` as well as on the bounds
+      // being equal, and that half had no fixture: every region reaching it from
+      // a well-typed caller is a real 2-tuple, so dropping the length check
+      // changed nothing observable (#411).
+      //
+      // `RangeTuple` is what the type says; `CommandPaletteGroup.postFilter`
+      // takes whatever the application hands it, which is the same reason the
+      // integer filter below exists. A longer array is not a one-character
+      // region and must not be skipped as one — the cast is how a loosely-typed
+      // caller reaches this, deliberately.
+      const value = 'alpha beta'
+      const malformed = [[2, 2, 999]] as unknown as [number, number][]
+
+      expect(highlight({ label: value, matches: [{ key: 'label', value, indices: malformed }] }, 'a', 'label'))
+        .toBe('al<mark>p</mark>ha beta')
+    })
+
     it.each(ASTRAL)('wraps %s wholly, wherever the region boundary falls', (astral) => {
       const value = `${astral.repeat(3)}tail`
 
@@ -540,6 +558,24 @@ describe('highlight', () => {
       const result = highlight({ label: value, matches: [{ key: 'label', value, indices: [[0, 1]] }] }, 'x', 'label')
 
       expect(result).toBe('<mark>a\r\n</mark>b')
+    })
+
+    it('keeps a lone CR or LF apart — the carve-out is the pair, not either half', () => {
+      // The case above cannot tell `previous === CR && current === LF` from
+      // `previous === CR || current === LF`: on a real pair both are true. So
+      // the conjunction went unpinned while its two constants were guarded, and
+      // widening it to `||` made a mark swallow the character after a lone CR,
+      // or the LF after any character (#410).
+      //
+      // Both fixtures sit entirely below the fast-path floor, which is what
+      // routes them into the carve-out rather than to the segmenter.
+      const afterLoneCR = 'a\rXb'
+      const beforeLoneLF = 'aX\nb'
+
+      expect(highlight({ label: afterLoneCR, matches: [{ key: 'label', value: afterLoneCR, indices: [[0, 1]] }] }, 'x', 'label'))
+        .toBe('<mark>a\r</mark>Xb')
+      expect(highlight({ label: beforeLoneLF, matches: [{ key: 'label', value: beforeLoneLF, indices: [[0, 1]] }] }, 'x', 'label'))
+        .toBe('<mark>aX</mark>\nb')
     })
 
     it('leaves a bare run of emoji modifiers whole — UAX #29 makes it one cluster', () => {


### PR DESCRIPTION
### Linked issue

Closes #410. Closes #411.

### Type of change

- [ ] Documentation (updates to the documentation or readme)
- [ ] Bug fix (a non-breaking change that fixes an issue)
- [ ] Enhancement (improving an existing functionality)
- [ ] New feature (a non-breaking change that adds functionality)
- [x] Chore (updates to the build process or auxiliary tools and libraries)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

Tests only — `src/` untouched.

### Description

The two survivors of a mutation pass over every constant and branch in `src/runtime/utils/search.ts` — 62 mutations, 55 killed, 5 provably equivalent.

They are **not peers**, and an earlier revision of this description presented them as if they were. #410 is a behavioural bug reachable from ordinary input. #411 is a guard that decides between two readings of malformed input, neither of which corrupts anything. Both are worth pinning; only one is a defect.

### #410 — the carve-out was pinned by its constants, not by the relationship between them

```ts
return previous === CARRIAGE_RETURN && current === LINE_FEED
```

Mutating either constant fails a test. The `&&` did not — because the only CR/LF fixture is a real pair, and on a real pair `&&` and `||` agree.

**Two shapes of over-joining, and one fixture pair does not cover both:**

| mutation | fires when | caught by |
| --- | --- | --- |
| `\|\|` | either side matches | a lone CR or LF beside a letter |
| `(CR\|LF) && (CR\|LF)` | both sides are line breaks, any order | **only** a reversed or doubled pair |

The second survived the first revision of this PR. Five fixtures now, all verified against a real `Intl.Segmenter` as pairs it breaks:

```
'a\rXb'    →  '<mark>a\r</mark>Xb'
'aX\nb'    →  '<mark>aX</mark>\nb'
'a\n\rb'   →  '<mark>a\n</mark>\rb'     reversed
'a\r\rb'   →  '<mark>a\r</mark>\rb'     doubled
'a\n\nb'   →  '<mark>a\n</mark>\nb'     doubled
```

**What this test deliberately does not cover:** *under*-joining. Every fixture is a pair the carve-out correctly declines to join, so a deleted carve-out — or no snapping at all — passes it untouched. That belongs to `keeps CRLF together`, twelve lines above. The comment says so, so the family resemblance between the two names cannot be read as redundancy.

### #411 — the length half of the single-character skip

```ts
if (region.length === 2 && region[0] === region[1]) {
```

**Reachable with no cast at all.** `postFilter` is typed `(term, items: T[]) => T[]` and `CommandPaletteItem` carries `[key: string]: any`, so `items[i].matches` is `any` inside that callback — type-checked against the real types under `--strict`. The `unknown` in the fixture is an artefact of calling `highlight()` directly, not of the scenario.

**But it sanitizes nothing, and the first revision of this description said otherwise.** It claimed the check exists "for the same reason the integer filter three lines below exists". It does not:

- the **integer filter** removes a region whose `NaN` would otherwise reach the cursor, where `substring(NaN)` reads as `substring(0)` and repeats the whole value — cascading corruption;
- the **length check** decides one thing only: whether a malformed region gets the one-character skip. Nothing downstream reads past `region[1]` — verified, only indices 0 and 1 are read anywhere in the file — so a three-element region slices identically either way.

It should still decline to skip: a longer array is out of contract rather than degenerate, and treating it as a single character drops a highlight the caller asked for. That is the claim, and it is smaller than the one this PR first made.

### Verification

| mutation | failing tests |
| --- | --- |
| CRLF `&&` → `\|\|` | 1 — the new test |
| CRLF `(CR\|LF) && (CR\|LF)` | 1 — the new test |
| CRLF operands swapped | 2 — both CR/LF tests |
| CRLF carve-out deleted | 1 — `keeps CRLF together` only, as designed |
| drop `region.length === 2 &&` | 1 — the new test |
| drop `region[0] === region[1] &&` | 42 |

The fourth row is the point of the division of labour: the old test pins under-joining, the new one pins over-joining, and neither pretends to the other's job.

`vitest run test/utils/ test/components/` → 6111 passed, 6 skipped, 255 files. `eslint` and `vue-tsc --noEmit` clean.

### Provenance, stated more carefully

An earlier revision said these came from "running the check `.sync/PORTING.md` now prescribes". That is literally true and rhetorically generous. That instruction is scoped advice — verify the branch your port touches — not a mandate to sweep the file. These came from a freestanding 62-way mutation audit, the third dedicated pass over this one file. Worth naming as what it was.

### Note on where this leaves the file

#411 is the first finding in this series that needed the type contract bent to construct at all. Review flagged that as the signal the organic defect supply here is exhausted, and that #392 and #406 — both real, both already found — are still open. That reading seems right; this is the last PR in the run.

### Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.