### PR TITLE
docs(composables,utils): document every published export, and keep it that way

### DIFF
--- a/src/runtime/composables/defineLocale.ts
+++ b/src/runtime/composables/defineLocale.ts
@@ -10,11 +10,54 @@ interface DefineLocaleOptions<M> {
   messages: M
 }
 
+/**
+ * Builds a `Locale` from a name, a language code and a message table.
+ *
+ * The one thing it adds over the object literal is `dir`, which defaults to
+ * `'ltr'` — so a locale definition only mentions direction when it is `'rtl'`.
+ *
+ * @param options `name` as it is shown to a reader, `code` for `<html lang>`,
+ *   `locale` for `Intl` formatting, `messages`, and `dir` when not `'ltr'`.
+ * @returns The locale, ready to pass to `<B24Locale>` or `extendLocale`.
+ *
+ * @see https://bitrix24.github.io/b24ui/docs/composables/define-locale/
+ *
+ * @example
+ * ```ts
+ * export default defineLocale({
+ *   name: 'Español',
+ *   code: 'es',
+ *   locale: 'es-ES',
+ *   messages: { inputMenu: { noMatch: 'Sin coincidencias' } }
+ * })
+ * ```
+ */
 /* @__NO_SIDE_EFFECTS__ */
 export function defineLocale<M>(options: DefineLocaleOptions<M>): Locale<M> {
   return defu<DefineLocaleOptions<M>, [{ dir: Direction }]>(options, { dir: 'ltr' })
 }
 
