### PR TITLE
docs(skills): position recipe markup with logical properties

### DIFF
--- a/skills/b24-ui-nuxt/references/recipes/overlays.md
+++ b/skills/b24-ui-nuxt/references/recipes/overlays.md
@@ -406,8 +406,8 @@ const highlight = {
     <div class="flex flex-col gap-2">
       <div class="grid grid-cols-[1fr_auto_auto] gap-x-6 px-3 py-1 text-(length:--ui-font-size-sm) opacity-80">
         <span />
-        <span class="text-right min-w-20">Count</span>
-        <span class="text-right min-w-24">Amount</span>
+        <span class="text-end min-w-20">Count</span>
+        <span class="text-end min-w-24">Amount</span>
       </div>
 
       <div
@@ -416,8 +416,8 @@ const highlight = {
         class="grid grid-cols-[1fr_auto_auto] gap-x-6 items-center px-3 py-3 rounded-xl bg-white/5"
       >
         <span class="font-(--ui-font-weight-medium)">{{ row.label }}</span>
-        <span class="text-right min-w-20">{{ row.count }}</span>
-        <span class="text-right min-w-24">{{ row.amount }}</span>
+        <span class="text-end min-w-20">{{ row.count }}</span>
+        <span class="text-end min-w-24">{{ row.amount }}</span>
       </div>
 
       <div class="style-filled-boost grid grid-cols-[1fr_auto_auto] gap-x-6 items-center px-3 py-3 rounded-xl text-(--ui-color-design-filled-boost-content)">
@@ -427,8 +427,8 @@ const highlight = {
             <Info1Icon class="size-4 opacity-80" />
           </B24Tooltip>
         </span>
-        <span class="text-right min-w-20">{{ highlight.count }}</span>
-        <span class="text-right min-w-24 font-(--ui-font-weight-semi-bold)">{{ highlight.amount }}</span>
+        <span class="text-end min-w-20">{{ highlight.count }}</span>
+        <span class="text-end min-w-24 font-(--ui-font-weight-semi-bold)">{{ highlight.amount }}</span>
       </div>
     </div>
 
@@ -448,5 +448,5 @@ Notes on the layout:
 - The radial gradient on `b24ui.root` uses the same `110.42% 110.42% at -10.42% 31.25%` geometry as the boost gradient elsewhere in the design system, only with the purple `copilot-bg-content-{3,2,1}` stops (light → dark from top-left outward). Swap the stops for `--ui-color-design-filled-warning-bg-gradient-*` or another sibling trio to recolor the surface without changing the geometry.
 - The highlighted KPI row uses the global `.style-filled-boost` utility from `008_ui_global.css`. The class wires up the boost background gradient (orange → pink → purple), the boost stroke and the boost content (text/icon) CSS vars. Apply `text-(--ui-color-design-filled-boost-content)` explicitly so the row's text picks up the boost content colour (the `.style-filled-boost` class only declares the var, it doesn't apply `color`).
 - The non-highlighted rows sit on `bg-white/5` — a translucent overlay over the gradient. It keeps the rows readable without inventing new tokens.
-- The grid template `1fr_auto_auto` keeps the metric label flexible while the two numeric columns stay right-aligned and proportional. For more than ~4 rows, consider `B24Table` instead — this pattern is for compact summaries, not data lists.
+- The grid template `1fr_auto_auto` keeps the metric label flexible while the two numeric columns stay end-aligned and proportional — `text-end` rather than `text-right`, so the digits follow the reading direction and sit on the left under RTL. For more than ~4 rows, consider `B24Table` instead — this pattern is for compact summaries, not data lists.
 - The pill button in the header and the two footer buttons all use `color="air-secondary-accent"` for a consistent translucent action surface on the purple background. The pill picks up its rounded silhouette from `rounded`; pair `:trailing-icon` with a domain-appropriate icon (`RepeatIcon`, `Calendar1Icon`, `FlipchartIcon`).

--- a/skills/b24-ui-nuxt/references/recipes/task-form.md
+++ b/skills/b24-ui-nuxt/references/recipes/task-form.md
@@ -18,7 +18,7 @@ div.flex.flex-col.gap-4.p-4.w-full
 │       └── slot: div.flex.items-center.gap-1 (toolbar row)
 │           ├── B24Button (FileUploadIcon, ghost, sm — attach file)
 │           ├── B24EditorToolbar (mention, bulletList, orderedList)
-│           └── B24Button (GoToLIcon, ghost, sm, ml-auto — expand)
+│           └── B24Button (GoToLIcon, ghost, sm, ms-auto — expand)
 ├── B24Card (b24ui.body='p-0') — responsible persons
 │   └── div.divide-y
 │       ├── row: Creator — B24Avatar + name
@@ -123,7 +123,7 @@ const actionButtons: { label: string, icon: IconComponent, active?: boolean }[] 
         <div class="flex items-center gap-1 px-2 py-1.5 border-b border-(--ui-color-divider-default)">
           <B24Button :icon="FileUploadIcon" color="air-tertiary" size="sm" aria-label="Attach file" />
           <B24EditorToolbar :editor="editor" :items="toolbarItems" />
-          <div class="ml-auto">
+          <div class="ms-auto">
             <B24Button :icon="GoToLIcon" color="air-tertiary" size="sm" aria-label="Expand editor" />
           </div>
         </div>
@@ -213,7 +213,7 @@ Place a `div` as the first child of `B24Editor`'s default slot to render a persi
   <div class="flex items-center gap-1 px-2 py-1.5 border-b border-(--ui-color-divider-default)">
     <B24Button :icon="FileUploadIcon" color="air-tertiary" size="sm" aria-label="Attach file" />
     <B24EditorToolbar :editor="editor" :items="toolbarItems" />
-    <div class="ml-auto">
+    <div class="ms-auto">
       <B24Button :icon="GoToLIcon" color="air-tertiary" size="sm" aria-label="Expand editor" />
     </div>
   </div>

--- a/test/utils/docs-logical-properties.spec.ts
+++ b/test/utils/docs-logical-properties.spec.ts
@@ -101,6 +101,53 @@ describe('docs examples position with logical properties', () => {
 })
 
 /**
+ * The skills are authoring material: an assistant reads a recipe and emits the
+ * markup in it verbatim. A physical utility there does not just sit in a doc,
+ * it gets generated into consumer code — so the recipes are held to the same
+ * line as the examples.
+ *
+ * Only fenced code is scanned. The prose genuinely discusses alignment
+ * ("the two numeric columns stay end-aligned"), and matching a class pattern
+ * against English is how a guard earns its ignore-comments: `right-aligned`
+ * matches `right-` followed by a word character, which is why this is worth
+ * saying rather than leaving to a reader to notice.
+ */
+const skillsDir = resolve(process.cwd(), 'skills')
+
+const skillFiles = await glob('**/*.md', { cwd: skillsDir })
+
+/** Fenced blocks only, keyed by file, with the fence's start line for the message. */
+const skillCode = skillFiles.flatMap((file) => {
+  const source = readFileSync(resolve(skillsDir, file), 'utf-8')
+
+  return [...source.matchAll(/^```[^\n]*\n([\s\S]*?)^```/gm)].map(match => ({
+    file,
+    line: source.slice(0, match.index).split('\n').length,
+    code: match[1]!
+  }))
+})
+
+describe('skill recipes position with logical properties', () => {
+  it('finds the fenced code to check', () => {
+    // Vacuous against a fence regex that stopped matching, which is the whole
+    // scan — so anchor on both the file count and the blocks found in them.
+    expect(skillFiles.length).toBeGreaterThan(10)
+    expect(skillCode.length).toBeGreaterThan(40)
+    expect(skillCode.some(block => block.code.includes('B24Card'))).toBe(true)
+  })
+
+  it.each(PHYSICAL)('uses $use rather than $label', ({ pattern, use }) => {
+    const offenders = skillCode
+      .flatMap(({ file, line, code }) =>
+        [...new Set(code.match(pattern) ?? [])].map(hit => `${file}:${line}: ${hit}… — use ${use}`)
+      )
+      .sort()
+
+    expect(offenders).toEqual([])
+  })
+})
+
+/**
  * `translate-x` is a physical axis with no logical counterpart, so mirroring it
  * means a paired `rtl:` utility with the *opposite sign* — what nuxt/ui@592d5b5
  * did for the alternating timeline.


### PR DESCRIPTION
Follow-up to #413, which flagged these and left them out of scope.

The skills are **authoring material**: an assistant reads a recipe and emits the markup in it verbatim. A physical utility here is not a stale doc — it is generated into consumer code. #413 forbade these spellings in the docs examples while the recipes carried on handing them out.

## Changes

| file | was | now |
|---|---|---|
| `references/recipes/overlays.md` | 6 × `text-right` in the KPI grid | `text-end` |
| `references/recipes/task-form.md` | 3 × `ml-auto` | `ms-auto` |

`overlays.md`'s grid mirrors `CardSalesDynamicsExample`, which #413 already converted — the recipe was the copy left behind. One of `task-form.md`'s three is in the component-tree diagram, which documents the class as surely as the code block does.

The prose beside the grid said the numeric columns "stay right-aligned", which this change would have made false. It now says end-aligned, and why:

> The grid template `1fr_auto_auto` keeps the metric label flexible while the two numeric columns stay end-aligned and proportional — `text-end` rather than `text-right`, so the digits follow the reading direction and sit on the left under RTL.

## Guard

`test/utils/docs-logical-properties.spec.ts` gains a second suite over `skills/**/*.md`, reusing the same five physical-utility patterns as the examples suite.

**It scans fenced code only**, and that is the one design decision here worth knowing. The prose genuinely discusses alignment, and `right-aligned` matches the `right-` class pattern — scanning prose would have put the guard in a fight with English and earned it a trail of ignore-comments. The sentence quoted above would itself have failed. That reasoning is recorded in the spec rather than left to be rediscovered.

### Mutation-tested

| mutation | result |
|---|---|
| revert one `text-end` → `text-right` in a fence | red — `b24-ui-nuxt/references/recipes/overlays.md:366: text-right… — use text-start/text-end` |
| revert one `ms-auto` → `ml-auto` | red, named the same way |
| break the fence regex so the scan goes quiet | red, caught by the anchor on blocks found |

Control, which must stay green and does: putting `right-aligned` **and** `ml-auto` into prose changes nothing.

## Verify (`CI=true`)

`lint` · `typecheck` · `test` · `docs:generate` — all green. Tests 6516 passed | 6 skipped across 284 files. `docs:generate` run with `deploy.yml`'s env, 1240 routes prerendered — `docs/nuxt.config.ts` consumes `skills/`, so this is load-bearing here rather than routine.

## Still out of scope

`playgrounds/` carries the same four widgets with 48 `text-right`. Not authoring material and not shipped to consumers, so it is the weakest of the three cases — worth doing for consistency, not urgency.


---
_Generated by [Claude Code](https://claude.ai/code/session_01JS8ypVfQSFzYVZzkTHhURb)_