### PR TITLE
test(console-gate): the dialog warnings are the harness, not the components

### DIFF
--- a/test/utils/console-gate.ts
+++ b/test/utils/console-gate.ts
@@ -56,11 +56,24 @@ const CHANNELS = ['warn', 'error'] as const
  * if the warning it emits is one somebody has looked at and chosen to leave.
  */
 export const KNOWN_NOISY_SPECS = new Set([
-  // ── Accessibility, in the dialog family ──────────────────────────────────
-  // `DialogContent requires a DialogTitle for the component to be accessible
-  // for screen reader users`, `Missing Description or aria-describedby`, and
-  // `console.error: aria-hidden` on focusable content. Real defects, the same
-  // class #50 was about, each needing its own fix.
+  // ── The dialog family, and this one is the test harness ──────────────────
+  // `DialogContent requires a DialogTitle`, `Missing Description or
+  // aria-describedby`, `console.error: aria-hidden`.
+  //
+  // Not defects. reka-ui checks its own accessibility with
+  // `document.getElementById(titleId)` in `onMounted`, and Vue Test Utils
+  // mounts into an element that is not in the document — so the lookup fails
+  // with the title present in the markup the component just produced. These
+  // specs render with `portal: false`, which keeps the content inside that
+  // detached wrapper instead of teleporting it to `document.body`.
+  //
+  // Measured on `Modal`, one mount each: 2 warnings detached, 0 with
+  // `attachTo: document.body`, 0 with the portal left on.
+  //
+  // Attaching in `componentRender` fixes all of them and is not a small
+  // change: reka-ui's focus scoping then really runs, so overlays gain the
+  // `aria-hidden` a browser gives them, and 344 snapshots across 26 files
+  // move. Worth doing, and worth doing on its own.
   'nuxt:components/Modal.spec.ts',
   'vue:components/Modal.spec.ts',
   'nuxt:components/Drawer.spec.ts',


### PR DESCRIPTION
### Linked issue

Part of #87

### Type of change

- [ ] Documentation (updates to the documentation or readme)
- [ ] Bug fix (a non-breaking change that fixes an issue)
- [ ] Enhancement (improving an existing functionality)
- [ ] New feature (a non-breaking change that adds functionality)
- [x] Chore (updates to the build process or auxiliary tools and libraries)
- [ ] Revert (undoing a merged change — retitle this PR `revert(Scope): ...`)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

> One comment block. No code changes at all.

### What this corrects

Sixteen of the console register's 38 entries were annotated as **real accessibility defects**, "each needing its own fix". They are not. They are an artefact of how the tests mount.

reka-ui checks its own accessibility with `document.getElementById(titleId)` inside `onMounted`. Vue Test Utils mounts into an element that is **not in the document**, and these specs pass `portal: false`, which keeps the content inside that detached wrapper instead of teleporting it to `document.body`. The lookup therefore fails while the title sits in the markup the component has just produced — including in the case named, without irony, `renders with title correctly`.

Measured on `Modal`, one mount each:

| mount | warnings |
|---|---|
| detached, `portal: false` — as the specs run today | **2** |
| `attachTo: document.body` | 0 |
| portal left on | 0 |

This is the second time an annotation in this file has blamed the wrong side; #507 corrected the first. The cost of getting it wrong is not theoretical — two reviewers built recommendations on top of the claim, one calling these a real barrier for screen-reader users and one prioritising the cluster first.

### Why the fix is not in this PR

It is one line in `componentRender`. It is also not small: attaching makes reka-ui's focus scoping actually run, so overlays gain the `aria-hidden` a browser gives them, and **344 snapshots across 26 files** move — well past the dialog family, into `CheckboxGroup`, `RadioGroup`, `Switch`, `Link` and the editor.

That is a genuine improvement in how faithfully these tests render, and it deserves its own review rather than riding along with a comment fix — particularly since #87 exists because snapshot churn is already hard to review. It also overlaps with #87's other half, which is about the snapshot corpus, so the two are probably one piece of work.

### Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

Gate on Node 24: `test` 318/318 (7468) · `lint` 0.

---
_Generated by [Claude Code](https://claude.ai/code/session_012MsMuj8Fic9tjWVjyEyrxc)_