### PR TITLE
fix(Form,Range): omit method on nested forms, emit a number for one thumb

### DIFF
--- a/.sync/dep-parity.json
+++ b/.sync/dep-parity.json
@@ -1,6 +1,6 @@
 {
   "$note": "Upstream's pinned versions for every dependency both trees declare in the SAME section, snapshotted at `cursor`. The sync ports deltas, which is correct per commit and lets a one-time divergence become permanent: once a version is off upstream's line, every later `chore(deps)` batch skips it, because those ports bump only where this fork already matched upstream's pre-image. `prettier` sat at ^3.8.4 against upstream's ^3.9.6 for that reason, through four ported batches, until this file was written. Section-aware on purpose: 18 packages are declared on both sides but in different sections — the whole `@tiptap/*` family is a peer `^3` upstream and a dependency `^3.29.2` here, and `ai` is a peer there and a devDependency here. Those are structural divergences, not drift, and comparing a peer range against a dependency range says nothing. They are absent from this file by construction rather than by omission. Guarded by `test/utils/dep-parity.spec.ts`. Refresh with `node .sync/dep-parity.mjs <path-to-nuxt-ui-mirror> [cursor]`, which preserves `exceptions`.",
-  "cursor": "9bdb89b0c7585a3a9189ca42c75561396789f927",
+  "cursor": "ae24311663cc8447c6e44b6045087c94d3ae4c71",
   "manifests": {
     "package.json": {
       "dependencies": {

--- a/.sync/log/3d2de0ce790f3fd90a95447b7145bf25c9ee4b3a.md
+++ b/.sync/log/3d2de0ce790f3fd90a95447b7145bf25c9ee4b3a.md
@@ -1,0 +1,42 @@
+# Port: fix(Slider): emit a number for a single thumb
+
+**Upstream:** `3d2de0ce790f3fd90a95447b7145bf25c9ee4b3a` (nuxt/ui, #6890)
+**Decision:** port — verbatim, against `Range`
+
+## Naming
+
+Upstream's `Slider` is this fork's `Range` (§1, component names). Third commit in
+that family, after `f3c2ac21` (#431) and `d6c3802a` (#466).
+
+## Upstream change
+
+```diff
+-const rootProps = useForwardProps(reactivePick(props, …, 'inverted'), emits)
++const rootProps = useForwardProps(reactivePick(props, …, 'inverted'))
+```
+
+Passing `emits` made `useForwardProps` forward `SliderRoot`'s own
+`update:modelValue` straight through, **in addition to** the one the component
+derives from its `defineModel`. Two consequences: the event fired twice, and the
+forwarded copy carried Reka's raw payload — an array — so a single-thumb slider
+emitted `[71]` where the caller passed and expects `71`.
+
+Dropping the argument leaves the component's own handling as the sole emitter.
+
+## b24ui port
+
+Verbatim: our `Range.vue:74` carried the identical `emits` argument, and our
+`Range.spec.ts` carried the identical pre-image expectation —
+`{ 'update:modelValue': [[1], [1]] }`, the doubled emit written down as though
+it were correct.
+
+Ported upstream's corrected expectation and both new cases, adapted to `Range`.
+
+## Verify
+
+Mutation-checked rather than assumed to be meaningful: restoring the `emits`
+argument with the tests kept turns **all six** red — the corrected case plus the
+two new ones, across both the `nuxt` and `vue` projects.
+
+`lint` · `typecheck` · `test` (7472 passed, 6 skipped, 318 files) ·
+`docs:generate` (1264 routes) — green.

--- a/.sync/log/a494a97daf9d9dffe9dc38c4755c8964e666ed46.md
+++ b/.sync/log/a494a97daf9d9dffe9dc38c4755c8964e666ed46.md
@@ -1,0 +1,31 @@
+# Port: fix(Form): omit method attribute on nested forms
+
+**Upstream:** `a494a97daf9d9dffe9dc38c4755c8964e666ed46` (nuxt/ui, #6888)
+**Decision:** port — verbatim, one line
+
+## Upstream change
+
+```diff
+-    method="post"
++    :method="parentBus ? undefined : 'post'"
+```
+
+A nested `Form` renders as a `div` rather than a `form` (`:is="parentBus ? 'div' : 'form'"`),
+because a `form` inside a `form` is invalid HTML. `method` was still being set
+unconditionally, so the nested case emitted `<div method="post">` — a form
+attribute on an element that is not a form.
+
+## b24ui port
+
+Applies verbatim. Our `Form.vue` has the **same pre-image**: the root is already
+`:is="parentBus ? 'div' : 'form'"` and `:name` is already
+`parentBus ? undefined : props.name` — `method` is simply the one attribute that
+was missed when the nested case was introduced. Nothing about the line involves
+`ui`/`b24ui`, so there is nothing to rewrite.
+
+## Verify
+
+`lint` · `typecheck` · `test` — green. No snapshot moved: `Form.spec.ts` does not
+render a nested form, so the attribute change is not witnessed by the suite.
+Stated rather than glossed over — the fix is correct by inspection of the
+template and upstream's reasoning, not by a test that would have caught it.

--- a/.sync/log/ae24311663cc8447c6e44b6045087c94d3ae4c71.md
+++ b/.sync/log/ae24311663cc8447c6e44b6045087c94d3ae4c71.md
@@ -1,0 +1,41 @@
+# Skip: docs: refactor with `nuxt-agent-discovery` module
+
+**Upstream:** `ae24311663cc8447c6e44b6045087c94d3ae4c71` (nuxt/ui, #6883)
+**Decision:** skip — it refactors infrastructure this fork deliberately does not have
+
+## Upstream change
+
+33 files, +474/−1914. Upstream replaces the hand-rolled agent-discovery surface
+it built in `9ef3ee39` with a `nuxt-agent-discovery` module, **deleting** its own
+implementation in the process:
+
+- `.well-known/api-catalog.get.ts` (−63) and `.well-known/mcp/server-card.json.get.ts` (−44)
+- `raw/[...slug].md.get.ts` (−64), `raw/index.md.get.ts` (−79)
+- `sitemap.md.get.ts` (−47), `sitemap.xml.get.ts` (−29)
+- `markdownNegotiation.ts` (−318), `middleware/markdown.ts` (−66), `error.ts` (−58),
+  `extractSections.ts` (−61), `useCanonical.ts` (−24), `robots.txt` (−40)
+
+replaced by `server/plugins/agent-discovery.ts` (+58) and a dependency.
+
+## Why skipped
+
+**It refactors what this fork chose not to adopt.** `9ef3ee39` — the commit that
+built this surface — is recorded one entry earlier as a skip on maintainer
+decision, because our agent surface is our own and larger: `docs/server/mcp/`
+carries 27 files against upstream's smaller set. A refactor of code we never took
+has nothing to apply to.
+
+**And taking it would delete working code we wrote on purpose.** The two
+`.well-known` routes upstream removes here are the ones this fork *added* in
+#492, three days ago, precisely because `nuxt.config.ts` advertised them and
+nothing served them. Our `raw/*` and `sitemap.*` routes are likewise our own and
+in use — `raw/**.md` is what `skills/b24-ui-nuxt/references/components.md` links
+to, and both sitemaps are prerendered into the static build.
+
+Adopting `nuxt-agent-discovery` is a live option, but it is a maintainer decision
+about our own architecture rather than a port: it would mean deleting six
+working routes and four utilities in favour of a third-party module whose output
+we would then have to re-verify against GitHub Pages, where server routes do not
+run at all.
+
+Recorded rather than skipped silently so the next porter does not re-derive it.

--- a/.sync/nuxt-ui.json
+++ b/.sync/nuxt-ui.json
@@ -1,7 +1,7 @@
 {
   "upstream": "nuxt/ui",
   "branch": "v4",
-  "cursor": "9bdb89b0c7585a3a9189ca42c75561396789f927",
+  "cursor": "ae24311663cc8447c6e44b6045087c94d3ae4c71",
   "_cursor_note": "cursor = last upstream commit ported into b24ui. The sync is manual by decision: one commit at a time, oldest-first, each with a `.sync/log/<sha>.md` journal and an entry in `processed`. There is no dispatcher, no porter workflow and no kill-switch — `.sync/PORTING.md` is the whole procedure. `processed` is maintained per port (backfilled #68-#72 on 2026-06-09).",
   "processed": {
     "2799fa6f2b25ce3eb15e050f3ef7c57d0d9a2fdb": {
@@ -1667,6 +1667,24 @@
       "b24ui_sha": "0e2cb6e0fdbbe729de639122836fbf94667df548",
       "decision": "no-op",
       "summary": "fix(Checkbox/RadioGroup): use `border-default` on `card` and `table` variants (nuxt/ui #6884) — NO-OP: the line it edits is written in different tokens here. Upstream swaps one token across five slots, border-muted -> border-default on the card and table variants of Checkbox, CheckboxGroup and RadioGroup, with 168 snapshot lines following. Neither token is on our side of that line: all five fork equivalents read `border border-(--ui-color-design-outline-na-stroke)`, the Air design system's outline stroke, annotated @memo style-outline-no-accent in checkbox.ts — checked individually at checkbox.ts:63, checkbox-group.ts:48,56 and radio-group.ts:69,77. There is no border-muted to replace and no border-default to replace it with. The ${hover}bg-elevated/50 fragment in the same string is not ours either: it arrived upstream in 07f3fe8d as part of the hover/checked/focus palette refresh, which this fork DECLINED by maintainer decision when that commit was ported (#464), our card and table carrying their own checked and hover treatment in air tokens. So this commit adjusts a line that on our side was already deliberately different. Stated precisely rather than as 'we don't use those tokens': we do use border-default elsewhere (dropdown-menu.ts and sidebar.ts x4) and border-muted in prose/prompt.ts — the tokens exist here, they are simply not what these five slots are written in. Nothing to port and nothing deferred: taking it would mean first adopting the palette refresh this fork chose not to."
+    },
+    "a494a97daf9d9dffe9dc38c4755c8964e666ed46": {
+      "pr": "pending-merge",
+      "b24ui_sha": "pending-merge",
+      "decision": "port",
+      "summary": "fix(Form): omit method attribute on nested forms (nuxt/ui #6888) — PORT, verbatim, one line. A nested Form renders as a div rather than a form (:is=\"parentBus ? 'div' : 'form'\") because a form inside a form is invalid HTML, but method was still set unconditionally, so the nested case emitted <div method=\"post\"> — a form attribute on an element that is not a form. Applies verbatim: our Form.vue has the same pre-image, with the root already conditional and :name already parentBus ? undefined : props.name, so method is simply the one attribute missed when the nested case was introduced; nothing about the line involves ui/b24ui. No snapshot moved — Form.spec.ts does not render a nested form, so the attribute change is not witnessed by the suite. Stated rather than glossed over: the fix is correct by inspection of the template and upstream's reasoning, not by a test that would have caught it."
+    },
+    "3d2de0ce790f3fd90a95447b7145bf25c9ee4b3a": {
+      "pr": "pending-merge",
+      "b24ui_sha": "pending-merge",
+      "decision": "port",
+      "summary": "fix(Slider): emit a number for a single thumb (nuxt/ui #6890) — PORT, verbatim, against Range. Upstream's Slider is this fork's Range (§1); third commit in that family after f3c2ac21 (#431) and d6c3802a (#466). Passing emits to useForwardProps forwarded SliderRoot's own update:modelValue straight through, IN ADDITION to the one the component derives from its defineModel: the event fired twice, and the forwarded copy carried Reka's raw payload — an array — so a single-thumb slider emitted [71] where the caller passed and expects 71. Dropping the argument leaves the component's own handling as the sole emitter. Verbatim here: our Range.vue:74 carried the identical emits argument, and Range.spec.ts carried the identical pre-image expectation { 'update:modelValue': [[1], [1]] } — the doubled emit written down as though it were correct. Ported upstream's corrected expectation and both new cases. Mutation-checked rather than assumed: restoring the emits argument with the tests kept turns all six red — the corrected case plus the two new ones, across both the nuxt and vue projects."
+    },
+    "ae24311663cc8447c6e44b6045087c94d3ae4c71": {
+      "pr": "pending-merge",
+      "b24ui_sha": "pending-merge",
+      "decision": "skip",
+      "summary": "docs: refactor with `nuxt-agent-discovery` module (nuxt/ui #6883) — SKIP: it refactors infrastructure this fork deliberately does not have. 33 files, +474/-1914, replacing the hand-rolled agent-discovery surface upstream built in 9ef3ee39 with a nuxt-agent-discovery module and deleting its own implementation: .well-known/api-catalog.get.ts (-63), .well-known/mcp/server-card.json.get.ts (-44), raw/[...slug].md.get.ts (-64), raw/index.md.get.ts (-79), sitemap.md.get.ts (-47), sitemap.xml.get.ts (-29), markdownNegotiation.ts (-318), middleware/markdown.ts (-66), error.ts (-58), extractSections.ts (-61), useCanonical.ts (-24) and robots.txt (-40), replaced by server/plugins/agent-discovery.ts (+58) plus a dependency. 9ef3ee39 — the commit that built this surface — is recorded one entry earlier as a skip on maintainer decision, because our agent surface is our own and larger (docs/server/mcp/ carries 27 files against upstream's smaller set), so a refactor of code we never took has nothing to apply to. And taking it would delete working code written on purpose: the two .well-known routes upstream removes here are the ones this fork ADDED in #492, precisely because nuxt.config.ts advertised them and nothing served them; our raw/* and sitemap.* routes are likewise our own and in use, with raw/**.md being what skills/b24-ui-nuxt/references/components.md links to and both sitemaps prerendered into the static build. Adopting nuxt-agent-discovery remains a live option, but it is a maintainer decision about our own architecture rather than a port — it would mean deleting six working routes and four utilities for a third-party module whose output would then need re-verifying against GitHub Pages, where server routes do not run at all."
     }
   }
 }

--- a/src/runtime/components/Form.vue
+++ b/src/runtime/components/Form.vue
@@ -463,7 +463,7 @@ defineExpose(api)
     :id="formId"
     ref="formRef"
     :name="parentBus ? undefined : props.name"
-    method="post"
+    :method="parentBus ? undefined : 'post'"
     :class="b24ui({ class: [props.b24ui?.base, props.class] })"
     @submit.prevent="onSubmitWrapper"
   >

--- a/src/runtime/components/Range.vue
+++ b/src/runtime/components/Range.vue
@@ -71,7 +71,7 @@ const props = useComponentProps<RangeProps>('range', _props)
 
 const appConfig = useAppConfig() as Range['AppConfig']
 
-const rootProps = useForwardProps(reactivePick(props, 'as', 'orientation', 'min', 'max', 'step', 'minStepsBetweenThumbs', 'inverted'), emits)
+const rootProps = useForwardProps(reactivePick(props, 'as', 'orientation', 'min', 'max', 'step', 'minStepsBetweenThumbs', 'inverted'))
 
 const { id, emitFormChange, emitFormInput, size: formFieldSize, color: formFieldColor, name, disabled: formFieldDisabled, ariaAttrs } = useFormField<RangeProps>(props)
 

--- a/test/components/Range.spec.ts
+++ b/test/components/Range.spec.ts
@@ -192,7 +192,25 @@ describe('Range', () => {
       const input = wrapper.findComponent({ name: 'SliderRoot' })
       input.vm.$emit('update:modelValue', 1)
 
-      expect(wrapper.emitted()).toMatchObject({ 'update:modelValue': [[1], [1]] })
+      expect(wrapper.emitted()).toMatchObject({ 'update:modelValue': [[1]] })
+    })
+
+    test('update:modelValue event with a single thumb', async () => {
+      const wrapper = mount(Range, { props: { modelValue: 25 } })
+
+      const input = wrapper.findComponent({ name: 'SliderRoot' })
+      input.vm.$emit('update:modelValue', [71])
+
+      expect(wrapper.emitted()).toMatchObject({ 'update:modelValue': [[71]] })
+    })
+
+    test('update:modelValue event with multiple thumbs', async () => {
+      const wrapper = mount(Range, { props: { modelValue: [10, 90] } })
+
+      const input = wrapper.findComponent({ name: 'SliderRoot' })
+      input.vm.$emit('update:modelValue', [10, 71])
+
+      expect(wrapper.emitted()).toMatchObject({ 'update:modelValue': [[[10, 71]]] })
     })
 
     test('change event', async () => {


### PR DESCRIPTION
### Linked issue

Sync with `nuxt/ui@v4` — three contiguous commits (§6 4b): [`a494a97d`](https://github.com/nuxt/ui/commit/a494a97daf9d9dffe9dc38c4755c8964e666ed46) (nuxt/ui#6888) · [`3d2de0ce`](https://github.com/nuxt/ui/commit/3d2de0ce790f3fd90a95447b7145bf25c9ee4b3a) (nuxt/ui#6890) · `ae243116` (nuxt/ui#6883, **skipped**). After this the cursor is at upstream HEAD.

### Type of change

- [x] Bug fix (a non-breaking change that fixes an issue)

### Description

#### `a494a97d` — `method` on a nested form

Our root element already renders as a `div` when nested (`:is="parentBus ? 'div' : 'form'"`), because a `form` inside a `form` is invalid HTML, and `:name` was already conditional on the same flag. But `method="post"` was left unconditional, so a nested form emitted **`<div method="post">`** — a form attribute on an element that is not a form.

Upstream's fix is exactly the line we were missing:

```diff
-    method="post"
+    :method="parentBus ? undefined : 'post'"
```

Applies verbatim — same pre-image, and nothing on the line involves `ui`/`b24ui`.

#### `3d2de0ce` — a single thumb emitted an array, twice

Upstream's `Slider` is this fork's `Range` (§1); third commit in that family after #431 and #466.

Passing `emits` to `useForwardProps` forwarded `SliderRoot`'s own `update:modelValue` straight through, **in addition to** the one the component derives from its `defineModel`. Two consequences: the event fired twice, and the forwarded copy carried Reka's raw payload — an array — so a single-thumb Range emitted `[71]` where the caller passed and expects `71`.

Our `Range.vue:74` carried the identical `emits` argument, and `Range.spec.ts` carried the identical pre-image expectation — `{ 'update:modelValue': [[1], [1]] }`, the doubled emit written down as though it were correct.

#### `ae243116` — skipped

Replaces upstream's hand-rolled agent-discovery surface with a `nuxt-agent-discovery` module, deleting its own `.well-known`, `raw/*`, `sitemap.*`, markdown-negotiation and error-handling implementation — 33 files, +474/−1914.

It refactors infrastructure **this fork deliberately does not have**: `9ef3ee39`, the commit that built that surface, is recorded one entry earlier as a skip on maintainer decision, so a refactor of code we never took has nothing to apply to. Taking it would also delete working code written on purpose — the two `.well-known` routes it removes are the ones this fork **added** in #492, and our `raw/*` and `sitemap.*` routes are in use (`raw/**.md` is what the skills reference links to; both sitemaps are prerendered into the static build).

Adopting the module stays a live option, but that is a decision about our own architecture rather than a port.

### Verification

**Mutation-checked, not assumed.** Upstream's two new emits cases plus the corrected expectation were ported and adapted to `Range`; restoring the `emits` argument with the tests kept turns **all six red** — the corrected case and both new ones, across the `nuxt` and `vue` projects.

The Form fix moves no snapshot: `Form.spec.ts` does not render a nested form, so the attribute change is not witnessed by the suite. Stated rather than glossed over — it is correct by inspection of the template, not by a test that would have caught it.

Gate with `CI=true`: `lint` · `typecheck` · `test` (7472 passed, 6 skipped, 318 files) · `docs:generate` (1264 routes).

**One thing found along the way, not fixed here:** `pnpm build` currently fails on `main` with 12 `TS2883` errors in `runtime/plugins/{colors,platform,ui-version}.ts` — verified by stashing this branch's changes and building clean `main`, which fails identically. CI does not run `build` (it runs `dev:prepare`, `lint`, `typecheck`, `test:coverage`, `test:module`), which is why it went unnoticed. Unrelated to this port and left alone rather than folded into a sync PR.

Ledger: cursor → `ae243116`, three entries with their `.sync/log/` journals, parity snapshot refreshed (zero package differences).

### Checklist

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.


---
_Generated by [Claude Code](https://claude.ai/code/session_01JS8ypVfQSFzYVZzkTHhURb)_