### PR TITLE
fix(module): annotate the runtime plugins so declaration emit succeeds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,6 +114,13 @@ jobs:
       - name: Typecheck
         run: pnpm run typecheck
 
+      # `typecheck` runs `vue-tsc --noEmit`; this runs the real declaration emit,
+      # which is a different thing and fails on its own (TS2883 on the runtime
+      # plugins, from #500's lockfile reshuffle, went unnoticed for three days
+      # because nothing here built the module).
+      - name: Build the module
+        run: pnpm run build
+
       # Coverage rather than a plain `vitest run`: it is the same suite with the
       # same assertions, plus a gate that goes red when coverage falls below
       # the thresholds in `vitest.config.ts`. Instrumenting every worker costs

--- a/src/runtime/plugins/colors.ts
+++ b/src/runtime/plugins/colors.ts
@@ -2,6 +2,7 @@ import { computed } from 'vue'
 // import colors from 'tailwindcss/colors'
 // import { defineNuxtPlugin, useAppConfig, useNuxtApp, useHead } from '#imports'
 import { defineNuxtPlugin, injectHead, useNuxtApp, useHead } from '#imports'
+import type { ObjectPlugin } from 'nuxt/app'
 
 /**
  * @see src/templates.ts -> getTemplates
@@ -29,7 +30,13 @@ function removeTemporaryColorsStyle() {
   document.querySelector('[data-bitrix24-ui-colors]')?.remove()
 }
 
-export default defineNuxtPlugin(() => {
+/**
+ * Annotated rather than inferred: `nuxt-module-build`'s declaration emit cannot
+ * name `ObjectPlugin` through pnpm's hashed `nuxt@x.y.z_<peers>` path, and fails
+ * the build with TS2883. The annotation makes the emitted `.d.ts` independent of
+ * how the peer graph happens to resolve.
+ */
+const plugin: ObjectPlugin = defineNuxtPlugin(() => {
   // const appConfig = useAppConfig()
   const nuxtApp = useNuxtApp()
 
@@ -81,3 +88,5 @@ export default defineNuxtPlugin(() => {
 
   useHead(headData)
 })
+
+export default plugin

--- a/src/runtime/plugins/platform.ts
+++ b/src/runtime/plugins/platform.ts
@@ -1,4 +1,5 @@
 import { defineNuxtPlugin, useState, useRequestHeader, useHead } from '#imports'
+import type { ObjectPlugin } from 'nuxt/app'
 
 /**
  * Plugin to detect the Bitrix24 application environment.
@@ -31,8 +32,13 @@ import { defineNuxtPlugin, useState, useRequestHeader, useHead } from '#imports'
  * if (platform.value.name === 'bitrix-desktop') { ... }
  *
  * @todo add docs
+ *
+ * Annotated rather than inferred: `nuxt-module-build`'s declaration emit cannot
+ * name `ObjectPlugin` through pnpm's hashed `nuxt@x.y.z_<peers>` path, and fails
+ * the build with TS2883. The annotation makes the emitted `.d.ts` independent of
+ * how the peer graph happens to resolve.
  */
-export default defineNuxtPlugin(() => {
+const plugin: ObjectPlugin = defineNuxtPlugin(() => {
   /**
    * Reactive platform state.
    * Prevents redundant User-Agent parsing during client-side navigation.
@@ -79,3 +85,5 @@ export default defineNuxtPlugin(() => {
     }
   })
 })
+
+export default plugin

--- a/src/runtime/plugins/ui-version.ts
+++ b/src/runtime/plugins/ui-version.ts
@@ -1,9 +1,15 @@
 import { defineNuxtPlugin, useHead, useAppConfig } from '#imports'
+import type { ObjectPlugin } from 'nuxt/app'
 
 /**
  * Add b24ui version
+ *
+ * Annotated rather than inferred: `nuxt-module-build`'s declaration emit cannot
+ * name `ObjectPlugin` through pnpm's hashed `nuxt@x.y.z_<peers>` path, and fails
+ * the build with TS2883. The annotation makes the emitted `.d.ts` independent of
+ * how the peer graph happens to resolve.
  */
-export default defineNuxtPlugin(() => {
+const plugin: ObjectPlugin = defineNuxtPlugin(() => {
   const appConfig = useAppConfig()
   const version = (appConfig.version || '__B24UI_VERSION__') as string
 
@@ -12,3 +18,5 @@ export default defineNuxtPlugin(() => {
     meta: [{ name: 'b24ui', content: version }]
   })
 })
+
+export default plugin


### PR DESCRIPTION
### Linked issue

Found while porting #509. Independent of it — this is a defect on `main`.

### Type of change

- [x] Bug fix (a non-breaking change that fixes an issue)
- [x] Chore (updates to the build process or auxiliary tools and libraries)

### Description

`pnpm build` has been failing on `main` since #500, with twelve `TS2883` errors:

```
src/runtime/plugins/colors.ts(32,1): error TS2883:
  The inferred type of 'default' cannot be named without a reference to
  'ObjectPlugin' from '.pnpm/nuxt@4.5.2_c8b663…/node_modules/nuxt/app'.
  This is likely not portable. A type annotation is necessary.
```

#### Cause

**Not the plugins** — `runtime/plugins/{colors,platform,ui-version}.ts` have not changed since #405.

#500 added `@vitest/coverage-v8`, which reshuffled **711 lines of the lockfile** and with them the `nuxt@4.5.2_<peers>` resolution hash. Declaration emit then had no portable name for the inferred plugin type — which is exactly what the error names.

Bisected with **exit codes** across seven commits: `a2d632cb` builds clean, `f288620b` (#500) does not. Worth noting how nearly I got this wrong: my first pass counted `TS2883` lines instead of checking exit status, which reported "0 errors" for commits where the build had failed for an unrelated reason. Those results were discarded.

#### Fix

Annotate the three exports explicitly — `const plugin: ObjectPlugin` plus `export default plugin` — so the emitted `.d.ts` no longer depends on how the peer graph happens to resolve. Each carries a short note saying why the annotation is not decoration.

#### Why it went unnoticed for three days

**CI never built the module.** It runs `dev:prepare`, `lint`, `typecheck`, `test:coverage` and `test:module`. `typecheck` is `vue-tsc --noEmit` — a different thing from the real declaration emit, and it passes while the build fails.

A `Build the module` step now runs between typecheck and the suite.

### Verification

The fix and the guard were each checked by making them fail:

| state | `pnpm build` |
| --- | --- |
| annotations removed (i.e. `main` today) | **exit 1**, twelve `TS2883` |
| as shipped | **exit 0** |

So the new CI step demonstrably goes red on the very breakage it is being added for, rather than being assumed to.

Gate with `CI=true`: `lint` · `typecheck` · `build` · `test` (7472 passed, 6 skipped, 318 files) — green.

### Checklist

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.


---
_Generated by [Claude Code](https://claude.ai/code/session_01JS8ypVfQSFzYVZzkTHhURb)_