+/**
+ * Overrides part of an existing locale, keeping everything not mentioned.
+ *
+ * Merged deeply, so a single string can be replaced without restating the
+ * table around it — which is the point: a shipped locale gains messages
+ * between releases, and a copy would silently miss them.
+ *
+ * @param locale The locale to start from.
+ * @param options The subset to override. Every field is optional and nested
+ *   `messages` are merged, not replaced.
+ * @returns A new locale. Neither argument is mutated.
+ *
+ * @see https://bitrix24.github.io/b24ui/docs/composables/extend-locale/
+ *
+ * @example
+ * ```ts
+ * export default extendLocale(en, {
+ *   messages: { inputMenu: { noMatch: 'Nothing here' } }
+ * })
+ * ```
+ */
 /* @__NO_SIDE_EFFECTS__ */
 export function extendLocale<M>(locale: Locale<M>, options: Partial<DefineLocaleOptions<DeepPartial<M>>>): Locale<M> {
   return defu<Locale<M>, [DefineLocaleOptions<M>]>(options, locale)

--- a/src/runtime/composables/defineShortcuts.ts
+++ b/src/runtime/composables/defineShortcuts.ts
@@ -70,6 +70,32 @@ function convertKeyToCode(key: string): string {
   return specialKeys[key.toLowerCase()] || key
 }
 
+/**
+ * Collects the shortcuts declared on a menu's items into a `defineShortcuts`
+ * config, so a keyboard binding is written once — on the item that shows it.
+ *
+ * Walks `children` and `items` recursively, and picks up any entry that has
+ * both a `kbds` array and an `onSelect` or `onClick` handler. Entries without
+ * one of the two are skipped rather than bound to nothing.
+ *
+ * @param items Menu items, flat or grouped, as passed to `DropdownMenu`,
+ *   `ContextMenu`, `NavigationMenu` or `CommandPalette`.
+ * @param separator How to join a multi-key binding into its config key. `'_'`
+ *   is a combination (`meta_k`, pressed together), `'-'` is a chain (`g-d`,
+ *   pressed in order).
+ * @returns A `ShortcutsConfig` keyed by binding, ready to hand to
+ *   `defineShortcuts`.
+ *
+ * @example
+ * ```ts
+ * const items = [{ label: 'Save', kbds: ['meta', 's'], onSelect: save }]
+ *
+ * defineShortcuts(extractShortcuts(items))
+ * // equivalent to defineShortcuts({ meta_s: save })
+ * ```
+ *
+ * @see https://bitrix24.github.io/b24ui/docs/composables/extract-shortcuts/
+ */
 export function extractShortcuts(items: any[] | any[][], separator: '_' | '-' = '_') {
   const shortcuts: Record<string, Handler> = {}
 
@@ -93,6 +119,42 @@ export function extractShortcuts(items: any[] | any[][], separator: '_' | '-' = 
   return shortcuts
 }
 
+/**
+ * Binds keyboard shortcuts for as long as the calling component is alive.
+ *
+ * Keys are written lowercase. `_` combines (`meta_k` — held together), `-`
+ * chains (`g-d` — pressed in sequence within `chainDelay`). `meta` is the
+ * Command key on macOS and Control elsewhere, so `meta_k` is the one binding
+ * that reads correctly on both.
+ *
+ * A shortcut is ignored while the user is typing, unless its config says
+ * otherwise: `usingInput: true` allows it in any field, and
+ * `usingInput: 'search'` allows it only in the input whose `name` is `search`.
+ * Setting an entry to `false`, `null` or `undefined` disables it, which is how
+ * a shortcut is turned off reactively without rebuilding the config.
+ *
+ * @param config Bindings, as a plain object or a ref — a ref is re-read when
+ *   it changes, so shortcuts can appear and disappear with state. Each value
+ *   is either a handler or a `{ handler, usingInput }` object.
+ * @param options Behaviour of the matcher itself.
+ * @param options.chainDelay How long a chained shortcut waits for its next
+ *   key, in milliseconds. Defaults to `800`.
+ * @param options.layoutIndependent Match on the physical key (`event.code`)
+ *   rather than the character it produces. Makes `meta_k` work on a Cyrillic
+ *   or Dvorak layout, at the cost of matching by position instead of by what
+ *   the user sees printed on the key. Defaults to `false`.
+ *
+ * @example
+ * ```ts
+ * defineShortcuts({
+ *   meta_k: () => open.value = true,
+ *   'g-d': () => navigateTo('/dashboard'),
+ *   escape: { handler: () => close(), usingInput: true }
+ * })
+ * ```
+ *
+ * @see https://bitrix24.github.io/b24ui/docs/composables/define-shortcuts/
+ */
 export function defineShortcuts(config: MaybeRef<ShortcutsConfig>, options: ShortcutsOptions = {}) {
   const chainDelay = options.chainDelay ?? 800
   const chainedInputs = ref<string[]>([])

--- a/src/runtime/composables/useAvatarGroup.ts
+++ b/src/runtime/composables/useAvatarGroup.ts
@@ -2,6 +2,7 @@ import { inject, provide, computed } from 'vue'
 import type { ComputedRef, InjectionKey } from 'vue'
 import type { AvatarGroupProps } from '../components/AvatarGroup.vue'
 
+/** The `size` and `color` an `AvatarGroup` imposes on the avatars inside it. */
 export const avatarGroupInjectionKey: InjectionKey<ComputedRef<{ size: AvatarGroupProps['size'], color: AvatarGroupProps['color'] }>> = Symbol('bitrix24-ui.avatar-group')
 
 /**

--- a/src/runtime/composables/useBlurOnOpen.ts
+++ b/src/runtime/composables/useBlurOnOpen.ts
@@ -68,6 +68,19 @@ function activeElement(): HTMLElement | null {
   return active && active !== document.body ? active : null
 }
 
+/**
+ * Wraps a component's `emit` so the focused element is blurred while an
+ * overlay is open, and given its focus back when it closes.
+ *
+ * Works around a Chromium behaviour where a focused control under a modal
+ * keeps receiving keystrokes. The blurred element is remembered per instance,
+ * not globally — two overlays open at once must not share one slot, or the
+ * second to close hands focus to the wrong place.
+ *
+ * @param open The overlay's open state.
+ * @param emits The component's `emit`, returned wrapped.
+ * @returns The same `emit`, with the blur and restore attached.
+ */
 export function useBlurOnOpen<E extends (event: any, ...args: any[]) => any>(
   open: MaybeRefOrGetter<boolean | undefined>,
   emits: E

--- a/src/runtime/composables/useComponentIcons.ts
+++ b/src/runtime/composables/useComponentIcons.ts
@@ -23,6 +23,19 @@ export interface UseComponentIconsProps {
   trailingIcon?: IconComponent
 }
 
+/**
+ * Works out which side a component's icon goes on, from the props every
+ * icon-bearing component shares.
+ *
+ * The rules are not obvious from the props alone: `loading` replaces the icon
+ * rather than joining it, `avatar` is always leading, and `trailingIcon`
+ * counts as trailing unless `trailing` is explicitly `false`. Centralised here
+ * so `Button`, `Badge`, `Link`, `Chip` and the inputs agree.
+ *
+ * @param componentProps The component's own props — a ref, getter or object.
+ * @returns `isLeading` / `isTrailing`, and the resolved
+ *   `leadingIconName` / `trailingIconName`.
+ */
 export function useComponentIcons(componentProps: MaybeRefOrGetter<UseComponentIconsProps>) {
   const props = computed(() => toValue(componentProps))
 

--- a/src/runtime/composables/useComponentProps.ts
+++ b/src/runtime/composables/useComponentProps.ts
@@ -19,6 +19,16 @@ export const defaultThemeContext: ThemeContext = {
   defaults: computed(() => ({}))
 }
 
+/**
+ * Reads the nearest `<B24Theme>`'s prop defaults.
+ *
+ * Falls back to an empty context rather than throwing, because a component
+ * mounted outside any `<B24Theme>` — in a test, in a portal, in isolation —
+ * should still render with its own defaults.
+ *
+ * @param fallback Context to use when there is no provider above.
+ * @returns The theme context in scope.
+ */
 export function injectThemeContext(fallback: ThemeContext = defaultThemeContext): ThemeContext {
   return _injectThemeContext(fallback)
 }

--- a/src/runtime/composables/useComponentProps.ts
+++ b/src/runtime/composables/useComponentProps.ts
@@ -33,6 +33,15 @@ export function injectThemeContext(fallback: ThemeContext = defaultThemeContext)
   return _injectThemeContext(fallback)
 }
 
+/**
+ * Publishes a `ThemeContext` to everything below, so `useComponentProps` in a
+ * descendant resolves prop defaults from it.
+ *
+ * `<B24Theme>` is the only caller in this package; it is exported for an
+ * application that wants a second scope — a themed dialog, a preview pane —
+ * without nesting another `<B24Theme>`. Half of the `createContext` pair whose
+ * reading half is `injectThemeContext`.
+ */
 export { provideThemeContext }
 
 function camelCase(str: string): string {

--- a/src/runtime/composables/useConfetti.ts
+++ b/src/runtime/composables/useConfetti.ts
@@ -21,4 +21,18 @@ function _useConfetti() {
   }
 }
 
+/**
+ * `canvas-confetti`, shared so every caller fires onto one canvas.
+ *
+ * @returns `fire(options)` for the default canvas, and `create(canvas, options)`
+ *   for one of your own — a fixed-position canvas of your own is what you want
+ *   if the confetti has to sit above a modal.
+ *
+ * @example
+ * ```ts
+ * const { fire } = useConfetti()
+ *
+ * fire({ particleCount: 120, spread: 70 })
+ * ```
+ */
 export const useConfetti = createSharedComposable(_useConfetti)

--- a/src/runtime/composables/useContentSearch.ts
+++ b/src/runtime/composables/useContentSearch.ts
@@ -184,4 +184,14 @@ function _useContentSearch() {
   }
 }
 
+/**
+ * The search index behind `ContentSearch` — the palette that opens on `meta_k`.
+ *
+ * Shared, so the state survives the palette closing and reopening, and two
+ * triggers on one page do not build two indexes.
+ *
+ * @returns `open`, plus the mappers that turn `@nuxt/content` navigation and
+ *   search hits into palette items — `mapFile`, `mapNavigationItems`,
+ *   `mapLinks`, `mapSearchResults` and `postFilter`.
+ */
 export const useContentSearch = /* @__PURE__ */ createSharedComposable(_useContentSearch)

--- a/src/runtime/composables/useDevice.ts
+++ b/src/runtime/composables/useDevice.ts
@@ -75,4 +75,21 @@ const _useDevice = () => {
   }
 }
 
+/**
+ * Which Bitrix24 client the app is running inside, and how much room it has.
+ *
+ * The platform half comes from the `platform` plugin, which reads it from the
+ * user agent — on the server from the request header, so the first paint is
+ * already correct. The screen half is reactive to the viewport.
+ *
+ * In a template, prefer the `bitrix-mobile:` and `bitrix-desktop:` Tailwind
+ * variants; reach for this when the decision is in script — a different
+ * endpoint, a different default, an interaction that only makes sense with a
+ * mouse.
+ *
+ * @returns `platform` and `version`, the `isWeb` / `isBitrixMobile` /
+ *   `isBitrixDesktop` flags, and `screen` breakpoints.
+ *
+ * @see https://bitrix24.github.io/b24ui/docs/composables/use-device/
+ */
 export const useDevice = /* @__PURE__ */ createSharedComposable(_useDevice)

--- a/src/runtime/composables/useEditorMenu.ts
+++ b/src/runtime/composables/useEditorMenu.ts
@@ -85,6 +85,21 @@ export interface EditorMenuOptions<T = any> {
   b24ui: ComputedRef<any>
 }
 
+/**
+ * The shared machinery behind the editor's `@mention` and `:emoji` menus: a
+ * TipTap Suggestion plugin, a floating-ui positioned popup, and the filtering
+ * between them.
+ *
+ * Both menus differ only in their trigger character and their item source, so
+ * they are one composable with two configurations rather than two
+ * near-identical files.
+ *
+ * @param options Trigger `char`, the `items` source, the popup `component` and
+ *   its floating-ui `options`, and where to `appendTo` when the editor's
+ *   parent clips or stacks badly.
+ * @returns `plugin` to register with TipTap, `destroy()`, and the live
+ *   `filteredItems` / `searchTerm` for a custom popup.
+ */
 export function useEditorMenu<T = any>(options: EditorMenuOptions<T>) {
   const filteredItems: Ref<T[]> = ref([])
   const selectedIndex = ref(0)

--- a/src/runtime/composables/useFieldGroup.ts
+++ b/src/runtime/composables/useFieldGroup.ts
@@ -3,6 +3,7 @@ import { computed, defineComponent, inject, provide } from 'vue'
 import type { FieldGroupProps } from '../components/FieldGroup.vue'
 import type { GetObjectField } from '../types/utils'
 
+/** The `size`, `orientation` and `noSplit` a `FieldGroup` imposes on the controls inside it. */
 export const fieldGroupInjectionKey: InjectionKey<ComputedRef<{
   size: FieldGroupProps['size']
   orientation: FieldGroupProps['orientation']
@@ -30,6 +31,13 @@ export function useFieldGroup<T>(props: Props<T>) {
   }
 }
 
+/**
+ * Opts a subtree out of the surrounding `FieldGroup`.
+ *
+ * Wrap a control in it when the group's `size` and `orientation` should not
+ * reach it — a standalone button inside a joined input row, say. Renders its
+ * slot and nothing else.
+ */
 export const FieldGroupReset = defineComponent({
   name: 'FieldGroupReset',
   setup(_, { slots }) {

--- a/src/runtime/composables/useFileUpload.ts
+++ b/src/runtime/composables/useFileUpload.ts
@@ -41,9 +41,11 @@ function parseAcceptToDataTypes(accept: string): string[] {
  * optional drop zone, and the wiring that keeps the two agreeing on which
  * types are allowed.
  *
- * `accept` is parsed once for both — the browser applies it to the dialog, and
- * the same list is handed to the drop zone so a rejected drag is rejected
- * before the drop rather than after.
+ * `accept` goes to the dialog verbatim. The drop zone gets the MIME half of
+ * it only: a drag exposes a type, not a filename, so extension entries are
+ * dropped from that list and an `accept` written purely as extensions
+ * (`'.pdf,.docx'`) leaves the drop zone accepting anything. Validate by name
+ * in `onUpdate` when extensions are the contract.
  *
  * @param options How the picker behaves.
  * @param options.accept Comma-separated MIME types or extensions, as the

--- a/src/runtime/composables/useFileUpload.ts
+++ b/src/runtime/composables/useFileUpload.ts
@@ -36,6 +36,37 @@ function parseAcceptToDataTypes(accept: string): string[] {
     })
 }
 
+/**
+ * The file-picking half of `FileUpload`: a hidden `<input type="file">`, an
+ * optional drop zone, and the wiring that keeps the two agreeing on which
+ * types are allowed.
+ *
+ * `accept` is parsed once for both — the browser applies it to the dialog, and
+ * the same list is handed to the drop zone so a rejected drag is rejected
+ * before the drop rather than after.
+ *
+ * @param options How the picker behaves.
+ * @param options.accept Comma-separated MIME types or extensions, as the
+ *   `accept` attribute takes them. `'*'` allows everything. Defaults to `'*'`.
+ * @param options.reset Clear the selection before each dialog, so picking the
+ *   same file twice fires `onUpdate` twice. Defaults to `false`.
+ * @param options.multiple Allow more than one file. Defaults to `false`.
+ * @param options.dropzone Attach the drop zone to `dropzoneRef`. Defaults to
+ *   `true`.
+ * @param options.onUpdate Called with the chosen files, from the dialog and
+ *   from a drop alike.
+ * @returns `open()` to raise the dialog, `isDragging` for the hover state, and
+ *   `inputRef` / `dropzoneRef` to bind to the elements.
+ *
+ * @example
+ * ```ts
+ * const { open, isDragging, dropzoneRef } = useFileUpload({
+ *   accept: 'image/*',
+ *   multiple: true,
+ *   onUpdate: files => upload(files)
+ * })
+ * ```
+ */
 export function useFileUpload(options: UseFileUploadOptions) {
   const {
     accept = '*',

--- a/src/runtime/composables/useFilter.ts
+++ b/src/runtime/composables/useFilter.ts
@@ -1,6 +1,17 @@
 import { useFilter as useRekaFilter } from 'reka-ui'
 import { get } from '../utils'
 
+/**
+ * The matcher behind the searchable menus — `CommandPalette`, `InputMenu`,
+ * `SelectMenu`.
+ *
+ * Ranks rather than filters: an exact match beats a prefix, which beats a
+ * substring, so typing `us` puts `User` above `Status`. Comparison is
+ * accent- and case-insensitive (`sensitivity: 'base'`), which is what makes
+ * `resume` find `Résumé`.
+ *
+ * @returns `filter` for the list, and the scoring predicates it is built from.
+ */
 export function useFilter() {
   const { contains, startsWith } = useRekaFilter({ sensitivity: 'base' })
 

--- a/src/runtime/composables/useFilter.ts
+++ b/src/runtime/composables/useFilter.ts
@@ -10,7 +10,9 @@ import { get } from '../utils'
  * accent- and case-insensitive (`sensitivity: 'base'`), which is what makes
  * `resume` find `Résumé`.
  *
- * @returns `filter` for the list, and the scoring predicates it is built from.
+ * @returns `filter` for a flat list and `filterGroups` for grouped items —
+ *   the menus and selects use one or the other — plus the `score` / `scoreItem`
+ *   predicates both are built from.
  */
 export function useFilter() {
   const { contains, startsWith } = useRekaFilter({ sensitivity: 'base' })

--- a/src/runtime/composables/useFormField.ts
+++ b/src/runtime/composables/useFormField.ts
@@ -15,13 +15,21 @@ type Props<T> = {
   disabled?: boolean
 }
 
+/** `Form`'s own settings — `disabled`, validation timing — read by every field under it. */
 export const formOptionsInjectionKey: InjectionKey<ComputedRef<FormInjectedOptions>> = Symbol('bitrix24-ui.form-options')
+/** The bus a `Form` and its fields talk over: blur, input, change, focus, and validation requests. */
 export const formBusInjectionKey: InjectionKey<UseEventBusReturn<FormEvent<any>, string>> = Symbol('bitrix24-ui.form-events')
+/** The `Form`'s `state` object, so a field can read the value it is bound to without a prop. */
 export const formStateInjectionKey: InjectionKey<ComputedRef<Record<string, any> | undefined>> = Symbol('bitrix24-ui.form-state')
+/** What a `FormField` tells the control inside it: `name`, `size`, `error`, and the ids for aria wiring. */
 export const formFieldInjectionKey: InjectionKey<ComputedRef<FormFieldInjectedOptions<FormFieldProps>> | undefined> = Symbol('bitrix24-ui.form-field')
+/** The id a `FormField` minted for its control, so `<label for>` and the control agree on one. */
 export const inputIdInjectionKey: InjectionKey<Ref<string | undefined>> = Symbol('bitrix24-ui.input-id')
+/** Every control registered with the `Form`, keyed by `name` — how `validate()` finds the field to focus. */
 export const formInputsInjectionKey: InjectionKey<Ref<Record<string, { id?: string, pattern?: RegExp }>>> = Symbol('bitrix24-ui.form-inputs')
+/** Whether the `Form`'s submit handler is still running; disables controls without each one being told. */
 export const formLoadingInjectionKey: InjectionKey<Readonly<Ref<boolean>>> = Symbol('bitrix24-ui.form-loading')
+/** The `Form`'s current validation errors, so a field can find its own by `name` or `errorPattern`. */
 export const formErrorsInjectionKey: InjectionKey<Readonly<Ref<FormErrorWithId[]>>> = Symbol('bitrix24-ui.form-errors')
 
 /**

--- a/src/runtime/composables/useKbd.ts
+++ b/src/runtime/composables/useKbd.ts
@@ -11,8 +11,9 @@ type KbdKeysSpecificMap = {
  * Modifier and special keys as the glyphs a keyboard shows: `meta` is `⌘` on
  * Apple and `Ctrl` elsewhere, resolved at render time by `useKbd`.
  *
- * The keys of this map are what `Kbd`'s `value` prop and `defineShortcuts`
- * bindings accept as names.
+ * These are the names `Kbd`'s `value` prop translates; anything else is
+ * rendered as given, so `value="F5"` prints `F5`. `defineShortcuts` does not
+ * read this map at all — it has its own `specialKeys` for matching events.
  */
 export const kbdKeysMap = {
   meta: '',

--- a/src/runtime/composables/useKbd.ts
+++ b/src/runtime/composables/useKbd.ts
@@ -7,6 +7,13 @@ type KbdKeysSpecificMap = {
   ctrl: string
 }
 
+/**
+ * Modifier and special keys as the glyphs a keyboard shows: `meta` is `⌘` on
+ * Apple and `Ctrl` elsewhere, resolved at render time by `useKbd`.
+ *
+ * The keys of this map are what `Kbd`'s `value` prop and `defineShortcuts`
+ * bindings accept as names.
+ */
 export const kbdKeysMap = {
   meta: '',
   ctrl: '',
@@ -68,4 +75,14 @@ const _useKbd = () => {
   }
 }
 
+/**
+ * Turns a key name into the glyph this platform prints on it.
+ *
+ * `meta` is `⌘` on Apple and `Ctrl` everywhere else, and `alt` is `⌥` or
+ * `Alt` — which is why a shortcut hint cannot be a hard-coded string if it is
+ * meant to read correctly on both.
+ *
+ * @returns `macOS`, and `getKbdKey(value)` which maps a name from `kbdKeysMap`
+ *   and passes anything else through unchanged.
+ */
 export const useKbd = /* @__PURE__ */ createSharedComposable(_useKbd)

--- a/src/runtime/composables/useLocale.ts
+++ b/src/runtime/composables/useLocale.ts
@@ -32,6 +32,6 @@ const _useLocale = (localeOverrides?: Ref<Locale<Messages> | undefined>) => {
  * @returns The locale context: `t()` for translation, plus `lang`, `code`,
  *   `dir` and the `locale` object itself.
  *
- * @see https://bitrix24.github.io/b24ui/docs/composables/define-locale/
+ * @see https://bitrix24.github.io/b24ui/docs/getting-started/integrations/i18n/vue/
  */
 export const useLocale = /* @__PURE__ */ import.meta.client ? createSharedComposable(_useLocale) : _useLocale

--- a/src/runtime/composables/useLocale.ts
+++ b/src/runtime/composables/useLocale.ts
@@ -5,6 +5,13 @@ import type { Locale, Messages } from '../types/locale'
 import { buildLocaleContext } from '../utils/locale'
 import en from '../locale/en'
 
+/**
+ * The app's active locale, provided by `<B24App>`.
+ *
+ * `Symbol.for` rather than `Symbol`: the key has to match across two copies of
+ * the package, which is what happens when an app and a library both depend on
+ * b24ui and the bundler does not dedupe them.
+ */
 export const localeContextInjectionKey: InjectionKey<Ref<Locale<unknown> | undefined>> = Symbol.for('bitrix24-ui.locale-context')
 
 const _useLocale = (localeOverrides?: Ref<Locale<Messages> | undefined>) => {
@@ -13,4 +20,18 @@ const _useLocale = (localeOverrides?: Ref<Locale<Messages> | undefined>) => {
   return buildLocaleContext<Messages>(computed(() => locale.value || en))
 }
 
+/**
+ * The active locale's messages and direction.
+ *
+ * Shared on the client and per-call on the server: a shared composable holds
+ * one instance for the process, which on a server would leak one request's
+ * locale into the next.
+ *
+ * @param localeOverrides Use a specific locale instead of the app's — for a
+ *   subtree that renders in a fixed language.
+ * @returns The locale context: `t()` for translation, plus `lang`, `code`,
+ *   `dir` and the `locale` object itself.
+ *
+ * @see https://bitrix24.github.io/b24ui/docs/composables/define-locale/
+ */
 export const useLocale = /* @__PURE__ */ import.meta.client ? createSharedComposable(_useLocale) : _useLocale

--- a/src/runtime/composables/useOverlay.ts
+++ b/src/runtime/composables/useOverlay.ts
@@ -171,4 +171,35 @@ function _useOverlay() {
   }
 }
 
+/**
+ * Opens modals, slideovers and drawers from script rather than from a template
+ * — the case where the component that raises the dialog is not the one that
+ * should own its markup: a route guard, a store action, a table row's menu.
+ *
+ * `create()` registers a component and hands back a handle. `open()` mounts it
+ * and returns a promise that settles with whatever the overlay emits on
+ * `close`, so a confirmation reads as one `await` instead of a callback and a
+ * ref. `patch()` updates the props of an overlay that is already on screen.
+ *
+ * Shared across the app (`createSharedComposable`), so the same overlay cannot
+ * be mounted twice by two callers, and `closeAll()` means all of them.
+ *
+ * Requires a `<B24OverlayProvider />` in the tree.
+ *
+ * @returns `overlays` plus `create`, `open`, `close`, `closeAll`, `patch`,
+ *   `unmount` and `isOpen`.
+ *
+ * @example
+ * ```ts
+ * const overlay = useOverlay()
+ * const modal = overlay.create(ConfirmModal)
+ *
+ * const confirmed = await modal.open({ title: 'Delete this deal?' }).result
+ * if (confirmed) {
+ *   await remove()
+ * }
+ * ```
+ *
+ * @see https://bitrix24.github.io/b24ui/docs/composables/use-overlay/
+ */
 export const useOverlay = /* @__PURE__ */ createSharedComposable(_useOverlay)

--- a/src/runtime/composables/usePortal.ts
+++ b/src/runtime/composables/usePortal.ts
@@ -1,8 +1,21 @@
 import { inject, computed } from 'vue'
 import type { Ref, InjectionKey } from 'vue'
 
+/** Where portalled content goes by default, for components whose `portal` prop is `true`. */
 export const portalTargetInjectionKey: InjectionKey<Ref<boolean | string | HTMLElement>> = Symbol('bitrix24-ui.portal-target')
 
+/**
+ * Resolves a component's `portal` prop into the props reka-ui's `Teleport`
+ * wants, honouring the app-wide default underneath it.
+ *
+ * `true` means "wherever the app said" — the target provided through
+ * `portalTargetInjectionKey`, or `body` if nothing did. `false` renders in
+ * place, which is what a popup inside a dialog usually needs. A string or an
+ * element is used as-is.
+ *
+ * @param portal The component's `portal` prop, as a ref.
+ * @returns `{ to, disabled }`, ready to spread onto a `Teleport`.
+ */
 export function usePortal(portal: Ref<boolean | string | HTMLElement | undefined>) {
   const globalPortal = inject(portalTargetInjectionKey, undefined)
 

--- a/src/runtime/composables/useResizable.ts
+++ b/src/runtime/composables/useResizable.ts
@@ -85,14 +85,16 @@ export type UseResizableReturn = {
 /**
  * Drag-to-resize for the dashboard panels, with the size remembered per `key`.
  *
- * Sizes are percentages of the container, not pixels, so a panel keeps its
- * proportion when the window changes. The stored value survives a reload —
- * which is why `key` has to be stable and distinct: two panels sharing one key
- * share one width.
+ * Sizes are in `options.unit`, which defaults to `'px'` here and in
+ * `DashboardGroup` alike — a panel keeps its width when the window changes,
+ * not its proportion. Pass `'%'` for proportional panels, or `'rem'` to have
+ * the panel follow the root font size. The stored value survives a reload — which is why `key` has to be stable and distinct:
+ * two panels sharing one key share one width.
  *
  * @param key Storage key for the remembered size. Stable and unique per panel.
  * @param options Panel geometry — `side`, `minSize`, `maxSize`, `defaultSize`,
- *   `collapsible`, `collapsedSize`. A ref is re-read when it changes.
+ *   `collapsible`, `collapsedSize`, and `unit` (`'px'` by default, also `'%'`
+ *   and `'rem'`). A ref is re-read when it changes.
  * @param context Externally-owned state.
  * @param context.collapsed Two-way collapsed state, when the caller owns it.
  * @returns `el` to bind, the live `size`, `isDragging` / `isCollapsed`, the

--- a/src/runtime/composables/useResizable.ts
+++ b/src/runtime/composables/useResizable.ts
@@ -82,6 +82,23 @@ export type UseResizableReturn = {
   collapse: (value?: boolean) => void
 }
 
+/**
+ * Drag-to-resize for the dashboard panels, with the size remembered per `key`.
+ *
+ * Sizes are percentages of the container, not pixels, so a panel keeps its
+ * proportion when the window changes. The stored value survives a reload —
+ * which is why `key` has to be stable and distinct: two panels sharing one key
+ * share one width.
+ *
+ * @param key Storage key for the remembered size. Stable and unique per panel.
+ * @param options Panel geometry — `side`, `minSize`, `maxSize`, `defaultSize`,
+ *   `collapsible`, `collapsedSize`. A ref is re-read when it changes.
+ * @param context Externally-owned state.
+ * @param context.collapsed Two-way collapsed state, when the caller owns it.
+ * @returns `el` to bind, the live `size`, `isDragging` / `isCollapsed`, the
+ *   `onMouseDown` / `onTouchStart` / `onDoubleClick` handlers for the handle,
+ *   and `collapse()`.
+ */
 export function useResizable(key: string, options: Ref<UseResizableProps> | UseResizableProps = {}, { collapsed = ref(false) }: { collapsed?: Ref<boolean> } = {}): UseResizableReturn {
   const el = ref<HTMLElement | null>(null)
   const opts = computed(() => ({

--- a/src/runtime/composables/useScrollShadow.ts
+++ b/src/runtime/composables/useScrollShadow.ts
@@ -15,6 +15,22 @@ export interface UseScrollShadowOptions {
   orientation?: MaybeRefOrGetter<'vertical' | 'horizontal'>
 }
 
+/**
+ * Fades the edges of a scrollable box, so the reader can tell there is more
+ * content past the fold.
+ *
+ * The shadow is a `mask-image`, applied only at the ends that can still be
+ * scrolled towards: nothing at the top when the box is at the top, both when
+ * it is in the middle. `isOverflowing` is false when the content fits, which
+ * is what stops the mask appearing on a box that does not scroll at all.
+ *
+ * @param element The scroll container.
+ * @param options Fade geometry.
+ * @param options.orientation Which axis scrolls. Defaults to `'vertical'`.
+ * @param options.size Fade length, as a CSS length.
+ * @returns `style` to bind, plus `isOverflowing` and `arrivedState` if the
+ *   caller wants to decide for itself.
+ */
 export function useScrollShadow(element: MaybeRef<HTMLElement | null | undefined>, options: UseScrollShadowOptions = {}) {
   const { arrivedState } = useScroll(element)
 

--- a/src/runtime/composables/useScrollShadow.ts
+++ b/src/runtime/composables/useScrollShadow.ts
@@ -27,7 +27,9 @@ export interface UseScrollShadowOptions {
  * @param element The scroll container.
  * @param options Fade geometry.
  * @param options.orientation Which axis scrolls. Defaults to `'vertical'`.
- * @param options.size Fade length, as a CSS length.
+ * @param options.size Fade length in pixels, as a bare number. Defaults to
+ *   `24`. A string with its own unit does not work — `px` is appended, so
+ *   `'2rem'` builds `2rempx` and the mask stops rendering.
  * @returns `style` to bind, plus `isOverflowing` and `arrivedState` if the
  *   caller wants to decide for itself.
  */

--- a/src/runtime/composables/useScrollspy.ts
+++ b/src/runtime/composables/useScrollspy.ts
@@ -1,5 +1,17 @@
 import { ref, watch, onBeforeMount, onBeforeUnmount } from 'vue'
 
+/**
+ * Tracks which headings are on screen, for a table of contents that follows
+ * the reader.
+ *
+ * Backed by an `IntersectionObserver` rather than scroll offsets, so it costs
+ * nothing while the page is still. `activeHeadings` is the answer a ToC wants:
+ * it keeps the last heading highlighted while the reader is between two, where
+ * `visibleHeadings` would go empty and the highlight would flicker.
+ *
+ * @returns `visibleHeadings` and `activeHeadings`, plus `updateHeadings()`
+ *   to (re)observe a set of elements after the content changes.
+ */
 export function useScrollspy() {
   const observer = ref<IntersectionObserver>()
   const visibleHeadings = ref<string[]>([])

--- a/src/runtime/composables/useToast.ts
+++ b/src/runtime/composables/useToast.ts
@@ -4,6 +4,11 @@ import { useState } from '#imports'
 import type { ToastEmits, ToastProps } from '../components/Toast.vue'
 import type { EmitsToProps } from '../types/utils'
 
+/**
+ * How many toasts `Toaster` keeps on screen at once, provided by `Toaster`
+ * itself and read by `useToast`. Older toasts fall off the end; `0` clears
+ * them all.
+ */
 export const toastMaxInjectionKey: InjectionKey<Ref<number | undefined>> = Symbol('bitrix24-ui.toast-max')
 
 export interface Toast extends Omit<ToastProps, 'defaultOpen'>, EmitsToProps<ToastEmits> {
@@ -15,6 +20,34 @@ export interface Toast extends Omit<ToastProps, 'defaultOpen'>, EmitsToProps<Toa
   _updated?: boolean
 }
 
+/**
+ * The queue behind `Toaster`. Every call returns the same shared list, so a
+ * toast raised from a composable, a store or a route handler reaches whichever
+ * `Toaster` is mounted.
+ *
+ * Toasts are queued rather than pushed straight in: duplicates are merged at
+ * display time, by `id`, no matter which `useToast()` instance queued them.
+ * Pass an explicit `id` to make a repeated notification collapse into one
+ * instead of stacking.
+ *
+ * Requires a `<B24Toaster />` in the tree — without one the toasts accumulate
+ * and nothing renders them.
+ *
+ * @returns The live `toasts` list plus `add`, `update`, `remove` and `clear`.
+ *   `add` returns the toast it created, whose `id` is what `update` and
+ *   `remove` take.
+ *
+ * @example
+ * ```ts
+ * const toast = useToast()
+ *
+ * const { id } = toast.add({ title: 'Saving…', color: 'air-primary' })
+ * await save()
+ * toast.update(id, { title: 'Saved', color: 'air-primary-success' })
+ * ```
+ *
+ * @see https://bitrix24.github.io/b24ui/docs/composables/use-toast/
+ */
 export function useToast() {
   const toasts = useState<Toast[]>('toasts', () => [])
   const max = inject(toastMaxInjectionKey, undefined)

--- a/src/runtime/utils/content.ts
+++ b/src/runtime/utils/content.ts
@@ -3,6 +3,14 @@ import type { IconComponent } from '#b24ui/types'
 
 type MapContentNavigationItemOptions = { labelAttribute?: string, deep?: number }
 
+/**
+ * Turns one `@nuxt/content` navigation entry into the item shape b24ui's
+ * navigation components take, recursing into `children`.
+ *
+ * @param item The content navigation entry.
+ * @param options Depth limits and per-item overrides.
+ * @param currentDepth Recursion depth; callers pass nothing.
+ */
 export function mapContentNavigationItem(item: ContentNavigationItem, options?: MapContentNavigationItemOptions, currentDepth: number = 0) {
   const navMap = {
     [options?.labelAttribute || 'title']: 'label',
@@ -30,6 +38,9 @@ export function mapContentNavigationItem(item: ContentNavigationItem, options?: 
   return link
 }
 
+/**
+ * `mapContentNavigationItem` over a whole tree — what a docs sidebar binds to.
+ */
 export function mapContentNavigation(navigation: ContentNavigationItem[], options?: MapContentNavigationItemOptions) {
   return navigation.map(item => mapContentNavigationItem(item, options))
 }

--- a/src/runtime/utils/dashboard.ts
+++ b/src/runtime/utils/dashboard.ts
@@ -10,4 +10,14 @@ export interface DashboardContext extends Pick<UseResizableProps, 'storage' | 's
   collapseSidebar?: (collapsed: boolean) => void
 }
 
+/**
+ * The `DashboardGroup` context pair: `provideDashboardContext` is called by
+ * `DashboardGroup`, `useDashboard` reads it from `DashboardSidebar`,
+ * `DashboardPanel`, `DashboardResizeHandle` and the search toggle.
+ *
+ * `useDashboard` throws when there is no `DashboardGroup` above — unlike the
+ * theme context, which falls back. A dashboard part outside its group has no
+ * sensible default to render: it does not know its own storage key, its
+ * sidebar state, or which unit its neighbours size themselves in.
+ */
 export const [useDashboard, provideDashboardContext] = createContext<DashboardContext>('DashboardGroup')

--- a/src/runtime/utils/editor.ts
+++ b/src/runtime/utils/editor.ts
@@ -47,12 +47,16 @@ export function isExtensionAvailable(editor: Editor | null, extensionName: strin
 }
 
 /**
+ * Every `create*Handler` below returns the same shape, and it is the shape
+ * `EditorToolbar` binds a button to: `canExecute` decides whether to enable
+ * it, `execute` runs on click, `isActive` shows it pressed, and `isDisabled`
+ * greys it out where the command makes no sense — inside a code block, or with
+ * an image selected. Only the differences are documented on each one.
+ */
+
+/**
  * A handler for a command that toggles, by name — `blockquote` becomes
  * `toggleBlockquote`.
- *
- * Returns the `{ canExecute, execute, isActive }` triple `EditorToolbar` binds
- * a button to: whether to enable it, what to run, and whether to show it
- * pressed.
  */
 export function createToggleHandler(name: string) {
   const fnName = `toggle${name.charAt(0).toUpperCase()}${name.slice(1)}`
@@ -66,11 +70,9 @@ export function createToggleHandler(name: string) {
 
 /**
  * A handler for a command that sets rather than toggles — `paragraph` becomes
- * `setParagraph`. Never reports active, because setting is not a state.
- *
- * Returns the `{ canExecute, execute, isActive }` triple `EditorToolbar` binds
- * a button to: whether to enable it, what to run, and whether to show it
- * pressed.
+ * `setParagraph`. Still reports active, because the node it sets *is* a state
+ * the toolbar shows pressed; what differs from `createToggleHandler` is only
+ * that running it twice is idempotent instead of undoing itself.
  */
 export function createSetHandler(name: string) {
   const fnName = `set${name.charAt(0).toUpperCase()}${name.slice(1)}`
@@ -86,10 +88,6 @@ export function createSetHandler(name: string) {
  * A handler for a command called by its own name and carrying no state, such
  * as `undo` and `redo`. Does not focus the editor first: undo should not move
  * the caret.
- *
- * Returns the `{ canExecute, execute, isActive }` triple `EditorToolbar` binds
- * a button to: whether to enable it, what to run, and whether to show it
- * pressed.
  */
 export function createSimpleHandler(name: string) {
   return {
@@ -104,10 +102,6 @@ export function createSimpleHandler(name: string) {
  * A handler for any inline mark, taking the mark's name from the item rather
  * than from a closure — so bold, italic, code and strike are one handler
  * configured four ways.
- *
- * Returns the `{ canExecute, execute, isActive }` triple `EditorToolbar` binds
- * a button to: whether to enable it, what to run, and whether to show it
- * pressed.
  */
 export function createMarkHandler() {
   return {
@@ -120,10 +114,6 @@ export function createMarkHandler() {
 
 /**
  * A handler for text alignment, reading the target alignment from the item.
- *
- * Returns the `{ canExecute, execute, isActive }` triple `EditorToolbar` binds
- * a button to: whether to enable it, what to run, and whether to show it
- * pressed.
  */
 export function createTextAlignHandler() {
   return {
@@ -136,10 +126,6 @@ export function createTextAlignHandler() {
 
 /**
  * A handler for headings, reading the level from the item.
- *
- * Returns the `{ canExecute, execute, isActive }` triple `EditorToolbar` binds
- * a button to: whether to enable it, what to run, and whether to show it
- * pressed.
  */
 export function createHeadingHandler() {
   return {
@@ -154,10 +140,6 @@ export function createHeadingHandler() {
  * A handler for links. Enabled when the editor can either set or unset one,
  * so the button stays usable both to add a link and to remove the one under
  * the caret.
- *
- * Returns the `{ canExecute, execute, isActive }` triple `EditorToolbar` binds
- * a button to: whether to enable it, what to run, and whether to show it
- * pressed.
  */
 export function createLinkHandler() {
   return {
@@ -202,10 +184,6 @@ export function createLinkHandler() {
 
 /**
  * A handler for images.
- *
- * Returns the `{ canExecute, execute, isActive }` triple `EditorToolbar` binds
- * a button to: whether to enable it, what to run, and whether to show it
- * pressed.
  */
 export function createImageHandler() {
   return {
@@ -237,10 +215,6 @@ export function createImageHandler() {
 
 /**
  * A handler for one of the three list types.
- *
- * Returns the `{ canExecute, execute, isActive }` triple `EditorToolbar` binds
- * a button to: whether to enable it, what to run, and whether to show it
- * pressed.
  */
 export function createListHandler(listType: 'bulletList' | 'orderedList' | 'taskList') {
   const fnNameMap = {
@@ -319,10 +293,6 @@ export function createListHandler(listType: 'bulletList' | 'orderedList' | 'task
  * A handler that moves the block at `cmd.pos` up or down — what the drag
  * handle's menu binds to. Disabled when there is no node at that position, or
  * no sibling to swap with.
- *
- * Returns the `{ canExecute, execute, isActive }` triple `EditorToolbar` binds
- * a button to: whether to enable it, what to run, and whether to show it
- * pressed.
  */
 export function createMoveHandler(direction: 'up' | 'down') {
   return {

--- a/src/runtime/utils/editor.ts
+++ b/src/runtime/utils/editor.ts
@@ -4,6 +4,11 @@ import { flip, shift, offset, size, autoPlacement, hide, inline } from '@floatin
 import { isArrayOfArray } from './index'
 import type { EditorHandlers, EditorCustomHandlers, EditorItem, FloatingUIOptions } from '../types/editor'
 
+/**
+ * Whether the editor's schema knows a mark — the check that decides if a
+ * toolbar button is offered at all, since a `Bold` button on an editor built
+ * without the Bold extension would be dead.
+ */
 export function isMarkInSchema(mark: string | Mark, editor: Editor | null): boolean {
   if (!editor?.schema) {
     return false
@@ -13,6 +18,10 @@ export function isMarkInSchema(mark: string | Mark, editor: Editor | null): bool
   return editor.schema.spec.marks.get(markName) !== undefined
 }
 
+/**
+ * Whether the current selection is one of `nodeTypes`. Used to hide controls
+ * that make no sense for what is selected — text alignment over an image, say.
+ */
 export function isNodeTypeSelected(editor: Editor | null, nodeTypes: string[]): boolean {
   if (!editor) {
     return false
@@ -28,6 +37,7 @@ export function isNodeTypeSelected(editor: Editor | null, nodeTypes: string[]): 
   })
 }
 
+/** Whether an extension is registered on this editor instance. */
 export function isExtensionAvailable(editor: Editor | null, extensionName: string): boolean {
   if (!editor) {
     return false
@@ -36,6 +46,14 @@ export function isExtensionAvailable(editor: Editor | null, extensionName: strin
   return editor.extensionManager.extensions.some(ext => ext.name === extensionName)
 }
 
+/**
+ * A handler for a command that toggles, by name — `blockquote` becomes
+ * `toggleBlockquote`.
+ *
+ * Returns the `{ canExecute, execute, isActive }` triple `EditorToolbar` binds
+ * a button to: whether to enable it, what to run, and whether to show it
+ * pressed.
+ */
 export function createToggleHandler(name: string) {
   const fnName = `toggle${name.charAt(0).toUpperCase()}${name.slice(1)}`
   return {
@@ -46,6 +64,14 @@ export function createToggleHandler(name: string) {
   }
 }
 
+/**
+ * A handler for a command that sets rather than toggles — `paragraph` becomes
+ * `setParagraph`. Never reports active, because setting is not a state.
+ *
+ * Returns the `{ canExecute, execute, isActive }` triple `EditorToolbar` binds
+ * a button to: whether to enable it, what to run, and whether to show it
+ * pressed.
+ */
 export function createSetHandler(name: string) {
   const fnName = `set${name.charAt(0).toUpperCase()}${name.slice(1)}`
   return {
@@ -56,6 +82,15 @@ export function createSetHandler(name: string) {
   }
 }
 
+/**
+ * A handler for a command called by its own name and carrying no state, such
+ * as `undo` and `redo`. Does not focus the editor first: undo should not move
+ * the caret.
+ *
+ * Returns the `{ canExecute, execute, isActive }` triple `EditorToolbar` binds
+ * a button to: whether to enable it, what to run, and whether to show it
+ * pressed.
+ */
 export function createSimpleHandler(name: string) {
   return {
     canExecute: (editor: Editor) => (editor.can() as any)[name](),
@@ -65,6 +100,15 @@ export function createSimpleHandler(name: string) {
   }
 }
 
+/**
+ * A handler for any inline mark, taking the mark's name from the item rather
+ * than from a closure — so bold, italic, code and strike are one handler
+ * configured four ways.
+ *
+ * Returns the `{ canExecute, execute, isActive }` triple `EditorToolbar` binds
+ * a button to: whether to enable it, what to run, and whether to show it
+ * pressed.
+ */
 export function createMarkHandler() {
   return {
     canExecute: (editor: Editor, cmd: any) => (editor.can() as any).toggleMark(cmd.mark),
@@ -74,6 +118,13 @@ export function createMarkHandler() {
   }
 }
 
+/**
+ * A handler for text alignment, reading the target alignment from the item.
+ *
+ * Returns the `{ canExecute, execute, isActive }` triple `EditorToolbar` binds
+ * a button to: whether to enable it, what to run, and whether to show it
+ * pressed.
+ */
 export function createTextAlignHandler() {
   return {
     canExecute: (editor: Editor, cmd: any) => (editor.can() as any).setTextAlign(cmd.align),
@@ -83,6 +134,13 @@ export function createTextAlignHandler() {
   }
 }
 
+/**
+ * A handler for headings, reading the level from the item.
+ *
+ * Returns the `{ canExecute, execute, isActive }` triple `EditorToolbar` binds
+ * a button to: whether to enable it, what to run, and whether to show it
+ * pressed.
+ */
 export function createHeadingHandler() {
   return {
     canExecute: (editor: Editor, cmd: any) => (editor.can() as any).toggleHeading({ level: cmd.level }),
@@ -92,6 +150,15 @@ export function createHeadingHandler() {
   }
 }
 
+/**
+ * A handler for links. Enabled when the editor can either set or unset one,
+ * so the button stays usable both to add a link and to remove the one under
+ * the caret.
+ *
+ * Returns the `{ canExecute, execute, isActive }` triple `EditorToolbar` binds
+ * a button to: whether to enable it, what to run, and whether to show it
+ * pressed.
+ */
 export function createLinkHandler() {
   return {
     canExecute: (editor: Editor) => {
@@ -133,6 +200,13 @@ export function createLinkHandler() {
   }
 }
 
+/**
+ * A handler for images.
+ *
+ * Returns the `{ canExecute, execute, isActive }` triple `EditorToolbar` binds
+ * a button to: whether to enable it, what to run, and whether to show it
+ * pressed.
+ */
 export function createImageHandler() {
   return {
     canExecute: (editor: Editor) => {
@@ -161,6 +235,13 @@ export function createImageHandler() {
   }
 }
 
+/**
+ * A handler for one of the three list types.
+ *
+ * Returns the `{ canExecute, execute, isActive }` triple `EditorToolbar` binds
+ * a button to: whether to enable it, what to run, and whether to show it
+ * pressed.
+ */
 export function createListHandler(listType: 'bulletList' | 'orderedList' | 'taskList') {
   const fnNameMap = {
     bulletList: 'toggleBulletList',
@@ -234,6 +315,15 @@ export function createListHandler(listType: 'bulletList' | 'orderedList' | 'task
   }
 }
 
+/**
+ * A handler that moves the block at `cmd.pos` up or down — what the drag
+ * handle's menu binds to. Disabled when there is no node at that position, or
+ * no sibling to swap with.
+ *
+ * Returns the `{ canExecute, execute, isActive }` triple `EditorToolbar` binds
+ * a button to: whether to enable it, what to run, and whether to show it
+ * pressed.
+ */
 export function createMoveHandler(direction: 'up' | 'down') {
   return {
     canExecute: (editor: Editor, cmd: any) => {
@@ -277,6 +367,11 @@ export function createMoveHandler(direction: 'up' | 'down') {
   }
 }
 
+/**
+ * The full set of built-in handlers, keyed by the `type` an editor item
+ * declares. `mapEditorItems` merges a caller's own over these, so a custom
+ * handler can replace a built-in under the same key.
+ */
 export function createHandlers(): EditorHandlers {
   return {
     mark: createMarkHandler(),
@@ -416,6 +511,18 @@ export function createHandlers(): EditorHandlers {
   }
 }
 
+/**
+ * Binds a toolbar or menu definition to a live editor: each item's `type` is
+ * looked up in the handlers, and the resulting `disabled` / `active` /
+ * `onSelect` are attached.
+ *
+ * Grouped input (an array of arrays) comes back grouped, so a toolbar's
+ * separators survive.
+ *
+ * @param editor The editor the items act on.
+ * @param items Item definitions, flat or grouped.
+ * @param customHandlers Handlers merged over the built-ins, by key.
+ */
 export function mapEditorItems(
   editor: Editor,
   items: (Partial<EditorItem> & Record<string, any>)[] | (Partial<EditorItem> & Record<string, any>)[][],
@@ -467,6 +574,14 @@ export function mapEditorItems(
   })
 }
 
+/**
+ * Assembles the floating-ui middleware chain for the editor's popups from a
+ * plain options object.
+ *
+ * The order is fixed here rather than taken from the caller — offset, flip,
+ * shift, size, autoPlacement, hide, inline — because floating-ui applies
+ * middleware in sequence and the result depends on it.
+ */
 export function buildFloatingUIMiddleware(options: FloatingUIOptions): Middleware[] {
   const middleware: Middleware[] = []
 

--- a/src/runtime/utils/form.ts
+++ b/src/runtime/utils/form.ts
@@ -3,6 +3,10 @@ import type { Struct } from 'superstruct'
 import type { FormSchema, ValidateReturnSchema } from '../types/form'
 import { assertNoPrototypeKeys, isPrototypeKey, ownContainer } from './prototype-guard'
 
+/**
+ * Whether a schema is superstruct's, detected by shape — superstruct exports
+ * no brand to check.
+ */
 export function isSuperStructSchema(schema: any): schema is Struct<any, any> {
   return (
     'schema' in schema
@@ -12,10 +16,20 @@ export function isSuperStructSchema(schema: any): schema is Struct<any, any> {
   )
 }
 
+/**
+ * Whether a schema implements Standard Schema, which Zod, Valibot, Yup, Joi
+ * and Arktype all do — the one check that covers every validator `Form`
+ * supports except superstruct.
+ */
 export function isStandardSchema(schema: any): schema is StandardSchemaV1 {
   return '~standard' in schema
 }
 
+/**
+ * Runs a Standard Schema over the form state and flattens its issues into the
+ * `{ name, message }` pairs `Form` renders, joining each issue's path with
+ * dots so it matches a `FormField`'s `name`.
+ */
 export async function validateStandardSchema(
   state: any,
   schema: StandardSchemaV1
@@ -58,6 +72,11 @@ async function validateSuperstructSchema(state: any, schema: Struct<any, any>): 
   }
 }
 
+/**
+ * Validates the form state with whichever library the schema came from.
+ *
+ * @throws {Error} if the schema is neither Standard Schema nor superstruct.
+ */
 export function validateSchema<T extends object>(state: T, schema: FormSchema<T>): Promise<ValidateReturnSchema<typeof state>> {
   if (isStandardSchema(schema)) {
     return validateStandardSchema(state, schema)
@@ -68,6 +87,15 @@ export function validateSchema<T extends object>(state: T, schema: FormSchema<T>
   }
 }
 
+/**
+ * Reads a dotted `path` out of the form state — the read half of the same
+ * traversal `setAtPath` writes with.
+ *
+ * Prototype-safe on the same terms as `get()` in `utils/index.ts`: an
+ * inherited key is refused, a field the form owns and happens to have named
+ * `constructor` still reads. No `path` returns `data` unchanged, which is how
+ * a `FormField` with no `name` reads the whole state.
+ */
 export function getAtPath<T extends object>(
   data: T,
   path?: string

--- a/src/runtime/utils/index.ts
+++ b/src/runtime/utils/index.ts
@@ -5,6 +5,10 @@ import type { IconComponent } from '../types/icons'
 import icons from '../dictionary/icons'
 import { assertNoPrototypeKeys, isPrototypeKey, ownContainer } from './prototype-guard'
 
+/**
+ * A new object with only `keys` copied across. Shallow; missing keys become
+ * `undefined` rather than being skipped.
+ */
 export function pick<Data extends object, Keys extends keyof Data>(data: Data, keys: Keys[]): Pick<Data, Keys> {
   const result = {} as Pick<Data, Keys>
 
@@ -15,6 +19,11 @@ export function pick<Data extends object, Keys extends keyof Data>(data: Data, k
   return result
 }
 
+/**
+ * A shallow copy of `data` without `keys`. Used throughout the components to
+ * split a props object into the part that is forwarded and the part that is
+ * consumed.
+ */
 export function omit<Data extends object, Keys extends keyof Data>(data: Data, keys: Keys[]): Omit<Data, Keys> {
   const result = { ...data }
 
@@ -37,6 +46,19 @@ function toPath(path: (string | number)[] | string): (string | number)[] {
   })
 }
 
+/**
+ * Reads a nested value by path — `'user.address.city'` or
+ * `['items', 0, 'label']` — returning `defaultValue` if any step is missing.
+ *
+ * Prototype-safe: a step that is not the object's **own** property is refused,
+ * so a path through `constructor` or `__proto__` cannot hand back a live
+ * intrinsic. A data model may legitimately carry a field named `constructor`,
+ * which is why the check is on ownership rather than on the name (#92).
+ *
+ * @param object The object to read from.
+ * @param path Dot-notation string, or an array of keys and indices.
+ * @param defaultValue Returned when the path does not resolve.
+ */
 export function get(object: Record<string, any> | undefined, path: (string | number)[] | string, defaultValue?: any): any {
   let result: any = object
 
@@ -78,6 +100,17 @@ export function get(object: Record<string, any> | undefined, path: (string | num
  * caller's data model ends up in a state they do not believe it is in either
  * way, and an exception is the outcome they can catch.
  */
+/**
+ * Writes a nested value by path, creating plain objects along the way.
+ *
+ * Prototype-safe on the same terms as `get`: it descends only through own
+ * properties, so `set({}, 'toString.x', 1)` cannot reach a shared intrinsic
+ * (#92).
+ *
+ * @param object The object to write into. Mutated.
+ * @param path Dot-notation string, or an array of keys and indices.
+ * @param value The value to write.
+ */
 export function set(object: Record<string, any>, path: (string | number)[] | string, value: any): void {
   const keys = toPath(path)
 
@@ -97,15 +130,38 @@ export function set(object: Record<string, any>, path: (string | number)[] | str
  * Index of the first item whose `valueKey` field strictly equals `value`.
  * Timeline and Stepper resolve their active item through this.
  */
+/**
+ * Index of the item whose `valueKey` equals `value`, or `-1`. Compared by
+ * identity, not by `compare` — this is the lookup for a `modelValue` that is
+ * already a primitive.
+ */
 export function itemValueIndex<T>(items: T[], value: unknown, valueKey: string): number {
   return items.findIndex(item => get(item as Record<string, any>, valueKey) === value)
 }
 
+/**
+ * `parseFloat`, but returns the input unchanged when it is not numeric — so an
+ * empty input stays `''` instead of becoming `NaN`, and a numeric string
+ * arrives as a number.
+ */
 export function looseToNumber(val: any): any {
   const n = Number.parseFloat(val)
   return Number.isNaN(n) ? val : n
 }
 
+/**
+ * Whether two selection values are the same, as the menus and selects mean it.
+ *
+ * Strings compare by identity. Objects compare deeply by default, which is
+ * what makes a `modelValue` rebuilt from JSON still match the item it came
+ * from. `comparator` narrows that: a key name compares by that field alone —
+ * `'id'` is the usual answer for records — and a function decides for itself.
+ * `undefined` on either side is never equal to anything.
+ *
+ * @param value The candidate.
+ * @param currentValue The current selection.
+ * @param comparator A key to compare by, or a predicate.
+ */
 export function compare<T>(value?: T, currentValue?: T, comparator?: string | ((a: T, b: T) => boolean)) {
   if (value === undefined || currentValue === undefined) {
     return false
@@ -126,6 +182,13 @@ export function compare<T>(value?: T, currentValue?: T, comparator?: string | ((
   return isEqual(value, currentValue)
 }
 
+/**
+ * Whether a value counts as "nothing selected".
+ *
+ * `false` and `0` are values, not emptiness — a checkbox bound to `false` is
+ * answered, and a quantity of `0` is a quantity. Empty strings, empty arrays,
+ * empty objects, `null` and `undefined` are empty.
+ */
 export function isEmpty(value: unknown): boolean {
   if (value == null) {
     return true
@@ -163,6 +226,22 @@ export function isEmpty(value: unknown): boolean {
   return false
 }
 
+/**
+ * The label to show for a selected value.
+ *
+ * Looks the value up in `items` and reads `labelKey` off what it finds. A
+ * value with no matching item is displayed as-is, so a free-typed entry in an
+ * `InputMenu` still reads back — that fallback is the reason this is not a
+ * one-line `find`.
+ *
+ * @param items The list to search.
+ * @param value The current selection.
+ * @param options Where to find an item's value and label.
+ * @param options.valueKey Field holding an item's value. Omit when items are
+ *   primitives.
+ * @param options.labelKey Field holding an item's label.
+ * @param options.by Passed to `compare` as its comparator.
+ */
 export function getDisplayValue<T extends Array<any>, V>(
   items: T,
   value: V | undefined | null,
@@ -202,6 +281,11 @@ export function getDisplayValue<T extends Array<any>, V>(
   return String(source)
 }
 
+/**
+ * Whether an items array is grouped (an array of arrays) rather than flat.
+ * A type guard, so the caller can branch without a cast — the menus accept
+ * both shapes and render a separator between groups.
+ */
 export function isArrayOfArray<
   A extends any[] | any[][]
 >(item: A): item is A extends Array<infer T>
@@ -212,6 +296,12 @@ export function isArrayOfArray<
   return Array.isArray(item[0])
 }
 
+/**
+ * Joins the class an `app.config` theme override contributes with the one
+ * passed as a prop, in that order — so the prop wins under `twMerge`. Returns
+ * `''` when neither is set, which keeps an empty `class` attribute out of the
+ * markup.
+ */
 export function mergeClasses(appConfigClass?: string | string[], propClass?: string) {
   if (!appConfigClass && !propClass) {
     return ''
@@ -223,6 +313,14 @@ export function mergeClasses(appConfigClass?: string | string[], propClass?: str
   ].filter(Boolean)
 }
 
+/**
+ * Flattens a slot's rendered children into plain text, descending through
+ * nested elements and default slots.
+ *
+ * Needed where a component has to know what its slot says rather than just
+ * render it — a `Kbd` reading its own key, a tooltip falling back to its
+ * trigger's label.
+ */
 export function getSlotChildrenText(children: any) {
   return children.map((node: any) => {
     if (!node.children || typeof node.children === 'string') return node.children || ''
@@ -268,6 +366,14 @@ function walkPromptElement(node: Node): string {
   return inner
 }
 
+/**
+ * Reads an element's visible text the way a chat prompt means it: block-level
+ * tags become line breaks, runs of blank lines collapse to one, and trailing
+ * whitespace goes.
+ *
+ * `textContent` would run the paragraphs together; `innerText` is not
+ * available server-side and depends on layout.
+ */
 export function extractPromptText(el: Element | null | undefined): string {
   if (!el) return ''
   return walkPromptElement(el)
@@ -289,6 +395,12 @@ export function resolveIcon(name?: string | null): IconComponent | undefined {
   return (icons as Record<string, IconComponent>)[name]
 }
 
+/**
+ * Resolves a `tailwind-variants` slot object into plain class strings,
+ * threading the caller's per-slot `b24ui` overrides through each slot function.
+ *
+ * What turns `b24ui.base({ class: … })` into something a template can bind.
+ */
 export function transformUI(ui: any, uiProp?: any) {
   return Object.entries(ui).reduce((acc, [key, value]) => {
     acc[key] = typeof value === 'function' ? value({ class: uiProp?.[key] }) : value
@@ -296,6 +408,14 @@ export function transformUI(ui: any, uiProp?: any) {
   }, { ...(uiProp || {}) })
 }
 
+/**
+ * Prefixes an absolute path with the app's `baseURL`, unless it already
+ * carries it.
+ *
+ * Protocol-relative (`//host/…`) and external URLs are left alone. Idempotent,
+ * so a path that has been through this once does not gain a second prefix —
+ * which is what happens when a link is resolved in both a parent and a child.
+ */
 export function resolveBaseURL(path?: string, baseURL?: string): string | undefined {
   if (path?.startsWith('/') && !path.startsWith('//')) {
     const _base = withLeadingSlash(withTrailingSlash(baseURL || '/'))

--- a/src/runtime/utils/index.ts
+++ b/src/runtime/utils/index.ts
@@ -50,10 +50,15 @@ function toPath(path: (string | number)[] | string): (string | number)[] {
  * Reads a nested value by path — `'user.address.city'` or
  * `['items', 0, 'label']` — returning `defaultValue` if any step is missing.
  *
- * Prototype-safe: a step that is not the object's **own** property is refused,
- * so a path through `constructor` or `__proto__` cannot hand back a live
- * intrinsic. A data model may legitimately carry a field named `constructor`,
- * which is why the check is on ownership rather than on the name (#92).
+ * Prototype-safe against the reads that matter: a step naming `__proto__`,
+ * `constructor` or `prototype` is refused *unless the object owns it*, so a
+ * path cannot hand back a live intrinsic. A data model may legitimately carry
+ * a field called `constructor` — parsed from JSON, say — which is why the
+ * check is ownership on top of the name rather than the name alone (#92).
+ *
+ * Only those three names are checked. `get({}, 'toString')` still returns the
+ * inherited function; reads are total by contract and that one is harmless,
+ * while `set()` refuses the same path outright because a write is not.
  *
  * @param object The object to read from.
  * @param path Dot-notation string, or an array of keys and indices.
@@ -85,7 +90,7 @@ export function get(object: Record<string, any> | undefined, path: (string | num
 }
 
 /**
- * Assigns `value` at a dotted `path`, creating intermediate objects as it goes.
+ * Writes a nested value by path, creating plain objects along the way.
  *
  * Neither this nor `get()` is reachable from inside b24ui — nothing in `src/`
  * calls `set()`, and every `get()` path the components pass is an
@@ -94,22 +99,19 @@ export function get(object: Record<string, any> | undefined, path: (string | num
  * from somewhere less trustworthy. See `utils/prototype-guard.ts` for what is
  * being defended against.
  *
- * @throws {TypeError} if any path segment names `__proto__`, `constructor` or
- * `prototype`. Such a path writes through to a shared prototype rather than to
- * `object`, and unlike a read there is no sensible value to return instead: the
- * caller's data model ends up in a state they do not believe it is in either
- * way, and an exception is the outcome they can catch.
- */
-/**
- * Writes a nested value by path, creating plain objects along the way.
- *
- * Prototype-safe on the same terms as `get`: it descends only through own
- * properties, so `set({}, 'toString.x', 1)` cannot reach a shared intrinsic
- * (#92).
+ * Stricter than `get()` in both directions. The three prototype names are
+ * refused outright rather than only when inherited, and the walk descends only
+ * through *own* containers — copying an inherited one rather than writing
+ * through it — so `set({}, 'toString.x', 1)` cannot reach a shared intrinsic
+ * even though no segment of that path is a reserved word (#92).
  *
  * @param object The object to write into. Mutated.
  * @param path Dot-notation string, or an array of keys and indices.
  * @param value The value to write.
+ * @throws {TypeError} if any path segment names `__proto__`, `constructor` or
+ * `prototype`. Unlike a read there is no sensible value to return instead: the
+ * caller's data model ends up in a state they do not believe it is in either
+ * way, and an exception is the outcome they can catch.
  */
 export function set(object: Record<string, any>, path: (string | number)[] | string, value: any): void {
   const keys = toPath(path)
@@ -127,13 +129,11 @@ export function set(object: Record<string, any>, path: (string | number)[] | str
 }
 
 /**
- * Index of the first item whose `valueKey` field strictly equals `value`.
+ * Index of the first item whose `valueKey` field equals `value`, or `-1`.
  * Timeline and Stepper resolve their active item through this.
- */
-/**
- * Index of the item whose `valueKey` equals `value`, or `-1`. Compared by
- * identity, not by `compare` — this is the lookup for a `modelValue` that is
- * already a primitive.
+ *
+ * Compared by identity, not by `compare()` — this is the lookup for a
+ * `modelValue` that is already a primitive.
  */
 export function itemValueIndex<T>(items: T[], value: unknown, valueKey: string): number {
   return items.findIndex(item => get(item as Record<string, any>, valueKey) === value)
@@ -152,7 +152,9 @@ export function looseToNumber(val: any): any {
 /**
  * Whether two selection values are the same, as the menus and selects mean it.
  *
- * Strings compare by identity. Objects compare deeply by default, which is
+ * Strings compare by identity, and that check runs *first* — a `comparator`
+ * is not consulted for a string value, so a predicate meant to loosen string
+ * matching has no effect here. Objects compare deeply by default, which is
  * what makes a `modelValue` rebuilt from JSON still match the item it came
  * from. `comparator` narrows that: a key name compares by that field alone —
  * `'id'` is the usual answer for records — and a function decides for itself.

--- a/src/runtime/utils/link-keys.ts
+++ b/src/runtime/utils/link-keys.ts
@@ -1,3 +1,10 @@
+/**
+ * The props `Link` owns, in one place.
+ *
+ * Every component that can render as a link splits its props on this list, so
+ * a prop added to `Link` reaches all of them by being added here — and cannot
+ * be forwarded by one component and swallowed by another.
+ */
 export const linkKeys = [
   'active',
   'activeClass',

--- a/src/runtime/utils/link.ts
+++ b/src/runtime/utils/link.ts
@@ -3,6 +3,15 @@ import { isEqual, diff } from 'ohash/utils'
 import type { LinkProps } from '../components/Link.vue'
 import { linkKeys } from './link-keys'
 
+/**
+ * Re-exported from `./link-keys` so a consumer importing from `b24ui/utils`
+ * finds it beside `pickLinkProps`, which is the function that consumes it.
+ *
+ * The list itself lives in its own module so a reader of the names does not
+ * have to load `reactivePick` and `ohash` with them — which is why
+ * `link-passthrough.spec.ts` imports `./link-keys` directly rather than going
+ * through here.
+ */
 export { linkKeys }
 
 /**

--- a/src/runtime/utils/link.ts
+++ b/src/runtime/utils/link.ts
@@ -5,6 +5,12 @@ import { linkKeys } from './link-keys'
 
 export { linkKeys }
 
+/**
+ * Splits the link-shaped props out of a component's own, so `Button`, `Badge`
+ * and the rest can forward them to `Link` without listing them each time.
+ *
+ * Keyed on `linkKeys`, which is the single list those components share.
+ */
 export function pickLinkProps(link: LinkProps & { [key: string]: any }) {
   const keys = Object.keys(link)
 
@@ -20,6 +26,12 @@ export function pickLinkProps(link: LinkProps & { [key: string]: any }) {
   return reactivePick(link, ...propsToInclude)
 }
 
+/**
+ * Whether every key of `item2` matches the same key of `item1` — used to
+ * decide active state for a link whose `to` is a route object: the current
+ * route carries more than the link declares, and only what the link declares
+ * should have to match.
+ */
 export function isPartiallyEqual(item1: any, item2: any) {
   const diffedKeys = diff(item1, item2).reduce((filtered, q) => {
     if (q.type === 'added') {

--- a/src/runtime/utils/locale.ts
+++ b/src/runtime/utils/locale.ts
@@ -13,10 +13,25 @@ export type LocaleContext<M> = {
   t: Translator
 }
 
+/**
+ * Binds a `t()` to a locale that may still change — the ref is read on every
+ * call, so switching language re-renders without rebuilding the translator.
+ */
 export function buildTranslator<M>(locale: MaybeRef<Locale<M>>): Translator {
   return (path, option) => translate(path, option, unref(locale))
 }
 
+/**
+ * Looks up `messages.<path>` in a locale and fills its `{placeholders}`.
+ *
+ * A missing message falls back to the path itself, and a placeholder with no
+ * value is left as written — both so a gap shows up in the interface as the
+ * key that is missing rather than as an empty space.
+ *
+ * @param path Dotted message key, without the `messages.` prefix.
+ * @param option Values for the `{placeholders}` in the message.
+ * @param locale The locale to read from.
+ */
 export function translate<M>(path: string, option: undefined | TranslatorOption, locale: Locale<M>): string {
   const prop: string = get(locale, `messages.${path}`, path)
 
@@ -26,6 +41,10 @@ export function translate<M>(path: string, option: undefined | TranslatorOption,
   )
 }
 
+/**
+ * Assembles what `useLocale()` hands back: a bound `t()` plus reactive `lang`,
+ * `code`, `dir` and the `locale` itself.
+ */
 export function buildLocaleContext<M>(locale: MaybeRef<Locale<M>>): LocaleContext<M> {
   const lang = computed(() => unref(locale).name)
   const code = computed(() => unref(locale).code)

--- a/test/utils/jsdoc-coverage.spec.ts
+++ b/test/utils/jsdoc-coverage.spec.ts
@@ -1,0 +1,77 @@
+import { readdirSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, it, expect } from 'vitest'
+
+/**
+ * `./composables` and `./utils` are published `exports` paths, so every symbol
+ * they hand out is a symbol somebody hovers in an editor. #89 measured what
+ * that hover said: 11 of 22 composable functions documented, 17 of 58 utils,
+ * and not one of the fifteen injection keys.
+ *
+ * A sweep fixes that once. This keeps it fixed — the next export arrives with
+ * a doc block or with a failing test, which is cheaper than another audit.
+ *
+ * Deliberately not a lint rule: `jsdoc/require-jsdoc` would police every file
+ * in the repository, and the claim here is narrower than that. It is about the
+ * two directories a consumer can import from.
+ */
+const ROOTS = ['src/runtime/composables', 'src/runtime/utils']
+
+/** `export function foo` / `export const foo` — what a consumer can import. */
+const EXPORT = /^export\s+(?:async\s+)?(?:function|const)\s+([A-Za-z_$][\w$]*)/gm
+
+/** Every `.ts` under `dir`, recursively, `node_modules` pruned. */
+function sources(dir: string): string[] {
+  return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const path = join(dir, entry.name)
+    if (entry.isDirectory()) return entry.name === 'node_modules' ? [] : sources(path)
+    return entry.name.endsWith('.ts') && !entry.name.endsWith('.d.ts') ? [path] : []
+  })
+}
+
+/**
+ * Exports with no doc block immediately above them.
+ *
+ * "Immediately" is the whole check: a comment separated by another statement
+ * documents that statement, and TypeScript shows the reader nothing.
+ */
+function undocumented(file: string): string[] {
+  const source = readFileSync(file, 'utf8')
+  const lines = source.split('\n')
+  const missing: string[] = []
+
+  for (const match of source.matchAll(EXPORT)) {
+    let line = source.slice(0, match.index).split('\n').length - 2
+    while (line >= 0 && lines[line]!.trim() === '') line--
+    if (line < 0 || !lines[line]!.trim().endsWith('*/')) missing.push(match[1]!)
+  }
+
+  return missing
+}
+
+describe('published composables and utils', () => {
+  const files = ROOTS.flatMap(sources)
+
+  it('are found at all', () => {
+    // Without this the assertion below passes on an empty list, which is how a
+    // guard over a directory that moved reads exactly like a guard that holds.
+    expect(files.length).toBeGreaterThan(40)
+  })
+
+  it('document every exported symbol', () => {
+    const gaps = files
+      .map(file => [file, undocumented(file)] as const)
+      .filter(([, names]) => names.length > 0)
+      .map(([file, names]) => `${file}: ${names.join(', ')}`)
+      .sort()
+
+    expect(gaps, [
+      'These are exported from a published path and have no doc block, so an',
+      'editor shows the reader a signature and nothing else (#89).',
+      '',
+      'A line saying what it is for is enough; @param and @returns where the',
+      'signature does not already say it. An injection key needs one line: who',
+      'provides it and who reads it.'
+    ].join('\n')).toEqual([])
+  })
+})

--- a/test/utils/jsdoc-coverage.spec.ts
+++ b/test/utils/jsdoc-coverage.spec.ts
@@ -17,8 +17,61 @@ import { describe, it, expect } from 'vitest'
  */
 const ROOTS = ['src/runtime/composables', 'src/runtime/utils']
 
-/** `export function foo` / `export const foo` — what a consumer can import. */
-const EXPORT = /^export\s+(?:async\s+)?(?:function|const)\s+([A-Za-z_$][\w$]*)/gm
+/**
+ * The export forms this guard understands, and the names each one publishes.
+ *
+ * The first version of this file matched only `export function|const <name>`,
+ * which read as "every export is covered" while three live ones were invisible
+ * to it: `export { provideThemeContext }`, `export { linkKeys }`, and
+ * `export const [useDashboard, provideDashboardContext] = createContext(…)`.
+ * Two of those were undocumented; the third was a re-export whose original is
+ * documented elsewhere, and it is covered here anyway — see below.
+ * A guard that reports 100% while missing exports is worse than no guard, so
+ * every form the language offers is listed here even where the codebase has no
+ * instance of it yet — `export default`, `export class`, `export let|var` and
+ * generator functions arrive documented or arrive red.
+ *
+ * `export type` / `export interface` are deliberately absent. A type's shape is
+ * its documentation and TypeScript renders it on hover in full; the claim being
+ * guarded is about values, whose signature says nothing about intent.
+ */
+const EXPORT_FORMS: { re: RegExp, names: (m: RegExpMatchArray) => string[] }[] = [
+  // export function foo / export async function* foo / export class Foo /
+  // export const|let|var foo
+  {
+    re: /^export\s+(?:async\s+)?(?:function\s*\*|function|class|const|let|var)\s+([a-z_$][\w$]*)/gim,
+    names: m => [m[1]!]
+  },
+  // export const [a, b] = … / export const { a, b } = …
+  {
+    re: /^export\s+(?:const|let|var)\s*[[{]([^\]}]+)[\]}]\s*=/gm,
+    names: m => bindings(m[1]!)
+  },
+  // export { a, b as c } — but not `export { type T }` or `export type { … }`.
+  // A re-export is included on purpose: it is a line a reader lands on, and
+  // one sentence saying why the symbol is surfaced here beats teaching this
+  // file to parse import clauses well enough to recognise one.
+  {
+    re: /^export\s*\{([^}]*)\}/gm,
+    names: m => bindings(m[1]!)
+  },
+  // export default … — anonymous to the importer, so it needs the prose more
+  // than a named export does, not less.
+  {
+    re: /^export\s+default\b/gm,
+    names: () => ['default']
+  }
+]
+
+/** Names in a `{ … }` / `[ … ]` list, minus `type` specifiers and aliases. */
+function bindings(list: string): string[] {
+  return list
+    .split(',')
+    .map(entry => entry.trim())
+    .filter(entry => entry.length > 0 && !entry.startsWith('type '))
+    .map(entry => entry.split(/\s+as\s+/).pop()!.trim())
+    .filter(entry => /^[a-z_$][\w$]*$/i.test(entry))
+}
 
 /** Every `.ts` under `dir`, recursively, `node_modules` pruned. */
 function sources(dir: string): string[] {
@@ -30,23 +83,54 @@ function sources(dir: string): string[] {
 }
 
 /**
- * Exports with no doc block immediately above them.
+ * Whether a JSDoc block sits immediately above line `index`.
  *
- * "Immediately" is the whole check: a comment separated by another statement
- * documents that statement, and TypeScript shows the reader nothing.
+ * "Immediately" is half the check: a comment separated by another *statement*
+ * documents that statement, and TypeScript shows the reader nothing. Blank
+ * lines are stepped over, and so is a one-line non-JSDoc annotation such as
+ * `@__NO_SIDE_EFFECTS__`, because the compiler steps over it too — it gathers
+ * JSDoc from the whole leading trivia, so the hover is unaffected by a bundler
+ * hint sitting between the block and the declaration.
+ *
+ * The other half is that it has to be a *JSDoc* block. Checking only for the
+ * closing delimiter accepted any block comment, which is how `defineLocale`
+ * and `extendLocale` passed this file's first version on that same
+ * `@__NO_SIDE_EFFECTS__` annotation while carrying no prose at all. Stepping
+ * over it and counting it are different things; only a comment opening with
+ * two stars is one an editor renders.
  */
+function isDocumented(lines: string[], index: number): boolean {
+  const skippable = (text: string) =>
+    text === '' || (text.startsWith('/*') && !text.startsWith('/**') && text.endsWith('*/'))
+
+  let line = index - 1
+  while (line >= 0 && skippable(lines[line]!.trim())) line--
+  if (line < 0) return false
+
+  const closing = lines[line]!.trim()
+  if (closing.startsWith('/**')) return closing.endsWith('*/')
+  if (closing !== '*/') return false
+
+  let open = line
+  while (open >= 0 && !lines[open]!.trim().startsWith('/*')) open--
+  return open >= 0 && lines[open]!.trim().startsWith('/**')
+}
+
+/** Exports with no doc block immediately above them. */
 function undocumented(file: string): string[] {
   const source = readFileSync(file, 'utf8')
   const lines = source.split('\n')
-  const missing: string[] = []
+  const missing = new Set<string>()
 
-  for (const match of source.matchAll(EXPORT)) {
-    let line = source.slice(0, match.index).split('\n').length - 2
-    while (line >= 0 && lines[line]!.trim() === '') line--
-    if (line < 0 || !lines[line]!.trim().endsWith('*/')) missing.push(match[1]!)
+  for (const form of EXPORT_FORMS) {
+    for (const match of source.matchAll(form.re)) {
+      const index = source.slice(0, match.index).split('\n').length - 1
+      if (isDocumented(lines, index)) continue
+      for (const name of form.names(match)) missing.add(name)
+    }
   }
 
-  return missing
+  return [...missing].sort()
 }
 
 describe('published composables and utils', () => {
@@ -71,7 +155,13 @@ describe('published composables and utils', () => {
       '',
       'A line saying what it is for is enough; @param and @returns where the',
       'signature does not already say it. An injection key needs one line: who',
-      'provides it and who reads it.'
+      'provides it and who reads it.',
+      '',
+      'The block has to open with /** and sit immediately above the export.',
+      'Blank lines and a one-line bundler annotation are stepped over; another',
+      'statement is not, and an annotation does not itself count as prose.',
+      'Documenting several exports under one shared block flags all but the',
+      'first, on purpose: each symbol is hovered on its own.'
     ].join('\n')).toEqual([])
   })
 })


### PR DESCRIPTION
### Linked issue

Resolves #89

### Type of change

- [x] Documentation (updates to the documentation or readme)
- [ ] Bug fix (a non-breaking change that fixes an issue)
- [ ] Enhancement (improving an existing functionality)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Chore (updates to the build process or auxiliary tools and libraries)
- [ ] Revert (undoing a merged change — retitle this PR `revert(Scope): ...`)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

> `src/` gains comments only. No behaviour change.

### Description

`./composables` and `./utils` are published `exports` paths, so every symbol they hand out is one somebody hovers in an editor.

Re-measured rather than taken from the issue, which is two months old and counted differently — it looked at exported *functions*, which leaves out the injection keys:

| | functions | injection keys |
|---|---|---|
| `src/runtime/composables` | 11/22 | **0/14** |
| `src/runtime/utils` | 17/58 | 0/1 |

Both directories are at **100%** now — and unlike the first version of this PR, that is now measured by a guard that can see every export form. See below.

Not a template pass. Each block says what the thing is for, and where the signature does not already say it, what the arguments mean. The ones that carry a worked example are the four the issue named — `defineShortcuts`, `extractShortcuts`, `useToast`, `useOverlay` — plus `useFileUpload`, `useConfetti`, `defineLocale` and `extendLocale`.

### The part that was only visible from the call site

Five composables had a **documented private implementation and an undocumented export**:

```ts
/**
 * Device Reactivity: Platform and Screen Information
 */
const _useDevice = () => { … }

export const useDevice = /* @__PURE__ */ createSharedComposable(_useDevice)
```

TypeScript resolves the export, so the hover on `useDevice()` was empty — the doc block above `_useDevice` documents `_useDevice`. Same for `useKbd`, `useLocale`, `useConfetti` and `useContentSearch`. Counting "files with a doc comment" would have called all five documented.

The **fifteen injection keys** had nothing at all. For `formFieldInjectionKey` and its seven siblings that is the difference between a name and a contract — what a `Form` provides, and what a control under it is entitled to read.

### The guard reported 100% while missing three exports

The first version matched only `export function|const <name>`. That is a guard that reads as complete coverage and is not, which is worse than no guard. Three live exports were invisible to it:

- `export { provideThemeContext }` — published, and genuinely undocumented.
- `export const [useDashboard, provideDashboardContext] = createContext(…)` — two exports on one line, neither matched.
- `export { linkKeys }` — a re-export, documented at its origin.

It also accepted any block comment as documentation, because it only tested that the line above ended with the closing delimiter: `defineLocale` and `extendLocale` passed on a bare `@__NO_SIDE_EFFECTS__` annotation while carrying no prose at all.

Every form is now recognised — list, destructuring, `default`, `class`, `let`/`var`, generators — the block must open with `/**`, and a one-line bundler annotation between the block and the declaration is *stepped over* rather than counted, which is what the compiler does with it. Verified by mutation, five breakages each turning it red on its own:

| mutation | result |
|---|---|
| doc removed from `export { provideThemeContext }` | red |
| doc removed from the destructured `createContext` pair | red |
| `/**` downgraded to `/*` on `defineLocale` | red |
| undocumented `export class` + `export default` added | red |
| undocumented `export let` added | red |

The import-clause parsing that would have let it skip re-exports was dropped: one sentence on the re-export line is cheaper, and stricter, than teaching a spec to recognise one.

### Six blocks described behaviour the code does not have

Four were caught before the first commit, by reading the `return` rather than the name:

| symbol | first draft said | actually |
|---|---|---|
| `useContentSearch` | "the term, the grouped results" | returns `open` and six mappers |
| `useLocale` | `t`, `code`, `dir` | also `lang` and `locale` |
| `buildFloatingUIMiddleware` | four middlewares | seven, in a fixed order |
| `useScrollspy` | "`observerCallback`-driven" | does not return it |

Six more were caught in review, and each was checked against the implementation before rewriting:

| symbol | said | actually |
|---|---|---|
| `useResizable` | sizes are percentages | `unit` defaults to `'px'` |
| `createSetHandler` | never reports active | calls `editor.isActive(name)` |
| `get()` | any non-own step is refused | only the three prototype names are |
| `useScrollShadow` | `size` is a CSS length | a bare pixel number; `'2rem'` builds `2rempx` |
| `useFileUpload` | the drop zone enforces `accept` | extension entries are filtered out of its list |
| `kbdKeysMap` | the closed set `Kbd` and `defineShortcuts` accept | `Kbd` passes unknown names through; `defineShortcuts` never reads it |

Also from review: `set()` and `itemValueIndex` had a second block stacked on the first and `set()`'s dropped its `@throws`; `useFilter` omitted `filterGroups` from `@returns`; `useLocale` pointed `@see` at another composable's page; and ten `create*Handler` blocks repeated one paragraph verbatim, now stated once for the family.

### Keeping it

`test/utils/jsdoc-coverage.spec.ts` — an export from either directory arrives with a doc block, or with a failing test.

Deliberately a spec rather than `jsdoc/require-jsdoc`: the lint rule would police the whole repository, and the claim here is narrower than that — it is about the two directories a consumer can import from. It also asserts it found files at all, because a guard over a directory that moved reads exactly like a guard that holds.

"Immediately above" is half the check. A comment separated from its export by another statement documents that statement, and the reader sees nothing — which is precisely how the five shared composables above looked documented while not being. The other half is that it has to be JSDoc.

`export type` / `export interface` are out of scope on purpose: a type's shape is its documentation and the editor renders it in full.

### Checklist

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.

Gate: `lint` 0 · `typecheck` 0 · `test` 316/316 (7440) · `test:module` 3/3 · `test:workflows` 49/0.