### PR TITLE
chore(deps): declare TypeScript instead of deriving it

### DIFF
--- a/package.json
+++ b/package.json
@@ -210,6 +210,7 @@
     "vue-component-type-helpers": "^3.3.10"
   },
   "devDependencies": {
+    "typescript": "^6.0.3",
     "@conventional-commits/parser": "0.4.1",
     "@nuxt/eslint-config": "^1.17.0",
     "@nuxt/module-builder": "^1.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -211,9 +211,6 @@ importers:
       tinyglobby:
         specifier: ^0.2.17
         version: 0.2.17
-      typescript:
-        specifier: ^5.6.3 || ^6.0.0 || ^7.0.0
-        version: 6.0.3
       ufo:
         specifier: ^1.6.4
         version: 1.6.4
@@ -287,6 +284,9 @@ importers:
       nuxt:
         specifier: ^4.5.2
         version: 4.5.2(5eaa5debc483dd6b779810f76a647995)
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
       unbuild:
         specifier: ^3.6.1
         version: 3.6.1(typescript@6.0.3)(vue-sfc-transformer@0.2.3(@volar/typescript@2.4.28(typescript@6.0.3))(@vue/compiler-core@3.5.41)(@vue/language-core@3.3.10)(esbuild@0.27.7)(rolldown@1.2.3)(typescript@6.0.3)(vue@3.5.41(typescript@6.0.3)))(vue-tsc@3.3.10(typescript@6.0.3))(vue@3.5.41(typescript@6.0.3))


### PR DESCRIPTION
### Linked issue

Closes #451.

### Type of change

- [ ] Documentation (updates to the documentation or readme)
- [x] Bug fix (a non-breaking change that fixes an issue)
- [ ] Enhancement (improving an existing functionality)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Chore (updates to the build process or auxiliary tools and libraries)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Description

`typescript` was declared **only** as a peerDependency (`^5.6.3 || ^6.0.0 || ^7.0.0`) and never as a devDependency, so pnpm picked it from that range. Any root `pnpm add` re-resolved the root importer's peers from scratch and flipped it to 5.9.3, churning ~305 lockfile lines inside a diff about something else.

```
main          root 6.0.3  →  pnpm add  →  5.9.3
this branch   root 6.0.3  →  pnpm add  →  6.0.3
```

### It drags the build toolchain with it

This is the part worth knowing, and the first revision of this PR did not have it. On `main`, one `pnpm add` moves the whole `dist` toolchain down:

| package | `main` after `pnpm add` | here |
| --- | --- | --- |
| `@nuxt/module-builder` | **5.9.3** | 6.0.3 |
| `unbuild` | **5.9.3** | 6.0.3 |
| `tsconfck` | **5.9.3** | 6.0.3 |
| `mkdist` | **both** | 6.0.3 |
| `vue-tsc` | 6.0.3 | 6.0.3 |

So `main` is one ordinary `pnpm add` away from building the published declarations with a **mixed toolchain** — and `deploy.yml` installs without `--frozen-lockfile`.

### A declaration, not an override — and that is the change from the first revision

This PR originally added `typescript: ^6.0.3` to `overrides` in `pnpm-workspace.yaml`. Review established that the smaller instrument does the same job, and that the larger one costs more than it returns.

**What the override did additionally:** collapsed the second TypeScript copy, which `nuxt-component-meta` pulls in through a hard `typescript: ^5.9.3` **dependency** — not, as the first revision's comment claimed, through `@nuxt/module-builder`'s peer. Module-builder already resolved to 6.0.3 on `main`.

**What that cost:** rewriting 24 recorded peer ranges to values upstream never published, forcing a third-party package's dependency across a major boundary, and erasing the unmet-peer report for `@nuxt/module-builder` (**not** optional), `tsconfck` and `unbuild`. With the override, `pnpm peers check` returns silence; here it still reports the pre-existing mismatch, which is the honest state:

```
✕ unmet peer typescript
  Installed: 6.0.3
  Wanted:
    ^5.9.3:  @nuxt/module-builder@1.0.3
    ^5.0.0:  tsconfck@3.1.6
```

The extra copy only ever reached docs-time metadata extraction, and the rendered prop tables are identical either way — 49 of 134 `/api/component-meta/*.json` payloads shift, entirely in TS-stdlib internals inside the recursive `schema` field that `compactProp` already strips, with **0** files differing on the surface `ComponentProps.vue` displays. Not worth erasing 24 upstream constraints for.

### Corrections to the first revision

Four claims in it were wrong, and they are recorded here rather than quietly dropped:

- **"the devDependency does not survive `pnpm add`"** — it does. Both instruments produce the same root resolution and byte-identical 46-line change sets. That row was the sole stated basis for choosing the override, and it was never measured; the probe behind it silently failed to find the root importer.
- **"the only typescript peer range in the tree that excludes 6.x"** — `unbuild@3.6.1` peers `^5.9.2` and `tsconfck@3.1.6` peers `^5.0.0`. Module-builder is the only **non-optional** one.
- **"removes a peer complaint rather than adding one"** — it removed the *report*, not the conflict, by rewriting the recorded ranges. Presented as an improvement; it was suppression.
- **"moves zero versions"** — measured with a comparator structurally blind to importer flips, i.e. blind to the bug being fixed.

### Verification

| check | result |
| --- | --- |
| `pnpm install --frozen-lockfile` | passes |
| `pnpm add -D` no longer flips the root | 6.0.3 before and after |
| `pnpm peers check` | still honest — pre-existing mismatch reported |
| `vue-tsc --noEmit` | clean |
| `eslint .` | clean |
| `vitest run test/` | 302 files, 6870 passed, 6 skipped |

The lockfile diff is **6 lines** (was 92 under the override).

`^6.0.3` is what `playgrounds/nuxt`, `playgrounds/vue` and `playgrounds/demo` already declare — the root was the odd one out.

### Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.