### PR TITLE
docs(playgrounds): position markup with logical properties

### DIFF
--- a/playgrounds/demo/app/components/NavbarHeader.vue
+++ b/playgrounds/demo/app/components/NavbarHeader.vue
@@ -36,7 +36,7 @@ defineShortcuts({
 </script>
 
 <template>
-  <div class="flex flex-row items-center justify-start pr-2">
+  <div class="flex flex-row items-center justify-start pe-2">
     <B24FieldGroup size="sm">
       <B24Button
         :icon="ChevronLeftLIcon"
@@ -52,7 +52,7 @@ defineShortcuts({
       />
     </B24FieldGroup>
 
-    <ProseH1 class="text-label leading-7 font-(--ui-font-weight-semi-bold) mb-0 ml-3 max-lg:text-(length:--ui-font-size-4xl)">
+    <ProseH1 class="text-label leading-7 font-(--ui-font-weight-semi-bold) mb-0 ms-3 max-lg:text-(length:--ui-font-size-4xl)">
       {{ title }}
     </ProseH1>
 

--- a/playgrounds/demo/app/components/PlaygroundPage.vue
+++ b/playgrounds/demo/app/components/PlaygroundPage.vue
@@ -30,7 +30,7 @@ const { cardVariant, cardBorderClass } = usePlaygroundCardStyles(playgroundConte
       <B24Switch v-model="playgroundContext.isUseBg.value" label="isUseBg" size="xs" />
     </template>
     <template v-if="slots.controls">
-      <div class="items-center flex-wrap gap-2 py-2 pr-3 max-w-full hidden lg:flex">
+      <div class="items-center flex-wrap gap-2 py-2 pe-3 max-w-full hidden lg:flex">
         <slot name="controls" :playground="playgroundContext" />
       </div>
     </template>

--- a/playgrounds/demo/app/components/SalesDynamicsWidget.vue
+++ b/playgrounds/demo/app/components/SalesDynamicsWidget.vue
@@ -78,8 +78,8 @@ const emit = defineEmits<{
     <div class="flex flex-col gap-2">
       <div class="grid grid-cols-[1fr_auto_auto] gap-x-6 px-3 py-1 text-(length:--ui-font-size-sm) opacity-80">
         <span />
-        <span class="text-right min-w-20">{{ countHeader }}</span>
-        <span class="text-right min-w-24">{{ amountHeader }}</span>
+        <span class="text-end min-w-20">{{ countHeader }}</span>
+        <span class="text-end min-w-24">{{ amountHeader }}</span>
       </div>
 
       <div
@@ -88,8 +88,8 @@ const emit = defineEmits<{
         class="grid grid-cols-[1fr_auto_auto] gap-x-6 items-center px-3 py-3 rounded-xl bg-white/5"
       >
         <span class="font-(--ui-font-weight-medium)">{{ row.label }}</span>
-        <span class="text-right min-w-20">{{ row.count }}</span>
-        <span class="text-right min-w-24">{{ row.amount }}</span>
+        <span class="text-end min-w-20">{{ row.count }}</span>
+        <span class="text-end min-w-24">{{ row.amount }}</span>
       </div>
 
       <div
@@ -102,8 +102,8 @@ const emit = defineEmits<{
             <Info1Icon class="size-4 opacity-80" />
           </B24Tooltip>
         </span>
-        <span class="text-right min-w-20">{{ highlight.count }}</span>
-        <span class="text-right min-w-24 font-(--ui-font-weight-semi-bold)">{{ highlight.amount }}</span>
+        <span class="text-end min-w-20">{{ highlight.count }}</span>
+        <span class="text-end min-w-24 font-(--ui-font-weight-semi-bold)">{{ highlight.amount }}</span>
       </div>
     </div>
 

--- a/playgrounds/demo/app/components/editor/EditorLinkPopover.vue
+++ b/playgrounds/demo/app/components/editor/EditorLinkPopover.vue
@@ -115,7 +115,7 @@ function handleKeyDown(event: KeyboardEvent) {
         placeholder="Paste a link..."
         @keydown="handleKeyDown"
       >
-        <div class="flex items-center mr-0.5">
+        <div class="flex items-center me-0.5">
           <B24Button
             :icon="LowerRightArrowIcon"
             color="air-tertiary-accent"

--- a/playgrounds/demo/app/pages/components/command-palette.vue
+++ b/playgrounds/demo/app/pages/components/command-palette.vue
@@ -202,7 +202,7 @@ defineShortcuts({
     >
       <template #footer>
         <div class="flex items-center justify-between gap-2">
-          <Bitrix24Icon class="size-5 text-(--b24ui-typography-label-color) ml-1" />
+          <Bitrix24Icon class="size-5 text-(--b24ui-typography-label-color) ms-1" />
           <div class="flex items-center gap-1">
             <B24Button label="Open" size="sm">
               <template #trailing>

--- a/playgrounds/demo/app/pages/components/slideover.vue
+++ b/playgrounds/demo/app/pages/components/slideover.vue
@@ -230,7 +230,7 @@ const openSliderTopAndBottomVer2 = async () => {
         content: [
           'light',
           'top-[58px] sm:top-[58px]',
-          'right-[22px] sm:right-[22px]',
+          'end-[22px] sm:end-[22px]',
           'max-h-[calc(100%-58px)] sm:max-h-[calc(100%-58px)]',
           'w-[calc(100%-60px-22px)] sm:w-[calc(100%-60px-22px)]'
         ].join(' '),
@@ -293,7 +293,7 @@ const openSliderTopAndBottomVer2 = async () => {
         content: [
           'light',
           'top-[58px] sm:top-[58px]',
-          'right-[22px] sm:right-[22px]',
+          'end-[22px] sm:end-[22px]',
           'max-h-[calc(100%-58px)] sm:max-h-[calc(100%-58px)]',
           'w-[calc(100%-60px-22px)] sm:w-[calc(100%-60px-22px)]',
           'p-0!'
@@ -502,7 +502,7 @@ const openSliderTopAndBottomVer2 = async () => {
               </tbody>
               <tfoot>
                 <tr>
-                  <th colspan="3" class="text-right">
+                  <th colspan="3" class="text-end">
                     Total:
                   </th>
                   <td>

--- a/playgrounds/demo/app/pages/components/table-wrapper.vue
+++ b/playgrounds/demo/app/pages/components/table-wrapper.vue
@@ -68,7 +68,7 @@ const isUseBg = ref(true)
               </tbody>
               <tfoot>
                 <tr>
-                  <th colspan="3" class="text-right">
+                  <th colspan="3" class="text-end">
                     Total:
                   </th>
                   <td>
@@ -141,7 +141,7 @@ const isUseBg = ref(true)
           </tbody>
           <tfoot>
             <tr>
-              <th colspan="3" class="text-right">
+              <th colspan="3" class="text-end">
                 Total:
               </th>
               <td>
@@ -207,7 +207,7 @@ const isUseBg = ref(true)
           </tbody>
           <tfoot>
             <tr>
-              <th colspan="3" class="text-right">
+              <th colspan="3" class="text-end">
                 Total:
               </th>
               <td>
@@ -274,7 +274,7 @@ const isUseBg = ref(true)
             </tbody>
             <tfoot>
               <tr>
-                <th colspan="3" class="text-right">
+                <th colspan="3" class="text-end">
                   Total:
                 </th>
                 <td>
@@ -343,7 +343,7 @@ const isUseBg = ref(true)
           </tbody>
           <tfoot>
             <tr>
-              <th colspan="3" class="text-right">
+              <th colspan="3" class="text-end">
                 Total:
               </th>
               <td>
@@ -1173,7 +1173,7 @@ const isUseBg = ref(true)
           </tbody>
           <tfoot>
             <tr>
-              <th colspan="4" class="text-right">
+              <th colspan="4" class="text-end">
                 Total:
               </th>
               <td>9,825,000</td>

--- a/playgrounds/demo/app/pages/components/table.vue
+++ b/playgrounds/demo/app/pages/components/table.vue
@@ -148,7 +148,7 @@ const columns: TableColumn<Payment>[] = [
     },
     enableHiding: false,
     cell: ({ row }) => {
-      return h('div', { class: 'text-right' }, h(B24DropdownMenu, {
+      return h('div', { class: 'text-end' }, h(B24DropdownMenu, {
         'content': {
           align: 'center',
           side: 'right',
@@ -179,7 +179,7 @@ const columns: TableColumn<Payment>[] = [
     meta: {
       class: {
         td: 'text-center font-(--ui-font-weight-semi-bold)',
-        th: 'text-right text-(--ui-color-accent-main-success) w-[192px]'
+        th: 'text-end text-(--ui-color-accent-main-success) w-[192px]'
       }
     },
     cell: ({ row }) => {
@@ -242,7 +242,7 @@ const columns: TableColumn<Payment>[] = [
   },
   {
     accessorKey: 'amount',
-    header: ({ column }) => h('div', { class: 'text-right' }, getPinnedHeader(column, 'Amount', 'right')),
+    header: ({ column }) => h('div', { class: 'text-end' }, getPinnedHeader(column, 'Amount', 'right')),
     footer: ({ column }) => {
       const total = column.getFacetedRowModel().rows.reduce((acc: number, row: TableRow<Payment>) => acc + Number.parseFloat(row.getValue('amount')), 0)
 
@@ -251,7 +251,7 @@ const columns: TableColumn<Payment>[] = [
         currency: 'EUR'
       }).format(total)
 
-      return h('div', { class: 'text-right font-(--ui-font-weight-medium)' }, `Total: ${formatted}`)
+      return h('div', { class: 'text-end font-(--ui-font-weight-medium)' }, `Total: ${formatted}`)
     },
     cell: ({ row }) => {
       const amount = Number.parseFloat(row.getValue('amount'))
@@ -261,7 +261,7 @@ const columns: TableColumn<Payment>[] = [
         currency: 'EUR'
       }).format(amount)
 
-      return h('div', { class: 'text-right font-(--ui-font-weight-medium)' }, formatted)
+      return h('div', { class: 'text-end font-(--ui-font-weight-medium)' }, formatted)
     },
     size: 117
   }

--- a/playgrounds/demo/app/pages/components/tabs.vue
+++ b/playgrounds/demo/app/pages/components/tabs.vue
@@ -82,7 +82,7 @@ const items = [
             :icon="Refresh5Icon"
             color="air-secondary-accent-2"
             label="Some text"
-            class="ml-2"
+            class="ms-2"
           />
         </template>
       </B24Tabs>

--- a/playgrounds/nuxt/app/components/NavbarHeader.vue
+++ b/playgrounds/nuxt/app/components/NavbarHeader.vue
@@ -36,7 +36,7 @@ defineShortcuts({
 </script>
 
 <template>
-  <div class="flex flex-row items-center justify-start pr-2">
+  <div class="flex flex-row items-center justify-start pe-2">
     <B24FieldGroup size="sm">
       <B24Button
         :icon="ChevronLeftLIcon"
@@ -52,7 +52,7 @@ defineShortcuts({
       />
     </B24FieldGroup>
 
-    <ProseH1 class="text-label leading-7 font-(--ui-font-weight-semi-bold) mb-0 ml-3 max-lg:text-(length:--ui-font-size-4xl)">
+    <ProseH1 class="text-label leading-7 font-(--ui-font-weight-semi-bold) mb-0 ms-3 max-lg:text-(length:--ui-font-size-4xl)">
       {{ title }}
     </ProseH1>
 

--- a/playgrounds/nuxt/app/components/PlaygroundPage.vue
+++ b/playgrounds/nuxt/app/components/PlaygroundPage.vue
@@ -30,7 +30,7 @@ const { cardVariant, cardBorderClass } = usePlaygroundCardStyles(playgroundConte
       <B24Switch v-model="playgroundContext.isUseBg.value" label="isUseBg" size="xs" />
     </template>
     <template v-if="slots.controls">
-      <div class="items-center flex-wrap gap-2 py-2 pr-3 max-w-full hidden lg:flex">
+      <div class="items-center flex-wrap gap-2 py-2 pe-3 max-w-full hidden lg:flex">
         <slot name="controls" :playground="playgroundContext" />
       </div>
     </template>

--- a/playgrounds/nuxt/app/components/SalesDynamicsWidget.vue
+++ b/playgrounds/nuxt/app/components/SalesDynamicsWidget.vue
@@ -78,8 +78,8 @@ const emit = defineEmits<{
     <div class="flex flex-col gap-2">
       <div class="grid grid-cols-[1fr_auto_auto] gap-x-6 px-3 py-1 text-(length:--ui-font-size-sm) opacity-80">
         <span />
-        <span class="text-right min-w-20">{{ countHeader }}</span>
-        <span class="text-right min-w-24">{{ amountHeader }}</span>
+        <span class="text-end min-w-20">{{ countHeader }}</span>
+        <span class="text-end min-w-24">{{ amountHeader }}</span>
       </div>
 
       <div
@@ -88,8 +88,8 @@ const emit = defineEmits<{
         class="grid grid-cols-[1fr_auto_auto] gap-x-6 items-center px-3 py-3 rounded-xl bg-white/5"
       >
         <span class="font-(--ui-font-weight-medium)">{{ row.label }}</span>
-        <span class="text-right min-w-20">{{ row.count }}</span>
-        <span class="text-right min-w-24">{{ row.amount }}</span>
+        <span class="text-end min-w-20">{{ row.count }}</span>
+        <span class="text-end min-w-24">{{ row.amount }}</span>
       </div>
 
       <div
@@ -102,8 +102,8 @@ const emit = defineEmits<{
             <Info1Icon class="size-4 opacity-80" />
           </B24Tooltip>
         </span>
-        <span class="text-right min-w-20">{{ highlight.count }}</span>
-        <span class="text-right min-w-24 font-(--ui-font-weight-semi-bold)">{{ highlight.amount }}</span>
+        <span class="text-end min-w-20">{{ highlight.count }}</span>
+        <span class="text-end min-w-24 font-(--ui-font-weight-semi-bold)">{{ highlight.amount }}</span>
       </div>
     </div>
 

--- a/playgrounds/nuxt/app/components/editor/EditorLinkPopover.vue
+++ b/playgrounds/nuxt/app/components/editor/EditorLinkPopover.vue
@@ -115,7 +115,7 @@ function handleKeyDown(event: KeyboardEvent) {
         placeholder="Paste a link..."
         @keydown="handleKeyDown"
       >
-        <div class="flex items-center mr-0.5">
+        <div class="flex items-center me-0.5">
           <B24Button
             :icon="LowerRightArrowIcon"
             color="air-tertiary-accent"

--- a/playgrounds/nuxt/app/pages/components/command-palette.vue
+++ b/playgrounds/nuxt/app/pages/components/command-palette.vue
@@ -202,7 +202,7 @@ defineShortcuts({
     >
       <template #footer>
         <div class="flex items-center justify-between gap-2">
-          <Bitrix24Icon class="size-5 text-(--b24ui-typography-label-color) ml-1" />
+          <Bitrix24Icon class="size-5 text-(--b24ui-typography-label-color) ms-1" />
           <div class="flex items-center gap-1">
             <B24Button label="Open" size="sm">
               <template #trailing>

--- a/playgrounds/nuxt/app/pages/components/slideover.vue
+++ b/playgrounds/nuxt/app/pages/components/slideover.vue
@@ -230,7 +230,7 @@ const openSliderTopAndBottomVer2 = async () => {
         content: [
           'light',
           'top-[58px] sm:top-[58px]',
-          'right-[22px] sm:right-[22px]',
+          'end-[22px] sm:end-[22px]',
           'max-h-[calc(100%-58px)] sm:max-h-[calc(100%-58px)]',
           'w-[calc(100%-60px-22px)] sm:w-[calc(100%-60px-22px)]'
         ].join(' '),
@@ -293,7 +293,7 @@ const openSliderTopAndBottomVer2 = async () => {
         content: [
           'light',
           'top-[58px] sm:top-[58px]',
-          'right-[22px] sm:right-[22px]',
+          'end-[22px] sm:end-[22px]',
           'max-h-[calc(100%-58px)] sm:max-h-[calc(100%-58px)]',
           'w-[calc(100%-60px-22px)] sm:w-[calc(100%-60px-22px)]',
           'p-0!'
@@ -502,7 +502,7 @@ const openSliderTopAndBottomVer2 = async () => {
               </tbody>
               <tfoot>
                 <tr>
-                  <th colspan="3" class="text-right">
+                  <th colspan="3" class="text-end">
                     Total:
                   </th>
                   <td>

--- a/playgrounds/nuxt/app/pages/components/table-wrapper.vue
+++ b/playgrounds/nuxt/app/pages/components/table-wrapper.vue
@@ -68,7 +68,7 @@ const isUseBg = ref(true)
               </tbody>
               <tfoot>
                 <tr>
-                  <th colspan="3" class="text-right">
+                  <th colspan="3" class="text-end">
                     Total:
                   </th>
                   <td>
@@ -141,7 +141,7 @@ const isUseBg = ref(true)
           </tbody>
           <tfoot>
             <tr>
-              <th colspan="3" class="text-right">
+              <th colspan="3" class="text-end">
                 Total:
               </th>
               <td>
@@ -207,7 +207,7 @@ const isUseBg = ref(true)
           </tbody>
           <tfoot>
             <tr>
-              <th colspan="3" class="text-right">
+              <th colspan="3" class="text-end">
                 Total:
               </th>
               <td>
@@ -274,7 +274,7 @@ const isUseBg = ref(true)
             </tbody>
             <tfoot>
               <tr>
-                <th colspan="3" class="text-right">
+                <th colspan="3" class="text-end">
                   Total:
                 </th>
                 <td>
@@ -343,7 +343,7 @@ const isUseBg = ref(true)
           </tbody>
           <tfoot>
             <tr>
-              <th colspan="3" class="text-right">
+              <th colspan="3" class="text-end">
                 Total:
               </th>
               <td>
@@ -1173,7 +1173,7 @@ const isUseBg = ref(true)
           </tbody>
           <tfoot>
             <tr>
-              <th colspan="4" class="text-right">
+              <th colspan="4" class="text-end">
                 Total:
               </th>
               <td>9,825,000</td>

--- a/playgrounds/nuxt/app/pages/components/table.vue
+++ b/playgrounds/nuxt/app/pages/components/table.vue
@@ -148,7 +148,7 @@ const columns: TableColumn<Payment>[] = [
     },
     enableHiding: false,
     cell: ({ row }) => {
-      return h('div', { class: 'text-right' }, h(B24DropdownMenu, {
+      return h('div', { class: 'text-end' }, h(B24DropdownMenu, {
         'content': {
           align: 'center',
           side: 'right',
@@ -179,7 +179,7 @@ const columns: TableColumn<Payment>[] = [
     meta: {
       class: {
         td: 'text-center font-(--ui-font-weight-semi-bold)',
-        th: 'text-right text-(--ui-color-accent-main-success) w-[192px]'
+        th: 'text-end text-(--ui-color-accent-main-success) w-[192px]'
       }
     },
     cell: ({ row }) => {
@@ -242,7 +242,7 @@ const columns: TableColumn<Payment>[] = [
   },
   {
     accessorKey: 'amount',
-    header: ({ column }) => h('div', { class: 'text-right' }, getPinnedHeader(column, 'Amount', 'right')),
+    header: ({ column }) => h('div', { class: 'text-end' }, getPinnedHeader(column, 'Amount', 'right')),
     footer: ({ column }) => {
       const total = column.getFacetedRowModel().rows.reduce((acc: number, row: TableRow<Payment>) => acc + Number.parseFloat(row.getValue('amount')), 0)
 
@@ -251,7 +251,7 @@ const columns: TableColumn<Payment>[] = [
         currency: 'EUR'
       }).format(total)
 
-      return h('div', { class: 'text-right font-(--ui-font-weight-medium)' }, `Total: ${formatted}`)
+      return h('div', { class: 'text-end font-(--ui-font-weight-medium)' }, `Total: ${formatted}`)
     },
     cell: ({ row }) => {
       const amount = Number.parseFloat(row.getValue('amount'))
@@ -261,7 +261,7 @@ const columns: TableColumn<Payment>[] = [
         currency: 'EUR'
       }).format(amount)
 
-      return h('div', { class: 'text-right font-(--ui-font-weight-medium)' }, formatted)
+      return h('div', { class: 'text-end font-(--ui-font-weight-medium)' }, formatted)
     },
     size: 117
   }

--- a/playgrounds/nuxt/app/pages/components/tabs.vue
+++ b/playgrounds/nuxt/app/pages/components/tabs.vue
@@ -82,7 +82,7 @@ const items = [
             :icon="Refresh5Icon"
             color="air-secondary-accent-2"
             label="Some text"
-            class="ml-2"
+            class="ms-2"
           />
         </template>
       </B24Tabs>

--- a/test/utils/docs-logical-properties.spec.ts
+++ b/test/utils/docs-logical-properties.spec.ts
@@ -54,6 +54,21 @@ const PHYSICAL = [
 
 const files = await glob('**/*.vue', { cwd: examplesDir })
 
+/**
+ * Offenders of one pattern across labelled sources.
+ *
+ * Named rather than counted: the failure has to say which file and which
+ * utility, or the next person re-runs the audit by hand. Deduped per source,
+ * so a file with twenty `text-right` reports once — the fix is the same edit.
+ */
+function offendersIn(units: Array<{ label: string, source: string }>, pattern: RegExp, use: string) {
+  return units
+    .flatMap(({ label, source }) =>
+      [...new Set(source.match(pattern) ?? [])].map(hit => `${label}: ${hit}… — use ${use}`)
+    )
+    .sort()
+}
+
 /** The theme's own spelling, used below to prove these utilities still exist. */
 const themeSource = (await glob('**/*.ts', { cwd: resolve(process.cwd(), 'src/theme') }))
   .map(file => readFileSync(resolve(process.cwd(), 'src/theme', file), 'utf-8'))
@@ -87,15 +102,12 @@ describe('docs examples position with logical properties', () => {
   })
 
   it.each(PHYSICAL)('uses $use rather than $label', ({ pattern, use }) => {
-    const offenders = files
-      .flatMap((file) => {
-        const source = readFileSync(resolve(examplesDir, file), 'utf-8')
-        return [...new Set(source.match(pattern) ?? [])].map(hit => `${file}: ${hit}… — use ${use}`)
-      })
-      .sort()
+    const offenders = offendersIn(
+      files.map(file => ({ label: file, source: readFileSync(resolve(examplesDir, file), 'utf-8') })),
+      pattern,
+      use
+    )
 
-    // Named rather than counted: the failure has to say which file and which
-    // utility, or the next person re-runs the audit by hand.
     expect(offenders).toEqual([])
   })
 })
@@ -137,11 +149,44 @@ describe('skill recipes position with logical properties', () => {
   })
 
   it.each(PHYSICAL)('uses $use rather than $label', ({ pattern, use }) => {
-    const offenders = skillCode
-      .flatMap(({ file, line, code }) =>
-        [...new Set(code.match(pattern) ?? [])].map(hit => `${file}:${line}: ${hit}… — use ${use}`)
-      )
-      .sort()
+    const offenders = offendersIn(
+      skillCode.map(({ file, line, code }) => ({ label: `${file}:${line}`, source: code })),
+      pattern,
+      use
+    )
+
+    expect(offenders).toEqual([])
+  })
+})
+
+/**
+ * The playgrounds are the weakest of the three cases — not authoring material,
+ * not shipped to a consumer — but they are where a component gets tried out, so
+ * a physical utility here is a pattern someone copies with the file already
+ * open in front of them. Same line, same reason.
+ *
+ * Not extended to `translate-x`: the playgrounds contain none, so the scan
+ * would have nothing to anchor on, and a threshold of zero cannot tell a clean
+ * tree from a broken tokeniser. If one appears, guard it then.
+ */
+const playgroundsDir = resolve(process.cwd(), 'playgrounds')
+
+const playgroundFiles = await glob('*/app/**/*.vue', { cwd: playgroundsDir })
+
+describe('playgrounds position with logical properties', () => {
+  it('finds the playground sources to check', () => {
+    // The glob is shaped to skip `node_modules` and `.nuxt`, so getting the
+    // depth wrong shows up here as an empty scan rather than as silent success.
+    expect(playgroundFiles.length).toBeGreaterThan(50)
+    expect(new Set(playgroundFiles.map(file => file.split('/')[0])).size).toBeGreaterThan(1)
+  })
+
+  it.each(PHYSICAL)('uses $use rather than $label', ({ pattern, use }) => {
+    const offenders = offendersIn(
+      playgroundFiles.map(file => ({ label: file, source: readFileSync(resolve(playgroundsDir, file), 'utf-8') })),
+      pattern,
+      use
+    )
 
     expect(offenders).toEqual([])
   })


### PR DESCRIPTION
Last of the three places #413 found the same physical spellings, after #415 did the skills.

The playgrounds are the weakest of the three cases — not authoring material, not shipped to a consumer — but they are where a component gets tried out, so a physical utility here is a pattern someone copies with the file already open in front of them.

## The count was wrong, and low

#413 and #415 both cited "48 `text-right` in `playgrounds/`". The real figure is **56 replacements across 18 files**: that audit only counted text-align.

| pattern | count |
|---|---|
| `text-left` / `text-right` | 36 |
| `ml-` / `mr-` | 8 |
| `pl-` / `pr-` | 4 |
| `left-` / `right-` | 8 |
| `border-l` / `border-r`, `translate-x` | 0 |

`nuxt` and `demo` are byte-identical mirrors of each other in every touched file except `tabs.vue`, which is why every count is even.

## Two spots that needed care rather than a sweep

**`table.vue:245`** carries both a class and an API value on one line:

```js
header: ({ column }) => h('div', { class: 'text-end' }, getPinnedHeader(column, 'Amount', 'right')),
```

The `'right'` is TanStack column pinning, not CSS — `src/runtime/components/Table.vue` writes `styles.left`/`styles.right` from it, so it must stay physical. Converted the class, left the value.

**`slideover.vue:233,296`** had `right-[22px] sm:right-[22px]`. The variant-prefixed half is exactly the form the guard's lookbehind could not see until #413 narrowed it — so this is the first real instance of that latent hole, and it would have survived the old guard.

## Guard

A third suite over `playgrounds/*/app/**/*.vue`, and the three suites now share one `offendersIn` helper instead of repeating the same `flatMap` three times.

**Deliberately not extended to `translate-x`.** The playgrounds contain none, so the scan would have nothing to anchor on, and a sanity threshold of zero cannot distinguish a clean tree from a broken tokeniser — it would be a guard that reports success while checking nothing. Worth adding the day one appears, not before.

### Mutation-tested

| mutation | result |
|---|---|
| revert one `text-end` → `text-right` | red |
| revert `end-[22px] sm:end-[22px]` → `right-…` (variant-prefixed) | red |
| flatten the glob depth to `*/app/*.vue` | red, caught by the anchor |

Both **older** suites re-verified against their own mutations too, since the shared helper is new to them: a docs-example `text-right` and a skills-fence `text-right` each still fail exactly one test.

## Verify (`CI=true`)

`lint` · `typecheck` · `test` · `build` · `docs:generate` — all green. Tests 6528 passed | 6 skipped across 284 files. `typecheck` matters here rather than being routine: it runs `nuxt typecheck` over both playgrounds.

## After this

**Corrected after merge.** This section first claimed that no physical `text-*`, `m[lr]-`, `p[lr]-`, `border-[lr]` or `left-`/`right-` utilities remained in `src/`. That was wrong — `src/` has 82, and a post-merge audit is what surfaced them. The accurate statement is narrower:

- **`docs/app/…/examples`, `skills/`, `playgrounds/`** — clean of all five patterns, each held by a suite in `docs-logical-properties.spec.ts`.
- **`src/theme`** — clean of physical **text-align** only, which is the single thing the spec asserts about it (#413).
- **`src/` otherwise** — 63 `left-`/`right-`, 12 `ml-`/`mr-`, 7 `pl-`/`pr-`, unguarded and deliberately untouched.

`src/` is a judgement surface rather than a sweep, and two examples show why a blind conversion would be a regression:

- `src/theme/toaster.ts` declares `position: 'top-left' | 'top-right' | …`. Those are **API names**: `top-left` must be the top-left corner whatever the reading direction, so its `left-4` has to stay physical. Converting it would make `top-left` mean top-right under RTL.
- `left-1/2 … -translate-x-1/2` (4 sites, in `modal.ts`, `toaster.ts`, `sidebar.ts`) is the direction-neutral centering idiom and is already correct. `start-1/2` with the same negative translate would not centre under RTL.

Others in the same set do look like genuine candidates — `src/theme/toast.ts:49`'s `absolute top-2 right-2` close button among them. Separating the two needs the same kind of decision #400 took for the amount column, so it belongs on its own issue rather than in this PR.

The other known remainder is `docs/modules/bx-assistant/runtime/components/AssistantPanel.vue:326` — a module rather than an example, outside every glob above.
