### PR TITLE
test(console-gate): fix two specs the gate caught, and correct what they were

### DIFF
--- a/.github/contributing/testing.md
+++ b/.github/contributing/testing.md
@@ -327,10 +327,12 @@ configuration, which is why the gate exists rather than a setting.
 The failure names the spec and up to five distinct messages. Three ways out,
 in order of preference:
 
-1. **Fix the component.** Usually right, and usually small. The first run of
-   this gate found `InputMenu` emitting `remove-tag` without declaring it,
-   `ChatMessages` invoking a slot outside the render function, and `FieldGroup`
-   rendering two components that do not resolve.
+1. **Fix whatever is warning** — and check which side that is before
+   assuming. The first run of this gate reported three findings that read like
+   component defects and were not: two were defects in the *tests* (a spec
+   emitting an event under a name reka-ui does not declare, and an axe case
+   that never registered the components it mounted), and one came from inside
+   reka-ui. A warning names a symptom, not an owner.
 2. **Take ownership of the warning**, if the test is asserting on it:
 
    ```ts
@@ -347,6 +349,31 @@ in order of preference:
 3. **Add an entry to `KNOWN_NOISY_SPECS`** in `test/utils/console-gate.ts`.
    Last resort, and it needs a stated reason next to it — an entry is a debt
    record, not a switch.
+
+### An inline template does not register components
+
+This is worth knowing before writing an axe case, because it fails silently:
+
+```ts
+// Renders <b24input></b24input> — an unknown element. axe finds nothing to
+// audit and reports zero violations.
+slots: { default: { template: `<B24Input />` } }
+
+// Renders a real input.
+global: { components: { B24Input } },
+slots: { default: { template: `<B24Input aria-label="Search" />` } }
+```
+
+A slot template is compiled at runtime with no access to the spec's imports.
+Without a registration the tag stays an unknown element, the component never
+mounts, and an axe assertion over it passes on nothing — the vacuous shape
+#454 is about. `FieldGroup`'s axe case did exactly this until the gate's
+`Failed to resolve component` warning surfaced it.
+
+Registering the components is half of it. The other half is that a fixture
+running through axe needs the accessible names a markup comparison does not: a
+bare `<input>` has none, which is why `Input`'s own axe case gives it a
+`placeholder`.
 
 ### The register
 

--- a/test/components/FieldGroup.spec.ts
+++ b/test/components/FieldGroup.spec.ts
@@ -46,10 +46,17 @@ describe('FieldGroup', () => {
 
   it('passes accessibility tests', async () => {
     const wrapper = await mountSuspended(FieldGroup, {
+      // Registered globally for this mount. The inline template below is
+      // compiled at runtime, so without a registration neither name resolves —
+      // which is what this case did, leaving axe to audit an empty group and
+      // pass on nothing. The vacuous shape #454 is about (#87). The
+      // `renderEach` cases above pass their own `components` and were fine.
+      global: { components: { B24Input, B24Button } },
       slots: {
-        default: {
-          template: `<B24Input /> <B24Button> Click me! </B24Button>`
-        }
+        // The input needs an accessible name that the markup cases do not:
+        // they compare HTML, this one runs axe, and a bare input has none.
+        // `Input`'s own axe case gives it a `placeholder` for the same reason.
+        default: { template: `<B24Input aria-label="Search" /> <B24Button> Click me! </B24Button>` }
       }
     })
 

--- a/test/components/FieldGroup.spec.ts
+++ b/test/components/FieldGroup.spec.ts
@@ -47,10 +47,12 @@ describe('FieldGroup', () => {
   it('passes accessibility tests', async () => {
     const wrapper = await mountSuspended(FieldGroup, {
       // Registered globally for this mount. The inline template below is
-      // compiled at runtime, so without a registration neither name resolves —
-      // which is what this case did, leaving axe to audit an empty group and
-      // pass on nothing. The vacuous shape #454 is about (#87). The
-      // `renderEach` cases above pass their own `components` and were fine.
+      // compiled at runtime with no access to this file's imports, so without
+      // a registration neither name resolves: the group rendered
+      // `<b24input></b24input>` and `<b24button></b24button>`, unknown elements
+      // with nothing inside them, and axe reported zero violations over that.
+      // The vacuous shape #454 is about (#87). The `renderEach` cases above
+      // pass their own `components` and were fine.
       global: { components: { B24Input, B24Button } },
       slots: {
         // The input needs an accessible name that the markup cases do not:

--- a/test/components/InputMenu.spec.ts
+++ b/test/components/InputMenu.spec.ts
@@ -175,7 +175,11 @@ describe('InputMenu', () => {
     test('remove-tag event', async () => {
       const wrapper = mount(InputMenu, { props: { modelValue: ['Option 1'], items: ['Option 1', 'Option 2'], multiple: true } })
       const input = wrapper.findComponent({ name: 'TagsInputRoot' })
-      await input.vm.$emit('remove-tag', 'Option 1')
+      // `removeTag`, not `remove-tag`: that is the name reka-ui's
+      // `TagsInputRoot` declares. Emitting the kebab spelling made Vue warn
+      // that the event is undeclared on every run — the assertion still
+      // passed, because Vue dispatches to `@remove-tag` regardless (#87).
+      await input.vm.$emit('removeTag', 'Option 1')
       expect(wrapper.emitted()).toMatchObject({ 'remove-tag': [['Option 1']] })
     })
 

--- a/test/components/InputMenu.spec.ts
+++ b/test/components/InputMenu.spec.ts
@@ -179,6 +179,11 @@ describe('InputMenu', () => {
       // `TagsInputRoot` declares. Emitting the kebab spelling made Vue warn
       // that the event is undeclared on every run — the assertion still
       // passed, because Vue dispatches to `@remove-tag` regardless (#87).
+      //
+      // This simulates the child's emit rather than provoking it, as the
+      // `ComboboxRoot` and `AutocompleteRoot` cases here do. It covers the
+      // forwarding, not the integration: were reka-ui to rename the event,
+      // this would stay green while the component stopped working.
       await input.vm.$emit('removeTag', 'Option 1')
       expect(wrapper.emitted()).toMatchObject({ 'remove-tag': [['Option 1']] })
     })

--- a/test/utils/console-gate.ts
+++ b/test/utils/console-gate.ts
@@ -87,21 +87,17 @@ export const KNOWN_NOISY_SPECS = new Set([
   'nuxt:components/ContextMenu.spec.ts',
   'vue:components/ContextMenu.spec.ts',
 
-  // ── Product defects the gate found on its first run ──────────────────────
-  //   FieldGroup    renders `B24Button` and `B24Input`, neither of which
-  //                 resolves — the components are not registered for it
-  //   InputMenu     emits `remove-tag` without declaring it in `emits`
-  //   ChatMessages  invokes the `viewport` slot outside the render function,
-  //                 so it tracks no dependencies
+  // ── `Slot "viewport" invoked outside of the render function` ─────────────
+  // Traced to reka-ui's `<Presence present=false>`, not to our own slot use:
+  // this component renders `<slot name="viewport">` from its template, which
+  // *is* inside the render function. Third-party, like `textValue` above.
+  'nuxt:components/ChatMessages.spec.ts',
+  'vue:components/ChatMessages.spec.ts',
+
+  // ── Lifecycle, and ours ──────────────────────────────────────────────────
   //   useKbd        calls `onMounted` with no active component instance
   //   useToast,
   //   useResizable  call `inject()` outside `setup()`
-  'nuxt:components/FieldGroup.spec.ts',
-  'vue:components/FieldGroup.spec.ts',
-  'nuxt:components/InputMenu.spec.ts',
-  'vue:components/InputMenu.spec.ts',
-  'nuxt:components/ChatMessages.spec.ts',
-  'vue:components/ChatMessages.spec.ts',
   'nuxt:composables/useKbd.spec.ts',
   'vue:composables/useKbd.spec.ts',
   'nuxt:composables/useToast.spec.ts',

--- a/test/utils/console-gate.ts
+++ b/test/utils/console-gate.ts
@@ -88,9 +88,11 @@ export const KNOWN_NOISY_SPECS = new Set([
   'vue:components/ContextMenu.spec.ts',
 
   // ── `Slot "viewport" invoked outside of the render function` ─────────────
-  // Traced to reka-ui's `<Presence present=false>`, not to our own slot use:
-  // this component renders `<slot name="viewport">` from its template, which
-  // *is* inside the render function. Third-party, like `textValue` above.
+  // Traced to reka-ui's `Presence`, which calls `slots.default()` from its
+  // `setup()` — before it returns a render function, which is exactly what the
+  // warning describes. Not our own slot use: this component renders
+  // `<slot name="viewport">` from its template, inside the render function.
+  // Third-party, like `textValue` above.
   'nuxt:components/ChatMessages.spec.ts',
   'vue:components/ChatMessages.spec.ts',
 


### PR DESCRIPTION
### Linked issue

Part of #87

### Type of change

- [ ] Documentation (updates to the documentation or readme)
- [ ] Bug fix (a non-breaking change that fixes an issue)
- [ ] Enhancement (improving an existing functionality)
- [ ] New feature (a non-breaking change that adds functionality)
- [x] Chore (updates to the build process or auxiliary tools and libraries)
- [ ] Revert (undoing a merged change — retitle this PR `revert(Scope): ...`)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

> No runtime change. `src/` is untouched.

### First, a correction

#506 reported that the console gate found three product defects on its first run. **It did not.** Tracing each warning to its source: two are defects in the *tests*, and the third is not ours at all. The register annotations said otherwise, and an annotation that misattributes a warning sends the next reader to the wrong file — so this PR fixes what is fixable and corrects the rest.

| reported as | actually |
|---|---|
| `InputMenu` emits `remove-tag` undeclared | the **test** emits it, on a reka-ui component |
| `ChatMessages` invokes a slot outside the render function | reka-ui's `<Presence>` does |
| `FieldGroup` renders components that do not resolve | the **test** does not register them |

### `InputMenu` — a test emitting the wrong name

```ts
const input = wrapper.findComponent({ name: 'TagsInputRoot' })
await input.vm.$emit('remove-tag', 'Option 1')   // ← declared as `removeTag`
```

reka-ui's `TagsInputRoot` declares `removeTag`. Vue warned that the event was undeclared **and dispatched it anyway**, so the assertion passed and the warning was noise nobody could see. The component's own runtime `emits` does contain `remove-tag` — dumped it to be sure.

Emitting the declared name fixes it. Nothing in `src/` was wrong.

### `FieldGroup` — an axe case auditing nothing

```ts
slots: { default: { template: `<B24Input /> <B24Button> Click me! </B24Button>` } }
```

An inline template is compiled at runtime with no component registration, so neither name resolved and **axe was auditing an empty group**. Vacuous in the sense #454 is about, and the two `Failed to resolve component` warnings were the only sign — hidden by `silent: true` until the gate.

The three `renderEach` cases beside it pass their own `components` and were fine. This one now registers them through `global`.

**Making it real made it fail**, on a genuine violation: a bare input has no accessible name. That is the fixture's omission rather than the group's — the markup cases do not need one because they compare HTML, this one runs axe. It now carries an `aria-label`, exactly as `Input`'s own axe case carries a `placeholder`.

So the sequence was: a vacuous test hid a warning, the warning led to the vacuous test, and fixing it surfaced a real violation underneath. That is the argument for the gate better than anything in #506.

### `ChatMessages` — third-party

The trace points at reka-ui's `<Presence present=false>` invoking the slot. This component renders `<slot name="viewport">` from its template, which *is* inside the render function. Its entries stay, with the attribution corrected in the register.

### Result

The register is **38 entries**, down from 42.

### Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

Gate on Node 24: `lint` 0 · `typecheck` 0 · `test:coverage` 318/318 (7468) with thresholds met · `test:module` 3/3.

---
_Generated by [Claude Code](https://claude.ai/code/session_012MsMuj8Fic9tjWVjyEyrxc)_