### PR TITLE
docs(security): add SECURITY.md now that a private channel exists

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -3,6 +3,9 @@
 # outside, where the missing field is usually the reproduction.
 blank_issues_enabled: true
 contact_links:
+  - name: Report a security vulnerability
+    url: https://github.com/bitrix24/b24ui/security/advisories/new
+    about: Privately, not through these forms. Everything here is public.
   - name: Documentation
     url: https://bitrix24.github.io/b24ui/
     about: Component reference, theming, and the getting-started guides.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,11 +82,8 @@ person, and take the hint when someone asks you to drop it.
 
 ## Security
 
-**Please do not open a public issue for a vulnerability.**
+**Please do not open a public issue for a vulnerability.** Report it privately
+through [Security → Report a vulnerability](https://github.com/bitrix24/b24ui/security/advisories/new).
 
-This repository does not yet publish a private channel to send one to, which
-means there is currently nowhere good for a report to go — and a public issue
-is the one place it should not go, because it discloses the problem to
-everyone before there is a fix. If you have found something security-sensitive,
-hold it until this section names a channel. That is the next thing to land
-here.
+[SECURITY.md](SECURITY.md) covers what to include, what counts as a
+vulnerability in a component library, and which versions get fixes.

--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ Learn more in the [installation guide](https://bitrix24.github.io/b24ui/docs/get
 
 Thank you for considering contributing to Bitrix24 UI. Here are a few ways you can get involved:
 
+- **Security**: found a vulnerability? [Report it privately](https://github.com/bitrix24/b24ui/security/advisories/new) — not through the forms below. [SECURITY.md](https://github.com/bitrix24/b24ui/blob/main/SECURITY.md) says what counts.
 - **Reporting bugs**: [open a bug report](https://github.com/bitrix24/b24ui/issues/new?template=bug-report.yml). The form asks for a reproduction, and that is the field that decides whether the report can be acted on — see [reporting a bug](https://github.com/bitrix24/b24ui/blob/main/CONTRIBUTING.md#reporting-a-bug).
 - **Suggestions**: [open a feature request](https://github.com/bitrix24/b24ui/issues/new?template=feature-request.yml). Have any thoughts to enhance Bitrix24 UI? We'd love to hear them.
 - **Code**: [CONTRIBUTING.md](https://github.com/bitrix24/b24ui/blob/main/CONTRIBUTING.md) is the map — setup, the deep-dive guides, and what CI expects of a pull request. The [contribution guide](https://bitrix24.github.io/b24ui/docs/getting-started/contribution/) on the documentation site covers getting the repository running.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -24,7 +24,13 @@ Useful to include, in rough order of how much they help:
   reported there too — we will coordinate rather than leave it to you.
 
 We will acknowledge the report, investigate, and agree a disclosure timeline
-with you. Please give us a reasonable window before disclosing publicly.
+with you.
+
+This is a small project and there is no on-call rotation behind that sentence,
+so here is the number rather than "a reasonable window": **if you have heard
+nothing after 90 days, consider yourself free to disclose.** You should not
+have to guess how long to wait, and silence from us is not a reason for you to
+stay silent indefinitely.
 
 ## What counts as a vulnerability here
 
@@ -33,16 +39,20 @@ that hold a Bitrix24 portal's credentials, so the interesting failures are the
 ones that cross that boundary:
 
 - **Markup that escapes escaping.** A prop, slot or `items` value that reaches
-  the DOM unescaped — a label, a link `to`, a description rendered as HTML —
-  is script execution in a page holding a portal session.
+  the DOM unescaped is script execution in a page holding a portal session.
+
+  `CommandPalette`'s `labelHtml`, `suffixHtml` and `descriptionHtml` are the
+  exception: they render with `v-html` on purpose, their JSDoc says so, and
+  sanitising what you put in them is the caller's job. Unescaped output from
+  any *other* prop is a defect here.
 - **A `to` that becomes a `javascript:` URL**, or any link prop that can be
   steered somewhere the author did not intend.
 - **A secret reaching somewhere it should not** — a webhook path or an OAuth
   token surfacing in rendered output, in an error message, or in a value the
   component copies to the clipboard. A webhook URL is full access to a portal.
-- **Prototype pollution** through the dotted-path helpers on the public
-  `./utils` entry (`get`, `set`, `getAtPath`, `setAtPath`). These are guarded
-  and the guard is tested, so a way around it is worth reporting.
+- **Prototype pollution** through the dotted-path helpers — `get` and `set` on
+  `./utils`, `getAtPath` and `setAtPath` on `./utils/form`. All four share one
+  guard and the guard is tested, so a way around it is worth reporting.
 - **A dependency advisory that this package actually reaches.** Not every
   advisory in the tree is exploitable through this library; if you can show a
   path from our API to it, that is the part worth writing down.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,67 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+**Please do not open a public issue.**
+
+Report it privately through GitHub:
+[**Security → Report a vulnerability**](https://github.com/bitrix24/b24ui/security/advisories/new).
+The thread there is visible only to you and the maintainers until a fix is
+released, and it is where the advisory and any CVE are published from
+afterwards.
+
+You need a GitHub account, and your username is visible to the maintainers —
+private, not anonymous. What is private is the report: nothing about it reaches
+the public repository until we publish it together.
+
+Useful to include, in rough order of how much they help:
+
+- what an attacker can do with it, and to whom;
+- steps to reproduce, or a proof of concept;
+- the version of `@bitrix24/b24ui-nuxt` you saw it in;
+- whether it also reproduces in [Nuxt UI](https://github.com/nuxt/ui). This
+  library is a fork, and a vulnerability inherited from upstream has to be
+  reported there too — we will coordinate rather than leave it to you.
+
+We will acknowledge the report, investigate, and agree a disclosure timeline
+with you. Please give us a reasonable window before disclosing publicly.
+
+## What counts as a vulnerability here
+
+This is a UI component library. It renders in the browser, inside applications
+that hold a Bitrix24 portal's credentials, so the interesting failures are the
+ones that cross that boundary:
+
+- **Markup that escapes escaping.** A prop, slot or `items` value that reaches
+  the DOM unescaped — a label, a link `to`, a description rendered as HTML —
+  is script execution in a page holding a portal session.
+- **A `to` that becomes a `javascript:` URL**, or any link prop that can be
+  steered somewhere the author did not intend.
+- **A secret reaching somewhere it should not** — a webhook path or an OAuth
+  token surfacing in rendered output, in an error message, or in a value the
+  component copies to the clipboard. A webhook URL is full access to a portal.
+- **Prototype pollution** through the dotted-path helpers on the public
+  `./utils` entry (`get`, `set`, `getAtPath`, `setAtPath`). These are guarded
+  and the guard is tested, so a way around it is worth reporting.
+- **A dependency advisory that this package actually reaches.** Not every
+  advisory in the tree is exploitable through this library; if you can show a
+  path from our API to it, that is the part worth writing down.
+
+Things that are worth an ordinary issue rather than a security report: styling
+bugs, accessibility defects, a component that crashes on bad input without
+leaking anything, and advisories in dev-only dependencies that never ship.
+
+## Supported versions
+
+| Version | Supported |
+|---|---|
+| 2.x | ✅ |
+| 1.x and 0.x | ❌ |
+
+Fixes go to the latest published `2.x` and are released from `main`. There is
+no long-term-support branch: if you are on an older `2.x`, upgrading within the
+major is the fix.
+
+Node `^20.19.0 || >=22.12.0`, as `package.json` declares. A report against a
+Node version outside that range is still welcome, but the fix may be "upgrade
+Node".

--- a/test/utils/governance-files.spec.ts
+++ b/test/utils/governance-files.spec.ts
@@ -107,43 +107,87 @@ describe('issue forms', () => {
  * The security policy names one channel, and it is the one place a dead link
  * costs something real: a reporter who cannot reach it either gives up or
  * files publicly, which is the outcome the whole file exists to prevent.
- *
- * The advisory URL is repository-specific — copy this file to another
- * repository, or rename this one, and it silently points at somebody else's
- * inbox. Checked against `package.json`'s own repository field rather than
- * against a second copy of the name.
  */
 describe('SECURITY.md', () => {
   const policy = readFileSync(join(repoRoot, 'SECURITY.md'), 'utf8')
   const pkg = JSON.parse(readFileSync(join(repoRoot, 'package.json'), 'utf8'))
-  const slug = pkg.repository.url.replace(/^git\+https:\/\/github\.com\//, '').replace(/\.git$/, '')
+
+  /**
+   * `owner/repo`, from whichever shape npm accepted for `repository`.
+   *
+   * Read inside the tests rather than in the `describe` body: the string
+   * shorthand leaves `repository.url` undefined, and a `.replace()` on that
+   * throws during collection, which takes down every test in this file with an
+   * error that blames the wrong thing.
+   */
+  function slug(): string {
+    const field = typeof pkg.repository === 'string' ? pkg.repository : pkg.repository?.url
+    const match = String(field).match(/(?:github\.com[:/])?([\w.-]+\/[\w.-]+?)(?:\.git)?$/)
+    expect(match, `package.json repository is not a shape this can read: ${field}`).not.toBeNull()
+    return match![1]!
+  }
 
   it('points at the private channel for this repository', () => {
-    expect(policy).toContain(`https://github.com/${slug}/security/advisories/new`)
+    expect(policy).toContain(`https://github.com/${slug()}/security/advisories/new`)
   })
 
   it('is reachable from CONTRIBUTING.md', () => {
     const contributing = readFileSync(join(repoRoot, 'CONTRIBUTING.md'), 'utf8')
-    expect(contributing).toContain(`https://github.com/${slug}/security/advisories/new`)
+    expect(contributing).toContain(`https://github.com/${slug()}/security/advisories/new`)
     expect(contributing).toContain('SECURITY.md')
   })
 
-  it('does not tell anyone to open an issue for a vulnerability', () => {
-    // The failure mode is not hypothetical: `bitrix24/b24phpsdk` publishes a
-    // SECURITY.md whose entire reporting section reads "Create issue with
-    // vulnerability details". A policy that says that is worse than none,
-    // because it looks official.
-    const reporting = policy.slice(0, policy.indexOf('## What counts')).toLowerCase()
-    expect(reporting).toContain('do not open a public issue')
+  /**
+   * Every mention of the public tracker, spelled out.
+   *
+   * The first version of this check hunted for harmful phrasings — a verb list
+   * near the word "issue", with negated sentences filtered out. Four reviewers
+   * defeated it independently and none of them had to try hard: "use the issue
+   * tracker to publish the details" carries no verb from the list, "rather than
+   * waiting, just open an issue" is exempted by its own opening words, and
+   * anything below the heading the scan stopped at was never read at all.
+   *
+   * A denylist of phrasings cannot work, because the space of ways to say
+   * "post it publicly" is the English language. So this is inverted: the word
+   * may appear only where this list says it may, anywhere in the file. Adding a
+   * sentence that mentions issues at all turns it red, and the author either
+   * rewrites the sentence or adds it here on purpose. That is the whole point —
+   * `bitrix24/b24phpsdk` publishes a SECURITY.md whose reporting section reads
+   * "Create issue with vulnerability details", and no amount of pattern
+   * matching would have caught it as reliably as noticing the word.
+   */
+  const PERMITTED_MENTIONS = [
+    'do not open a public issue',
+    'worth an ordinary issue rather than a security report'
+  ]
 
-    // Negated sentences are dropped first — the required sentence above is
-    // itself "do not open a public issue", and a naive scan flags it. What is
-    // being looked for is an *instruction* to use one.
-    const instructions = reporting
-      .split(/(?<=[.:])\s/)
-      .filter(sentence => !/\b(?:do not|don't|never|rather than|instead of)\b/.test(sentence))
+  it('mentions the public tracker only where it is meant to', () => {
+    expect(policy.toLowerCase()).toContain(PERMITTED_MENTIONS[0])
 
-    expect(instructions.filter(sentence => /\b(?:create|open|file)\b[^.]{1,40}\bissue\b/.test(sentence))).toEqual([])
+    let remaining = policy.toLowerCase()
+    for (const permitted of PERMITTED_MENTIONS) remaining = remaining.split(permitted).join(' ')
+
+    const stray = [...remaining.matchAll(/\b(?:issues?|tickets?|tracker)\b/g)].map((match) => {
+      const from = Math.max(0, match.index - 60)
+      return `…${remaining.slice(from, match.index + 60).replace(/\s+/g, ' ').trim()}…`
+    })
+
+    expect(stray, [
+      'SECURITY.md mentions the public issue tracker somewhere this file does',
+      'not expect. A security policy that points a reporter at a public issue is',
+      'worse than no policy, because it looks official.',
+      '',
+      'If the sentence is fine, add it to PERMITTED_MENTIONS above — deliberately,',
+      'not to make this green.'
+    ].join('\n')).toEqual([])
+  })
+
+  it('pins the versions it claims to support', () => {
+    // Prose the release process cannot see. A 3.0.0 leaves the table below
+    // saying 2.x is current, which is the kind of wrong that reads as fact.
+    const major = String(pkg.version).split('.')[0]
+    expect(policy, `package.json is at ${pkg.version}`).toContain(`| ${major}.x |`)
+    expect(policy, `package.json declares engines.node ${pkg.engines.node}`).toContain(pkg.engines.node)
   })
 })
 

--- a/test/utils/governance-files.spec.ts
+++ b/test/utils/governance-files.spec.ts
@@ -104,6 +104,50 @@ describe('issue forms', () => {
 })
 
 /**
+ * The security policy names one channel, and it is the one place a dead link
+ * costs something real: a reporter who cannot reach it either gives up or
+ * files publicly, which is the outcome the whole file exists to prevent.
+ *
+ * The advisory URL is repository-specific — copy this file to another
+ * repository, or rename this one, and it silently points at somebody else's
+ * inbox. Checked against `package.json`'s own repository field rather than
+ * against a second copy of the name.
+ */
+describe('SECURITY.md', () => {
+  const policy = readFileSync(join(repoRoot, 'SECURITY.md'), 'utf8')
+  const pkg = JSON.parse(readFileSync(join(repoRoot, 'package.json'), 'utf8'))
+  const slug = pkg.repository.url.replace(/^git\+https:\/\/github\.com\//, '').replace(/\.git$/, '')
+
+  it('points at the private channel for this repository', () => {
+    expect(policy).toContain(`https://github.com/${slug}/security/advisories/new`)
+  })
+
+  it('is reachable from CONTRIBUTING.md', () => {
+    const contributing = readFileSync(join(repoRoot, 'CONTRIBUTING.md'), 'utf8')
+    expect(contributing).toContain(`https://github.com/${slug}/security/advisories/new`)
+    expect(contributing).toContain('SECURITY.md')
+  })
+
+  it('does not tell anyone to open an issue for a vulnerability', () => {
+    // The failure mode is not hypothetical: `bitrix24/b24phpsdk` publishes a
+    // SECURITY.md whose entire reporting section reads "Create issue with
+    // vulnerability details". A policy that says that is worse than none,
+    // because it looks official.
+    const reporting = policy.slice(0, policy.indexOf('## What counts')).toLowerCase()
+    expect(reporting).toContain('do not open a public issue')
+
+    // Negated sentences are dropped first — the required sentence above is
+    // itself "do not open a public issue", and a naive scan flags it. What is
+    // being looked for is an *instruction* to use one.
+    const instructions = reporting
+      .split(/(?<=[.:])\s/)
+      .filter(sentence => !/\b(?:do not|don't|never|rather than|instead of)\b/.test(sentence))
+
+    expect(instructions.filter(sentence => /\b(?:create|open|file)\b[^.]{1,40}\bissue\b/.test(sentence))).toEqual([])
+  })
+})
+
+/**
  * `CONTRIBUTING.md` quotes the pinned Node and pnpm versions as prose. That is
  * the right place for them — it is the first thing a contributor reads — but
  * prose does not run, and `documented-scripts.spec.ts` only checks script


### PR DESCRIPTION
### Linked issue

Part of #97

### Type of change

- [x] Documentation (updates to the documentation or readme)
- [ ] Bug fix (a non-breaking change that fixes an issue)
- [ ] Enhancement (improving an existing functionality)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Chore (updates to the build process or auxiliary tools and libraries)
- [ ] Revert (undoing a merged change — retitle this PR `revert(Scope): ...`)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

> No runtime change. `src/` is untouched.

### Description

Private vulnerability reporting is now enabled on this repository, which removes the only reason #501 held this file back. Verified rather than assumed — the `/security/policy` tab renders a **Report a vulnerability** link pointing at `/security/advisories/new`, and that link only appears when the setting is on.

`CONTRIBUTING.md` currently tells a reporter there is nowhere to send a finding and to hold it. That was true when it shipped this morning and is now the worst kind of stale: it asks someone to sit on something we can receive.

### What the policy says, and why it says it

"Report a vulnerability" means something specific for a component library, and it is not obvious from outside. The file names what actually matters here:

- markup that escapes escaping — a label, a `description`, an `items` value reaching the DOM unescaped is script execution in a page holding a portal session;
- a link `to` that can be steered into a `javascript:` URL;
- a webhook path or OAuth token surfacing in rendered output, an error message, or a clipboard value — a webhook URL is full access to a portal;
- a way around the prototype-pollution guard on the public `./utils` path helpers (`get`, `set`, `getAtPath`, `setAtPath`), which is guarded and tested, so a bypass is worth writing up.

And what is *not* a security report: styling bugs, accessibility defects, a component that crashes on bad input without leaking anything, dev-only dependency advisories. Saying so is part of the job — a policy that treats everything as a vulnerability gets everything filed as one.

It also states plainly that the channel is **private but not anonymous**: a GitHub account is required and the username is visible to maintainers. Better said here than discovered halfway through filing.

Supported versions: `2.x` only, fixes released from `main`, no LTS branch.

### Three new checks

`governance-files.spec.ts` gains them because each guards a way this file rots into something harmful rather than merely wrong:

| check | what it prevents |
|---|---|
| the advisory URL matches `package.json`'s repository | a copy of this file into another repository, or a rename of this one, silently pointing reporters at somebody else's inbox |
| `CONTRIBUTING.md` keeps linking it | the entry point going stale again, exactly as it did today |
| the reporting section never instructs anyone to open an issue | the failure below |

That third one is not hypothetical. `bitrix24/b24phpsdk` publishes a `SECURITY.md` whose entire reporting section reads:

> ## Reporting a Vulnerability
> Create issue with vulnerability details

That is a published instruction to disclose publicly, under a filename that makes it look official — worse than having no policy at all. The check is seeded with that exact text as a mutation.

It needed two passes: the first version flagged this file's own required sentence, "do not open a public issue". Negated sentences are dropped before the scan now, so what it looks for is an *instruction* rather than a mention.

Three mutations, three failures: the channel URL pointed at `b24gosdk`, the link removed from `CONTRIBUTING.md`, and the `b24phpsdk` text pasted in verbatim.

### Beyond this repository

Surveying the organisation while writing this — seventeen public repositories:

| repository | private reporting | policy |
|---|---|---|
| `b24ui` | ✅ | this PR |
| `b24jssdk` | ✅ | none yet |
| `b24rabbitmq` | — | ✅ good |
| `b24gosdk` | — | ✅ good |
| `b24phpsdk` | ❌ | ⚠️ instructs public disclosure |
| `b24icons`, `b24jssdk-nuxt`, … | ❌ | none |

`b24phpsdk` is the one worth acting on next and it is not this repository. `b24jssdk` has the channel on and no policy — the same half-finished state this PR closes here.

### Checklist

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.

Gate on Node 24: `lint` 0 · `typecheck` 0 · `test:coverage` 318/318 (7462) with thresholds met · `test:module` 3/3 · `test:workflows` 49/0.

---
_Generated by [Claude Code](https://claude.ai/code/session_012MsMuj8Fic9tjWVjyEyrxc)_