### PR TITLE
chore(deps): narrow tailwind source scope in docs and playgrounds

### DIFF
--- a/.sync/log/689c671a287071f822dbeb078ede9365399bdb5f.md
+++ b/.sync/log/689c671a287071f822dbeb078ede9365399bdb5f.md
@@ -1,0 +1,80 @@
+# Port: chore: narrow tailwind source scope in docs and playgrounds
+
+**Upstream:** `689c671a287071f822dbeb078ede9365399bdb5f` (nuxt/ui, #6843)
+**Decision:** port — adapted, four entry points instead of three
+
+## Upstream change
+
+Every Tailwind entry point pointed `source()` at the repository root, so the
+CSS watcher scanned the whole tree — including directories the built site never
+renders. Upstream replaced that with `source(none)` plus an explicit `@source`
+per directory that is genuinely in scope.
+
+```
+-@import "tailwindcss" theme(static) source("../../../..");
++@import "tailwindcss" theme(static) source(none);
++@source "../../..";
++@source "../../../../src";
+```
+
+Naming what is in scope rather than what is out of it.
+
+## b24ui port
+
+Same shape, and the relative depths match ours exactly, so the paths are
+upstream's verbatim. Two fork differences:
+
+- **Four entry points, not three.** We also carry `playgrounds/demo`, which is
+  self-contained (no cross-directory `dirs`/aliases in its `nuxt.config.ts`), so
+  it gets the same pair as `playgrounds/nuxt`.
+- **`playgrounds/vue` borrows the same way upstream's does.** Checked rather
+  than assumed: our `vite.config.ts` lists `../nuxt/app/composables` and
+  `../nuxt/app/components`, so `@source "../../../../nuxt/app"` applies here for
+  the same reason.
+
+This also **deletes a fork-local patch**. Our `docs/app/assets/css/main.css`
+carried:
+
+```css
+@source not "../../../../.sync";
+```
+
+added because `.sync/log/*.md` quotes illustrative class strings with
+placeholders (`--reka-*-content-available-height`) that produce invalid CSS.
+That exclusion only existed to claw back part of a root source that was too
+broad. With `source(none)` the sync notes were never in scope to begin with,
+so the patch goes.
+
+`skills/` is likewise no longer scanned, and does not need to be: it is served
+raw as a Nitro `publicAssets` entry at `/.well-known/skills`, so its class
+strings are file bytes, never DOM.
+
+## Verify
+
+`docs:generate` alone does not test this — it succeeds either way. The question
+is whether the narrower scan drops a rule the site needs, so the check is a
+before/after comparison of the emitted stylesheet.
+
+**237 class selectors disappear, 0 appear; 593,334 → 574,778 bytes.** Each was
+accounted for rather than counted:
+
+- **227** occur only in `playgrounds/`, `test/` or `skills/` — never in `docs/`
+  or `src/`. Correct to drop. (The first pass here used substring matching and
+  reported 30 false regressions: `py-3.5` "found" inside
+  `[&>table>thead>tr>td]:py-3.5`, which is a different generated class. Matching
+  whole unprefixed tokens brings it to zero.)
+- **2** came from `CHANGELOG.md` prose — `focus:outline-hidden` and
+  `aria-busy:cursor-progress`, both quoted in entries that say the class was
+  *removed*. Same noise as `.sync/log`, and the reason the exclusion above
+  existed.
+- The rest are foreign spellings of classes we do use. `animate-[accordion-down_200ms_ease-out]`
+  is upstream's; ours is `animate-[accordion-down_200ms_var(--ease-out)]`, and
+  that one is present in both builds.
+
+The decisive check is direct rather than inferential: across the **201**
+prerendered pages, **2,046** distinct class tokens appear in `class="…"`
+attributes, and **none** of them lost its rule.
+
+## Gauntlet (CI=true)
+
+`lint` · `typecheck` · `test` · `build` · `docs:generate` — all green.

--- a/.sync/nuxt-ui.json
+++ b/.sync/nuxt-ui.json
@@ -1,7 +1,7 @@
 {
   "upstream": "nuxt/ui",
   "branch": "v4",
-  "cursor": "a4ab81a9957f2f1a503112eda21eb5721b88cda5",
+  "cursor": "689c671a287071f822dbeb078ede9365399bdb5f",
   "_cursor_note": "cursor = last upstream commit ported into b24ui. The sync is manual by decision: one commit at a time, oldest-first, each with a `.sync/log/<sha>.md` journal and an entry in `processed`. There is no dispatcher, no porter workflow and no kill-switch — `.sync/PORTING.md` is the whole procedure. `processed` is maintained per port (backfilled #68-#72 on 2026-06-09).",
   "processed": {
     "2799fa6f2b25ce3eb15e050f3ef7c57d0d9a2fdb": {
@@ -1481,6 +1481,12 @@
       "b24ui_sha": "9ea693d4357b80a45fd65353b7914d3743745c90",
       "decision": "no-op",
       "summary": "docs: add calendar template to lists and ci (nuxt/ui) — NO-OP: six files, none with a surface here the change fits. Follow-up to 4a3168fb, threading the calendar template through every other list that enumerates templates. Checked each surface rather than concluding from the subject: .github/workflows/module.yml does not exist here at all (our workflows are ci, deploy, npm-publish, release-please, release-watchdog, none of which builds template repositories); README.md has no template list; docs 1.index.md has no such section; 1.nuxt.md has neither the `npm create nuxt@latest -- -t ui/*` block nor the template card-group, and its only card-group is the package-manager install block, a different thing sharing the same component; docs/nuxt.config.ts does carry the LLM retrieval-keywords string (ours says bitrix24 ui where upstream says nuxt ui) but adding `vue calendar` would advertise a template that does not exist, and those keywords are a promise about what this library ships; and skills/nuxt-ui/references/guidelines/conventions.md is covered by the §2 invariant that skills/ is b24ui-authored. This is not \"we are behind on templates\" — the pair is upstream cataloguing a repository it owns, and the equivalent work here would be authoring a b24ui calendar template first, which is a product decision rather than a port."
+    },
+    "689c671a287071f822dbeb078ede9365399bdb5f": {
+      "pr": "pending-merge",
+      "b24ui_sha": "pending-merge",
+      "decision": "port",
+      "summary": "chore: narrow tailwind source scope in docs and playgrounds (nuxt/ui #6843) — PORT, adapted to four entry points. Every Tailwind entry pointed source() at the repo root, so the CSS watcher scanned the whole tree. Replaced with source(none) plus explicit @source per in-scope directory. Paths are upstream's verbatim (our depths match); we carry a fourth entry point, playgrounds/demo, which is self-contained and gets the same pair as playgrounds/nuxt, and our playgrounds/vue borrows ../nuxt/app the same way upstream's does (checked in vite.config.ts, not assumed). Deletes a fork-local patch: docs/app/assets/css/main.css had `@source not \"../../../../.sync\"`, added because .sync/log/*.md quotes class strings with placeholders that produce invalid CSS — an exclusion that only existed to claw back an over-broad root source, and is unnecessary once nothing is in scope by default. skills/ also leaves the scan and does not need it: it is served raw via Nitro publicAssets at /.well-known/skills, so its class strings are never DOM. Verified by diffing the emitted stylesheet, since docs:generate passes either way: 237 selectors drop and 0 appear (593,334 -> 574,778 bytes); 227 occur only in playgrounds/test/skills, 2 came from CHANGELOG.md prose quoting classes it says were removed, the rest are upstream spellings of classes we write differently (animate-[accordion-down_200ms_ease-out] vs our var(--ease-out) form, which survives in both builds). Decisively: across 201 prerendered pages and 2,046 distinct class tokens in class= attributes, none lost its rule."
     }
   }
 }

--- a/docs/app/assets/css/main.css
+++ b/docs/app/assets/css/main.css
@@ -1,14 +1,21 @@
-@import "tailwindcss" theme(static) source("../../../..");
+@import "tailwindcss" theme(static) source(none);
 @import "@bitrix24/b24ui-nuxt";
 
-@source "../../../content/**/*";
 /*
- * Exclude the upstream-sync notes from Tailwind's class scanning. The root
- * `source("../../../..")` above scans the whole repo, and `.sync/log/*.md`
- * contains illustrative class strings with placeholders (e.g.
+ * Scoped to what the docs render: the site itself, and the library source that
+ * `nuxt.config.ts` resolves `../src/module` from. A repo-root source also put
+ * `test`, `playgrounds`, `skills` and `.sync` on the CSS watcher.
+ *
+ * `.sync` in particular needed an explicit `@source not` before this, because
+ * `.sync/log/*.md` quotes illustrative class strings with placeholders (e.g.
  * `--reka-*-content-available-height`) that produce invalid CSS during build.
+ * Naming what is in scope rather than what is out of it makes that exclusion
+ * unnecessary — and `skills/`, served raw at `/.well-known/skills`, never
+ * needed scanning either.
  */
-@source not "../../../../.sync";
+@source "../../..";
+@source "../../../../src";
+@source "../../../content/**/*";
 
 @theme static {
 

--- a/playgrounds/demo/app/assets/css/main.css
+++ b/playgrounds/demo/app/assets/css/main.css
@@ -1,5 +1,13 @@
-@import "tailwindcss" theme(static) source("../../../../..");
+@import "tailwindcss" theme(static) source(none);
 @import "@bitrix24/b24ui-nuxt";
+
+/*
+ * Scoped to this playground and the library source, which the module resolves
+ * components and theme from. A repo-root source also put `docs`, `test` and the
+ * sibling playgrounds on the CSS watcher.
+ */
+@source "../../..";
+@source "../../../../../src";
 
 /*
  * Custom bg

--- a/playgrounds/nuxt/app/assets/css/main.css
+++ b/playgrounds/nuxt/app/assets/css/main.css
@@ -1,5 +1,13 @@
-@import "tailwindcss" theme(static) source("../../../../..");
+@import "tailwindcss" theme(static) source(none);
 @import "@bitrix24/b24ui-nuxt";
+
+/*
+ * Scoped to this playground and the library source, which the module resolves
+ * components and theme from. A repo-root source also put `docs`, `test` and the
+ * sibling playgrounds on the CSS watcher.
+ */
+@source "../../..";
+@source "../../../../../src";
 
 /*
  * Custom bg

--- a/playgrounds/vue/src/assets/css/main.css
+++ b/playgrounds/vue/src/assets/css/main.css
@@ -1,5 +1,14 @@
-@import "tailwindcss" theme(static) source("../../../../..");
+@import "tailwindcss" theme(static) source(none);
 @import "@bitrix24/b24ui-nuxt";
+
+/*
+ * Scoped to this playground, the Nuxt playground's `app` that `vite.config.ts`
+ * borrows components and composables from, and the library source, which the
+ * plugin resolves components and theme from.
+ */
+@source "../../..";
+@source "../../../../nuxt/app";
+@source "../../../../../src";
 
 /*
  * Custom bg


### PR DESCRIPTION
Port of [`nuxt/ui@689c671a`](https://github.com/nuxt/ui/commit/689c671a287071f822dbeb078ede9365399bdb5f) (nuxt/ui#6843). First of three in the current sync queue.

## Upstream change

Every Tailwind entry point pointed `source()` at the repository root, so the CSS watcher scanned the whole tree — including directories the built site never renders.

```diff
-@import "tailwindcss" theme(static) source("../../../..");
+@import "tailwindcss" theme(static) source(none);
+@source "../../..";
+@source "../../../../src";
```

Naming what is in scope rather than what is out of it.

## Deviations

Relative depths match upstream's, so the paths are verbatim. Two fork differences:

- **Four entry points, not three.** We also carry `playgrounds/demo`. Checked its `nuxt.config.ts` for cross-directory `dirs`/aliases — none, it is self-contained — so it gets the same pair as `playgrounds/nuxt`.
- **`playgrounds/vue` borrows the same way upstream's does.** Verified in our `vite.config.ts` rather than assumed: it lists `../nuxt/app/composables` and `../nuxt/app/components`, so `@source "../../../../nuxt/app"` applies here for the same reason it does upstream.

### It deletes a fork-local patch

`docs/app/assets/css/main.css` carried:

```css
@source not "../../../../.sync";
```

added because `.sync/log/*.md` quotes illustrative class strings with placeholders (`--reka-*-content-available-height`) that produce invalid CSS during build. That exclusion existed only to claw back part of a root source that was too broad. With `source(none)` the sync notes were never in scope, so the patch goes — the upstream approach subsumes it.

`skills/` leaves the scan too, and does not need it: Nitro serves it raw as a `publicAssets` entry at `/.well-known/skills`, so its class strings are file bytes and never reach the DOM.

## Verification

**`docs:generate` does not test this** — it succeeds either way. The question is whether a narrower scan drops a rule the site needs, so the check is a before/after diff of the emitted stylesheet.

**237 class selectors disappear, 0 appear. 593,334 → 574,778 bytes.** Every one accounted for:

| bucket | n | verdict |
|---|---|---|
| occur only in `playgrounds/`, `test/`, `skills/` | 227 | correct to drop |
| `CHANGELOG.md` prose — `focus:outline-hidden`, `aria-busy:cursor-progress` | 2 | correct; both quoted in entries saying the class was *removed* — the same noise the `.sync` exclusion existed for |
| upstream spellings of classes we write differently | 8 | correct; e.g. `animate-[accordion-down_200ms_ease-out]` vs our `…_200ms_var(--ease-out)`, which is present in **both** builds |

**The decisive check is direct rather than inferential.** Across the **201** prerendered pages, **2,046** distinct class tokens appear in `class="…"` attributes:

```
classes the HTML actually uses that the new CSS no longer defines: 0
```

### A wrong answer on the way there

The first pass at the bucket analysis reported **30 regressions**. It was wrong: it matched substrings, so `py-3.5` was "found" in `src/theme/table-wrapper.ts` inside `[&>table>thead>tr>td]:py-3.5` — a different generated class, since a variant prefix produces a different selector. Matching whole unprefixed tokens takes it to zero. Recorded because the same mistake is easy to repeat the next time someone audits a `@source` change.

## Verify (`CI=true`)

`lint` · `typecheck` · `test` · `build` · `docs:generate` — all green. Tests 6540 passed | 6 skipped across 286 files. `docs:generate` run with `deploy.yml`'s env, 1240 routes prerendered.

## Ledger

`cursor` advances to `689c671a`, entry added, log at `.sync/log/689c671a….md`. `pr`/`b24ui_sha` are `pending-merge` and get reconciled by the next commit in the queue, per `PORTING.md` §6 step 4.

Remaining in the queue: `a4fe7d86` (`docs(page-hero)`, expected `n/a` — no `page-hero.md` here) and `08e75317` (`docs: resolve icon load failures during prerender`, expected largely `n/a` — no `@nuxt/icon`/`clientBundle` in our docs; its `code-icon.ts` half is a pure alphabetical reorder, 65 key→value pairs identical before and after).


---
_Generated by [Claude Code](https://claude.ai/code/session_01JS8ypVfQSFzYVZzkTHhURb)_