### PR TITLE
test: pin the suite timezone to UTC

### DIFF
--- a/test/utils/timezone-determinism.spec.ts
+++ b/test/utils/timezone-determinism.spec.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest'
+
+/**
+ * The suite renders dates into committed snapshots, so its timezone is part of
+ * the expected output — and nothing in a normal run says so out loud.
+ *
+ * `Calendar.spec.ts`, `InputDate.spec.ts` and `InputTime.spec.ts` freeze "now"
+ * at `new Date('2025-01-01')`. A bare `YYYY-MM-DD` string parses as UTC
+ * midnight, which in every negative-offset zone is still 2024-12-31 locally,
+ * so `data-today` moves to the wrong cell and 69 snapshots fail at once
+ * (Calendar 45, InputDate 24). GitHub runners are UTC and stay green, so the
+ * whole failure is pushed onto whichever contributor happens to sit west of
+ * Greenwich — on a clean clone, with no diff of theirs to explain it.
+ *
+ * `vitest.config.ts` pins `TZ=UTC` for that reason. These assertions exist so
+ * that removing the pin fails here, naming the cause, rather than 69 snapshot
+ * diffs that only reproduce on some machines.
+ */
+describe('suite timezone', () => {
+  it('is pinned, so snapshot dates do not depend on the machine', () => {
+    expect(process.env.TZ).toBe('UTC')
+  })
+
+  // The env var alone is not the property under test — Node caches its
+  // timezone, and a runner that reads `TZ` too late would leave this suite
+  // formatting in local time while the variable claims otherwise. Assert the
+  // observable behaviour instead.
+  it('is in effect for Date, not just declared', () => {
+    expect(new Date('2025-01-01').getTimezoneOffset()).toBe(0)
+  })
+
+  it('keeps a UTC-midnight date on the same calendar day the specs expect', () => {
+    const frozenNow = new Date('2025-01-01')
+
+    expect(frozenNow.getFullYear()).toBe(2025)
+    expect(frozenNow.getMonth()).toBe(0)
+    expect(frozenNow.getDate()).toBe(1)
+  })
+
+  it('formats through Intl in UTC too, so locale-formatted cells are stable', () => {
+    const formatted = new Date('2025-01-01T00:30:00Z').toLocaleString('en-US', {
+      day: 'numeric',
+      month: 'short',
+      hour: '2-digit',
+      minute: '2-digit',
+      hour12: false
+    })
+
+    expect(formatted).toBe('Jan 1, 00:30')
+  })
+})

--- a/test/utils/timezone-determinism.spec.ts
+++ b/test/utils/timezone-determinism.spec.ts
@@ -7,45 +7,38 @@ import { describe, it, expect } from 'vitest'
  * `Calendar.spec.ts`, `InputDate.spec.ts` and `InputTime.spec.ts` freeze "now"
  * at `new Date('2025-01-01')`. A bare `YYYY-MM-DD` string parses as UTC
  * midnight, which in every negative-offset zone is still 2024-12-31 locally,
- * so `data-today` moves to the wrong cell and 69 snapshots fail at once
- * (Calendar 45, InputDate 24). GitHub runners are UTC and stay green, so the
- * whole failure is pushed onto whichever contributor happens to sit west of
+ * so `data-today` moves to the wrong cell and 69 tests fail at once per
+ * project (Calendar 45, InputDate 24) — both projects run them, so a full run
+ * is roughly double that. GitHub runners are UTC and stay green, so the whole
+ * failure is pushed onto whichever contributor happens to sit west of
  * Greenwich — on a clean clone, with no diff of theirs to explain it.
  *
  * `vitest.config.ts` pins `TZ=UTC` for that reason. These assertions exist so
