### PR TITLE
chore(sync): record CLAUDE.md and the bench scaling as skipped

### DIFF
--- a/.sync/dep-parity.json
+++ b/.sync/dep-parity.json
@@ -1,6 +1,6 @@
 {
   "$note": "Upstream's pinned versions for every dependency both trees declare in the SAME section, snapshotted at `cursor`. The sync ports deltas, which is correct per commit and lets a one-time divergence become permanent: once a version is off upstream's line, every later `chore(deps)` batch skips it, because those ports bump only where this fork already matched upstream's pre-image. `prettier` sat at ^3.8.4 against upstream's ^3.9.6 for that reason, through four ported batches, until this file was written. Section-aware on purpose: 18 packages are declared on both sides but in different sections — the whole `@tiptap/*` family is a peer `^3` upstream and a dependency `^3.29.2` here, and `ai` is a peer there and a devDependency here. Those are structural divergences, not drift, and comparing a peer range against a dependency range says nothing. They are absent from this file by construction rather than by omission. Guarded by `test/utils/dep-parity.spec.ts`. Refresh with `node .sync/dep-parity.mjs <path-to-nuxt-ui-mirror> [cursor]`, which preserves `exceptions`.",
-  "cursor": "f6d188bd785d40f2a2d721e3400091cc19cee236",
+  "cursor": "3d2129d2dc1123ebbc573ce4fca2b48fd6a895b4",
   "manifests": {
     "package.json": {
       "dependencies": {

--- a/.sync/log/3d2129d2dc1123ebbc573ce4fca2b48fd6a895b4.md
+++ b/.sync/log/3d2129d2dc1123ebbc573ce4fca2b48fd6a895b4.md
@@ -1,0 +1,26 @@
+# Skip: test(bench): scale tv benchmarks past codspeed's noise floor
+
+**Upstream:** `3d2129d2dc1123ebbc573ce4fca2b48fd6a895b4` (nuxt/ui)
+**Decision:** skip — the problem it solves does not exist here
+
+## Upstream change
+
+Every `bench` body in `test/bench/tv.bench.ts` gets wrapped in a
+100-iteration loop, with the reason in a comment: CodSpeed runs the benchmarks
+under an instruction-counting simulator, GitHub's hosted runners alternate
+between Intel and AMD, and glibc picks different string routines by cache size,
+so anything under ~1 ms collects phantom regressions.
+
+## Why not here
+
+We have `test/bench/tv.bench.ts` — it was ported, and the change would apply
+cleanly. But **this fork does not run CodSpeed.** `bench` is a plain
+`vitest bench --project vue`, no workflow invokes it, and nothing compares runs
+across machines. Nothing here reads these numbers except a person running them
+deliberately.
+
+So the change would buy nothing and cost a hundredfold longer local run. The
+comment it adds would also be false in this repo: it explains a CI setup we do
+not have.
+
+Take this the day benchmarks are wired into CI, and take the comment with it.

--- a/.sync/log/6f82268bc26f16ade37aab67abdc6456e10d1793.md
+++ b/.sync/log/6f82268bc26f16ade37aab67abdc6456e10d1793.md
@@ -1,0 +1,53 @@
+# Skip: chore: add CLAUDE.md importing AGENTS.md
+
+**Upstream:** `6f82268bc26f16ade37aab67abdc6456e10d1793` (nuxt/ui, #6852)
+**Decision:** skip — this fork has already decided the opposite, deliberately
+
+## Upstream change
+
+Three lines, a new tracked `CLAUDE.md`:
+
+```md
+<!-- Claude Code only auto-loads CLAUDE.md, so this imports the shared agent instructions. -->
+
+@AGENTS.md
+```
+
+## Why not here
+
+We have `AGENTS.md` (156 lines) and no `CLAUDE.md`, so the file would apply
+cleanly — and it would still be wrong to add, because **`CLAUDE.md` is in our
+`.gitignore`**, at line 51, under a section headed `# AI`:
+
+```
+# AI
+CLAUDE.md
+.claude/settings.local.json
+.claude/channels/
+.claude/debug/
+```
+
+The company it keeps is what settles it: this fork classifies `CLAUDE.md`
+alongside per-developer Claude Code state, not alongside tracked instructions.
+Porting the commit would mean deleting that line and reversing a standing
+decision, which a sync port is not the place to do.
+
+The trade-off is real and worth naming rather than hiding: upstream's comment
+says Claude Code auto-loads only `CLAUDE.md`, so our tracked `AGENTS.md` is not
+loaded automatically, and each developer supplies their own ignored
+`CLAUDE.md`. If that is judged a mistake, it should be changed on its own
+merits — `.gitignore` line 51 and this commit — not carried in as a port.
+
+Traced via `git log -S 'CLAUDE.md' -- .gitignore`: the entry arrived in
+`b55bd3e7`, a deps port, whose body does not mention it.
+
+## A larger finding, from that same commit body
+
+Worth recording here because this is where it surfaced. `b55bd3e7` reads:
+
+> Skipped: ai + @ai-sdk/* (**b24ui stays on the deferred v6 line**)
+
+Five other ledger entries say the same. The `ai` v6 line was a deliberate,
+repeatedly reaffirmed deferral, not drift — and #425 ended it. That bump was
+made on instruction and stands, but it broke the DeepSeek provider spec, fixed
+in #438, and the reasoning is now in §2.

--- a/.sync/nuxt-ui.json
+++ b/.sync/nuxt-ui.json
@@ -1,7 +1,7 @@
 {
   "upstream": "nuxt/ui",
   "branch": "v4",
-  "cursor": "f6d188bd785d40f2a2d721e3400091cc19cee236",
+  "cursor": "3d2129d2dc1123ebbc573ce4fca2b48fd6a895b4",
   "_cursor_note": "cursor = last upstream commit ported into b24ui. The sync is manual by decision: one commit at a time, oldest-first, each with a `.sync/log/<sha>.md` journal and an entry in `processed`. There is no dispatcher, no porter workflow and no kill-switch — `.sync/PORTING.md` is the whole procedure. `processed` is maintained per port (backfilled #68-#72 on 2026-06-09).",
   "processed": {
     "2799fa6f2b25ce3eb15e050f3ef7c57d0d9a2fdb": {
@@ -1535,6 +1535,18 @@
       "b24ui_sha": "807d52efaf8a29cc23b97df3a047c082752bfad0",
       "decision": "port",
       "summary": "docs(showcase): add kleinezeitung.at (nuxt/ui) — PORT of the schema half; content half is a no-op for the same reason as cf5f15e3. Upstream's entry needed a wider viewport, a delay and an element removed before the screenshot was usable, so screenshotOptions gained width/cookies/removeElements and delay became optional. Ported because it is not decorative here: docs/modules/showcase.ts reads screenshotOptions and spreads it straight into capture-website, so the new keys reach the screenshotter as soon as the schema stops rejecting them, and the old schema REQUIRED delay so an entry wanting only width would have failed validation. DEVIATION recorded: while checking the widening would actually do something, found that delay was inert in this fork — our module hardcoded `delay: 2` AFTER the spread, overwriting any per-entry value, where upstream has no default there at all (which is why their schema could treat delay as the one real option). Porting the widening as-is would have shipped a schema advertising an option the module discards, the same shape of false claim as the MCP inputExamples that named non-existent examples. The fork's 2s default is worth keeping, so it moved BEFORE the spread: still a default, now overridable. One line, a deviation from the upstream commit rather than part of it. No showcase entry sets screenshotOptions today, so nothing changes behaviourally — the point is that schema and module now agree. Also refreshed .sync/dep-parity.json to this cursor; versions identical."
+    },
+    "6f82268bc26f16ade37aab67abdc6456e10d1793": {
+      "pr": "pending-merge",
+      "b24ui_sha": "pending-merge",
+      "decision": "skip",
+      "summary": "chore: add CLAUDE.md importing AGENTS.md (nuxt/ui #6852) — SKIP, this fork already decided the opposite deliberately. Three lines adding a tracked CLAUDE.md that imports AGENTS.md. We have AGENTS.md (156 lines) and no CLAUDE.md, so it would apply cleanly — and would still be wrong, because CLAUDE.md is in our .gitignore at line 51 under a `# AI` heading, alongside .claude/settings.local.json, .claude/channels/ and .claude/debug/. The company it keeps settles it: this fork classifies CLAUDE.md as per-developer Claude Code state, not tracked instructions. Porting would mean deleting that line and reversing a standing decision, which a sync port is not the place to do. Trade-off named rather than hidden: upstream's comment says Claude Code auto-loads only CLAUDE.md, so our tracked AGENTS.md is not auto-loaded and each developer supplies their own ignored copy; if that is a mistake it should be changed on its own merits, not carried in as a port. Traced with git log -S 'CLAUDE.md' -- .gitignore: the entry arrived in b55bd3e7, a deps port whose body never mentions it. That same body is where a larger finding surfaced — 'Skipped: ai + @ai-sdk/* (b24ui stays on the deferred v6 line)', echoed by five other entries, showing the ai v6 line was a deliberate repeatedly reaffirmed deferral rather than drift. #425 ended it on instruction and stands, but it broke the DeepSeek provider spec (fixed in #438) and the reasoning is now a §2 invariant."
+    },
+    "3d2129d2dc1123ebbc573ce4fca2b48fd6a895b4": {
+      "pr": "pending-merge",
+      "b24ui_sha": "pending-merge",
+      "decision": "skip",
+      "summary": "test(bench): scale tv benchmarks past codspeed's noise floor (nuxt/ui) — SKIP, the problem it solves does not exist here. Every bench body in test/bench/tv.bench.ts is wrapped in a 100-iteration loop because CodSpeed runs them under an instruction-counting simulator, GitHub's hosted runners alternate Intel and AMD, and glibc selects different string routines by cache size, so anything under ~1ms collects phantom regressions. We have that file and the change would apply cleanly, but this fork does not run CodSpeed: `bench` is a plain `vitest bench --project vue`, no workflow invokes it, and nothing compares runs across machines. The change would buy nothing and cost a hundredfold longer local run, and the comment it adds would be false here since it explains a CI setup we do not have. Take it the day benchmarks are wired into CI, and take the comment with it."
     }
   }
 }


### PR DESCRIPTION
First two of six in the current queue. Both deliberately **not** taken; adjacent, so batched per `PORTING.md` §6 step 4b. No code changes.

## 1. [`nuxt/ui@6f82268b`](https://github.com/nuxt/ui/commit/6f82268bc26f16ade37aab67abdc6456e10d1793) — `add CLAUDE.md importing AGENTS.md` → **skip**

Three lines adding a tracked `CLAUDE.md` that imports `AGENTS.md`. We have `AGENTS.md` (156 lines) and no `CLAUDE.md`, so it would apply cleanly — and would still be wrong:

```
# AI
CLAUDE.md
.claude/settings.local.json
.claude/channels/
.claude/debug/
```

`CLAUDE.md` is in our `.gitignore` at line 51. **The company it keeps settles it**: this fork classifies the file as per-developer Claude Code state, not as tracked instructions. Porting the commit would mean deleting that line and reversing a standing decision — not something a sync port should do on its own authority.

The trade-off is named rather than hidden: upstream's comment says Claude Code auto-loads only `CLAUDE.md`, so our tracked `AGENTS.md` is **not** loaded automatically, and each developer supplies their own ignored copy. If that is judged a mistake, it is a two-line change — `.gitignore` line 51 plus this commit — and it should be made on its own merits.

## 2. [`nuxt/ui@3d2129d2`](https://github.com/nuxt/ui/commit/3d2129d2dc1123ebbc573ce4fca2b48fd6a895b4) — `scale tv benchmarks past codspeed's noise floor` → **skip**

Wraps every `bench` body in a 100-iteration loop, because CodSpeed runs them under an instruction-counting simulator and GitHub's runners alternate between Intel and AMD, so sub-millisecond bodies collect phantom regressions.

We have `test/bench/tv.bench.ts` and the change would apply cleanly. But **this fork does not run CodSpeed**: `bench` is a plain `vitest bench --project vue`, no workflow invokes it, and nothing compares runs across machines.

So it would buy nothing, cost a hundredfold longer local run, and add a comment describing CI we do not have. Worth taking the day benchmarks are wired into CI — and taking the comment with it.

## A larger finding, surfaced by the first one

Checking *why* `CLAUDE.md` was ignored led to `git log -S 'CLAUDE.md' -- .gitignore` → `b55bd3e7`, a deps port. Its body never mentions `CLAUDE.md`, but it does say:

> Skipped: ai + @ai-sdk/* (**b24ui stays on the deferred v6 line**)

Five other ledger entries say the same. That is what prompted #438: the `ai` v6 line was a deliberate, repeatedly reaffirmed deferral rather than drift, deferred for exactly the DeepSeek provider coupling that #425 then broke. Recorded in both logs here, and as a §2 invariant in #438.

## Ledger

`cursor` → `3d2129d2`. Both entries added with `decision: skip` and the reasoning in `.sync/log/`. `.sync/dep-parity.json` refreshed to the new cursor per the §6 step from #429 — neither commit touches a manifest, so only the cursor line moves and all 148 versions are identical.

## Verify (`CI=true`)

`lint` and the `test/utils` suite (495 tests, 25 files). Documentation and ledger only; nothing executable changes.

Remaining in the queue: `ae2bd5eb` (**Splitter**, adopting), `2beb2345` + `a630c943` (showcase, no-ops), `14ac2438` (**ProgressGroup** plus the `--percent` fix for the existing `Progress`).


---
_Generated by [Claude Code](https://claude.ai/code/session_01JS8ypVfQSFzYVZzkTHhURb)_