### PR TITLE
ci(release): restore the `revert` and `feature` changelog sections

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -7,8 +7,10 @@
       "release-type": "node",
       "changelog-sections": [
         { "type": "feat", "section": "Features" },
+        { "type": "feature", "section": "Features" },
         { "type": "fix", "section": "Bug Fixes" },
         { "type": "perf", "section": "Performance" },
+        { "type": "revert", "section": "Reverts" },
         { "type": "docs", "section": "Docs" },
         { "type": "test", "section": "Tests" },
         { "type": "chore", "section": "Chore" },


### PR DESCRIPTION
### Linked issue

Closes #434.

### Type of change

- [ ] Documentation (updates to the documentation or readme)
- [ ] Bug fix (a non-breaking change that fixes an issue)
- [ ] Enhancement (improving an existing functionality)
- [ ] New feature (a non-breaking change that adds functionality)
- [x] Chore (updates to the build process or auxiliary tools and libraries)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Description

`changelog-sections` **replaces** the preset's default type list wholesale rather than extending it, so any type absent from ours resolves to nothing. Ours listed nine; two of the five the preset shows were missing.

```diff
         { "type": "feat", "section": "Features" },
+        { "type": "feature", "section": "Features" },
         { "type": "fix", "section": "Bug Fixes" },
         { "type": "perf", "section": "Performance" },
+        { "type": "revert", "section": "Reverts" },
         { "type": "docs", "section": "Docs" },
```

### Which preset, exactly

**Corrected from the first revision of this description**, which cited `conventional-changelog-conventionalcommits@10.3.0` and its `effect: 'bump' | 'hidden'` key. That is not what runs here. The action is pinned to `release-please-action@v5.0.0`, whose lockfile resolves `release-please@17.6.0` → **`conventional-changelog-conventionalcommits@6.1.0`**. Grepping the shipped `dist/index.js` at the pinned SHA finds zero occurrences of `DEFAULT_COMMIT_TYPES` or `effect: 'bump'`.

In 6.1.0 the defaults are an inline array in `writer-opts.js` → `defaultConfig()`, keyed `hidden: true`:

| type | section | default |
| --- | --- | --- |
| `feat`, `feature` | Features | visible |
| `fix` | Bug Fixes | visible |
| `perf` | Performance Improvements | visible |
| `revert` | Reverts | visible |
| `docs`, `style`, `chore`, `refactor`, `test`, `build`, `ci` | … | `hidden: true` |

Membership is identical in 6.x and 10.x, so the conclusion is unchanged — but the key name is not, and writing `effect` into this file would be a silent no-op. The citation matters for anyone re-deriving this.

### Why each line

**`revert`** — a revert is exactly the news a consumer has to see, and it rendered nothing.

**`feature`** is the sharper case, and it is not about the changelog at all. `DefaultVersioningStrategy` bumps on `commit.type === 'feat' || commit.type === 'feature'`, and it never sees `changelog-sections`. So a `feature:` commit **already cuts a minor release while contributing no changelog line** — the version moves and nothing explains why.

### Nothing published is missing anything — but not for the reason first given

The earlier claim was "zero `revert:` commits in this history, so nothing published is missing anything". The count is right (`^revert(\(|!|:)` → 0, `feature` → 0). The inference was a non-sequitur that happened to land correctly.

Two GitHub-style reverts **do** exist — `8b774dcd` and `2cc874e2`, both 2025-01-10, both shipped in v0.1.3, neither in `CHANGELOG.md`. What actually saves the conclusion: both predate `bootstrap-sha` (`ae76be29`, 2026-08-06), and `release-please-config.json` only landed 2026-08-08, so this config has produced exactly **one** release — 2.11.0 — containing no revert of any form.

### Scope, stated rather than implied

This reaches conventional `revert:` / `revert(scope):` subjects **only**.

Plain `git revert` produces `Revert "<original subject>"`, which release-please's parser rejects outright (`unexpected token ' ' at 1:7`) and discards silently. Since this repo squash-merges, a revert PR's auto-generated title becomes the subject verbatim — so the realistic revert form stays invisible after this change. Both existing reverts are of that form.

`releasing.md` prescribes exactly that path ("revert it, ship the patch, re-land it afterwards") without saying the subject must read `revert:`. Documenting it there is the follow-up that makes this section reachable; filed rather than bundled here.

### `style` stays out — corrected reasoning

The first revision said "the preset hides `style` by default, so listing or omitting it produce the same empty output". That is wrong, and it contradicted this PR's own thesis one paragraph away.

Listing and omitting differ twice over. A listed entry arrives with no `hidden` flag and therefore **prints**. And an omitted type skips the `if (entry)` section rewrite in `writer-opts.js`, so a **breaking** commit of that type keeps its raw type string as the group title — where `commitGroupOrder.indexOf()` returns `-1` and sorts it *above* Features:

```
### style
* a breaking style commit …

### Features
…
```

The decision to omit still stands, but on different grounds: this is not a `style` problem. **Twelve** types in this history are unconfigured — `playground` (31), `doc` (23), `style` (22), `playgrounds` (12), `cli` (6), `demo` (2), `core`, `ai`, plus typos. Fixing one of twelve here would be arbitrary, so the general case is filed separately.

No live defect either way: all 30 breaking commits so far are of configured types (`fix` 15, `feat` 12, `refactor` 2, `chore` 1).

### Ordering

Section order is the config array's own order, so `Reverts` lands after `Performance` and above the docs/tests/chore block. The earlier claim that it "follows the preset's own" was overstated — only the head matches; our tail (`test, chore, ci, refactor, build`) already diverged from the preset's and is untouched here.

Two types sharing the `"Features"` label merge into one heading, confirmed by running the real writer. Not new behaviour: `chore`, `refactor` and `build` have all mapped to `"Chore"` since the pipeline was set up, and every shipped release renders one `### Chore`.

### Effect on the open release PR: none

Rendering release-please's own `buildNotes` over the 60 unreleased commits with both configs:

```
IDENTICAL NOTES: true      old len 13050   new len 13050
```

Byte-identical, and release-please will not even push — `manifest.js` compares bodies and returns early when they match. #356 keeps its version, headings and 59 bullets. Version arithmetic is untouched: `changelog-sections` is not an input to it.

### Type of change, and the checklist

Retitled from `fix(release):` to `ci(release):`. Squash-merging makes the PR title the commit subject, and `fix` would file this under `### Bug Fixes` in the shipped 2.12.0 notes beside real component fixes — misleading, since `release-please-config.json` is not in the published package's `files`. The repo's precedent for release-pipeline work is `ci:` (#327 sits under `### CI`).

The documentation checkbox is **unticked**: this changes one file by two lines and touches no docs. The `revert:`-subject documentation is filed as follow-up.

### Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.