- * that removing the pin fails here, naming the cause, rather than 69 snapshot
- * diffs that only reproduce on some machines.
+ * that losing the pin fails here, naming the cause, rather than as a wall of
+ * snapshot diffs that only reproduce on some machines.
  */
 describe('suite timezone', () => {
   it('is pinned, so snapshot dates do not depend on the machine', () => {
     expect(process.env.TZ).toBe('UTC')
   })
 
-  // The env var alone is not the property under test — Node caches its
-  // timezone, and a runner that reads `TZ` too late would leave this suite
-  // formatting in local time while the variable claims otherwise. Assert the
-  // observable behaviour instead.
+  // The variable alone is not the property under test, and the gap between the
+  // two is exactly how this breaks: under `--pool=threads` the worker receives
+  // `TZ` as a copy of `process.env` while ICU goes on reading the OS
+  // environment, so the assertion above passes while every date below is still
+  // local. Assert the observed offset — with it at zero, local `Date` field
+  // reads equal their UTC counterparts by definition, which is the whole of
+  // what the frozen `2025-01-01` in the date specs depends on.
   it('is in effect for Date, not just declared', () => {
     expect(new Date('2025-01-01').getTimezoneOffset()).toBe(0)
   })
 
-  it('keeps a UTC-midnight date on the same calendar day the specs expect', () => {
-    const frozenNow = new Date('2025-01-01')
-
-    expect(frozenNow.getFullYear()).toBe(2025)
-    expect(frozenNow.getMonth()).toBe(0)
-    expect(frozenNow.getDate()).toBe(1)
-  })
-
-  it('formats through Intl in UTC too, so locale-formatted cells are stable', () => {
-    const formatted = new Date('2025-01-01T00:30:00Z').toLocaleString('en-US', {
-      day: 'numeric',
-      month: 'short',
-      hour: '2-digit',
-      minute: '2-digit',
-      hour12: false
-    })
-
-    expect(formatted).toBe('Jan 1, 00:30')
+  // `Intl` resolves its timezone separately from `Date`'s own getters, so a
+  // partial-ICU build can disagree with the assertion above. Asserted through
+  // `resolvedOptions()` rather than a formatted string: the formats themselves
+  // come from CLDR and get revised between releases, and a test that fails on
+  // a CLDR punctuation change while blaming the timezone is worse than no test.
+  it('resolves Intl in UTC too, so locale-formatted cells are stable', () => {
+    expect(Intl.DateTimeFormat().resolvedOptions().timeZone).toBe('UTC')
   })
 })

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -6,6 +6,29 @@ import bitrix24UIPluginVite from './src/vite'
 import { glob } from 'tinyglobby'
 import { nuxtInclude, vueInclude, vueExclude } from './test/vitest-include'
 
+/**
+ * Pin the suite's timezone.
+ *
+ * The date specs freeze "now" at `new Date('2025-01-01')`, which parses as UTC
+ * midnight — in any negative-offset zone that is still 2024-12-31 locally, so
+ * the calendar's `data-today` lands a day early and every snapshot carrying it
+ * fails: 69 tests per project, in both, on a clean clone. CI runners are UTC,
+ * so nothing here ever goes red; the failure is reserved for contributors west
+ * of Greenwich, who get a red checkout and no hint why.
+ *
+ * This is an assignment on `process.env` rather than vitest's `test.env`
+ * because the two are not interchangeable. `test.env` is handed to the worker
+ * as a JavaScript object: under the default `forks` pool that becomes the
+ * child process's real environment and V8 reads `TZ` from it, but under
+ * `--pool=threads` it is only a per-worker `process.env` copy — ICU keeps
+ * reading the OS environment, and the pin silently does nothing while
+ * `process.env.TZ` still reads `'UTC'`. Assigning here calls `setenv` in the
+ * parent before any pool starts, so both pools inherit a genuinely UTC
+ * environment. Asserted by `test/utils/timezone-determinism.spec.ts`, which
+ * checks observed `Date` behaviour and not just the variable.
+ */
+process.env.TZ = 'UTC'
+
 const components = await glob('./src/runtime/components/*.vue', { absolute: true })
 const vueComponents = await glob('./src/runtime/vue/components/*.vue', { absolute: true })
 const vueRouterOverrides = await glob('./src/runtime/vue/overrides/vue-router/*.vue', { absolute: true })
@@ -15,14 +38,8 @@ export default defineConfig({
     testTimeout: 5000,
     globals: true,
     silent: true,
-    // Pin the suite's timezone. The date specs freeze "now" at
-    // `new Date('2025-01-01')`, which is UTC midnight — in any negative-offset
-    // zone that is still 2024-12-31 locally, so the calendar's `data-today`
-    // lands a day early and 69 snapshots come back with yesterday's date. CI
-    // runners are UTC, so nothing here ever goes red: the failure is reserved
-    // for contributors west of Greenwich, who get a red clean clone and no
-    // hint why. Asserted by `test/utils/timezone-determinism.spec.ts`.
-    env: { TZ: 'UTC' },
+    // The timezone is pinned above, before this config object — see the note
+    // on the `process.env.TZ` assignment for why it cannot live here.
     resolveSnapshotPath(path, extension, { config }) {
       if (config.name === 'vue') {
         return path.replace(/\/([^/]+)\.spec\.ts$/, `/__snapshots__/$1-vue.spec.ts${extension}`)

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -15,6 +15,14 @@ export default defineConfig({
     testTimeout: 5000,
     globals: true,
     silent: true,
+    // Pin the suite's timezone. The date specs freeze "now" at
+    // `new Date('2025-01-01')`, which is UTC midnight — in any negative-offset
+    // zone that is still 2024-12-31 locally, so the calendar's `data-today`
+    // lands a day early and 69 snapshots come back with yesterday's date. CI
+    // runners are UTC, so nothing here ever goes red: the failure is reserved
+    // for contributors west of Greenwich, who get a red clean clone and no
+    // hint why. Asserted by `test/utils/timezone-determinism.spec.ts`.
+    env: { TZ: 'UTC' },
     resolveSnapshotPath(path, extension, { config }) {
       if (config.name === 'vue') {
         return path.replace(/\/([^/]+)\.spec\.ts$/, `/__snapshots__/$1-vue.spec.ts${extension}`)


### PR DESCRIPTION
### Linked issue

Resolves #84

Split out of it, filed rather than folded in: #420 (the `Table` defect #84 misdiagnosed) and #421 (the non-UTC coverage gap this PR creates).

### Type of change

- [ ] Documentation (updates to the documentation or readme)
- [x] Bug fix (a non-breaking change that fixes an issue) <!-- test-only: fixes the suite, ships nothing to npm consumers — hence the `test:` prefix, not `fix:` -->
- [ ] Enhancement (improving an existing functionality)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Chore (updates to the build process or auxiliary tools and libraries)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Description

69 tests fail on a clean clone for any contributor west of Greenwich, and CI can never see it.

`Calendar.spec.ts`, `InputDate.spec.ts` and `InputTime.spec.ts` freeze "now" at `new Date('2025-01-01')`. A bare `YYYY-MM-DD` string parses as UTC midnight, so in `America/Los_Angeles` that instant is still 16:00 on 2024-12-31 locally. The calendar's `data-today` moves to the previous day and every snapshot containing it fails:

```diff
- aria-label="Wednesday, January 1, 2025" ... data-today=""
+ aria-label="Tuesday, December 31, 2024" ... data-today=""
```

`TZ` was not pinned anywhere — not in `vitest.config.ts`, not in the setup files, not in the workflow. GitHub runners are UTC, so the suite is green here and red only on the contributor's machine, with no diff of theirs to explain it.

Measured before the fix, per project:

| TZ | result |
|---|---|
| UTC | 122 passed |
| Asia/Tokyo | 122 passed |
| Pacific/Kiritimati (UTC+14) | 122 passed |
| **America/Los_Angeles** | **69 failed** \| 53 passed |

The split is Calendar 45/51 and InputDate 24/33; `InputTime` is clean. Both projects run these specs against separate snapshot files, so a full run fails roughly twice that.

**The fix** is `process.env.TZ = 'UTC'` in the config's module scope.

Note it is deliberately *not* vitest's `test.env`, which was the first attempt here and is only half a fix. Vitest hands `test.env` to the worker as a JavaScript object: `child_process.fork` turns that into the child's real environment, so it works under the default `forks` pool — but a `worker_threads` worker receives a per-worker `process.env` copy while ICU keeps reading the OS environment. Under `--pool=threads` the variable read back as `'UTC'` while every date stayed local, i.e. the pin silently did nothing. Assigning in module scope is a `setenv` in the parent before any pool starts, so both pools inherit a genuinely UTC environment.

**The guard spec** (`test/utils/timezone-determinism.spec.ts`) exists so the pin cannot be lost silently. It asserts the variable, the observed offset, and `Intl.DateTimeFormat().resolvedOptions().timeZone` — the last one through `resolvedOptions()` rather than a formatted string, because formats come from CLDR and a test that fails on a locale-data revision while blaming the timezone is worse than no test.

### Verification

| Run | Before | After |
|---|---|---|
| Full suite, `TZ=America/Los_Angeles`, `forks` | 69 failed per project | **288 files, 6546 tests passed** |
| Full suite, `TZ=Pacific/Kiritimati`, `threads` | — | **288 files, 6546 tests passed** |
| Guard spec, `forks` × `threads` × `America/New_York` × `Pacific/Kiritimati` | — | passed in all four |
| Guard spec with the pin removed | — | fails under **both** pools, as intended |
| Date specs, `--pool=threads`, `TZ=America/Los_Angeles` | 69 failed | 122 passed |

`eslint` clean on both changed files. No snapshots were regenerated — none needed to change.