### PR TITLE
fix(types): stop advertising `isAction` on components that cannot honour it

### DIFF
--- a/src/runtime/components/Breadcrumb.vue
+++ b/src/runtime/components/Breadcrumb.vue
@@ -11,7 +11,7 @@ import type { ComponentConfig } from '../types/tv'
 
 type Breadcrumb = ComponentConfig<typeof theme, AppConfig, 'breadcrumb'>
 
-export interface BreadcrumbItem extends Omit<LinkProps, 'raw' | 'custom'> {
+export interface BreadcrumbItem extends Omit<LinkProps, 'raw' | 'custom' | 'isAction'> {
   label?: string
   /**
    * @IconComponent

--- a/src/runtime/components/Button.vue
+++ b/src/runtime/components/Button.vue
@@ -9,7 +9,7 @@ import type { ComponentConfig } from '../types/tv'
 
 type Button = ComponentConfig<typeof theme, AppConfig, 'button'>
 
-export interface ButtonProps extends Omit<UseComponentIconsProps, 'trailing' | 'trailingIcon'>, Omit<LinkProps, 'raw' | 'custom'> {
+export interface ButtonProps extends Omit<UseComponentIconsProps, 'trailing' | 'trailingIcon'>, Omit<LinkProps, 'raw' | 'custom' | 'isAction'> {
   label?: string
   /**
    * @defaultValue 'air-secondary-no-accent'

--- a/src/runtime/components/CommandPalette.vue
+++ b/src/runtime/components/CommandPalette.vue
@@ -19,7 +19,7 @@ import type { ComponentConfig } from '../types/tv'
 
 type CommandPalette = ComponentConfig<typeof theme, AppConfig, 'commandPalette'>
 
-export interface CommandPaletteItem extends Omit<LinkProps, 'type' | 'raw' | 'custom'> {
+export interface CommandPaletteItem extends Omit<LinkProps, 'type' | 'raw' | 'custom' | 'isAction'> {
   prefix?: string
   label?: string
   suffix?: string

--- a/src/runtime/components/ContextMenu.vue
+++ b/src/runtime/components/ContextMenu.vue
@@ -13,7 +13,7 @@ import type { ComponentConfig } from '../types/tv'
 
 type ContextMenu = ComponentConfig<typeof theme, AppConfig, 'contextMenu'>
 
-export interface ContextMenuItem extends Omit<LinkProps, 'type' | 'raw' | 'custom'> {
+export interface ContextMenuItem extends Omit<LinkProps, 'type' | 'raw' | 'custom' | 'isAction'> {
   label?: string
   description?: string
   /**

--- a/src/runtime/components/DropdownMenu.vue
+++ b/src/runtime/components/DropdownMenu.vue
@@ -14,7 +14,7 @@ import type { ComponentConfig } from '../types/tv'
 
 type DropdownMenu = ComponentConfig<typeof theme, AppConfig, 'dropdownMenu'>
 
-export interface DropdownMenuItem extends Omit<LinkProps, 'type' | 'raw' | 'custom'> {
+export interface DropdownMenuItem extends Omit<LinkProps, 'type' | 'raw' | 'custom' | 'isAction'> {
   label?: string
   description?: string
   /**

--- a/src/runtime/components/FooterColumns.vue
+++ b/src/runtime/components/FooterColumns.vue
@@ -8,7 +8,7 @@ import type { ComponentConfig } from '../types/tv'
 
 type FooterColumns = ComponentConfig<typeof theme, AppConfig, 'footerColumns'>
 
-export interface FooterColumnLink extends Omit<LinkProps, 'custom'> {
+export interface FooterColumnLink extends Omit<LinkProps, 'custom' | 'isAction'> {
   label: string
   /**
    * @IconComponent

--- a/src/runtime/components/NavigationMenu.vue
+++ b/src/runtime/components/NavigationMenu.vue
@@ -26,7 +26,7 @@ export interface NavigationMenuChildItem extends Omit<NavigationMenuItem, 'type'
   [key: string]: any
 }
 
-export interface NavigationMenuItem extends Omit<LinkProps, 'type' | 'raw' | 'custom'> {
+export interface NavigationMenuItem extends Omit<LinkProps, 'type' | 'raw' | 'custom' | 'isAction'> {
   label?: string
   /**
    * Icon is only used when `orientation` is `vertical`

--- a/src/runtime/components/PageLinks.vue
+++ b/src/runtime/components/PageLinks.vue
@@ -8,7 +8,7 @@ import type { ComponentConfig } from '../types/tv'
 
 type PageLinks = ComponentConfig<typeof theme, AppConfig, 'pageLinks'>
 
-export interface PageLink extends Omit<LinkProps, 'custom'> {
+export interface PageLink extends Omit<LinkProps, 'custom' | 'isAction'> {
   label: string
   /**
    * @IconComponent

--- a/src/runtime/components/content/ContentSearch.vue
+++ b/src/runtime/components/content/ContentSearch.vue
@@ -15,7 +15,7 @@ import type { ComponentConfig } from '../../types/tv'
 
 type ContentSearch = ComponentConfig<typeof theme, AppConfig, 'contentSearch'>
 
-export interface ContentSearchLink extends Omit<LinkProps, 'custom'> {
+export interface ContentSearchLink extends Omit<LinkProps, 'custom' | 'isAction'> {
   label?: string
   description?: string
   /**
@@ -52,7 +52,7 @@ export type ContentSearchStatus = 'idle' | 'loading' | 'ready' | 'error'
 
 export type ContentSearchFn = (query: string, opts?: ContentSearchOptions) => Promise<ContentSearchResult[]>
 
-export interface ContentSearchItem extends Omit<LinkProps, 'custom'>, CommandPaletteItem {
+export interface ContentSearchItem extends Omit<LinkProps, 'custom' | 'isAction'>, CommandPaletteItem {
   level?: number
   /**
    * @IconComponent

--- a/test/utils/link-props-inheritance.spec.ts
+++ b/test/utils/link-props-inheritance.spec.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, expectTypeOf } from 'vitest'
 import type { LinkProps } from '../../src/runtime/components/Link.vue'
 import type { PageLink } from '../../src/runtime/components/PageLinks.vue'
 import type { FooterColumnLink } from '../../src/runtime/components/FooterColumns.vue'
+import type { ContentSearchLink } from '../../src/runtime/components/content/ContentSearch.vue'
 import Button from '../../src/runtime/components/Button.vue'
 import Link from '../../src/runtime/components/Link.vue'
 import { linkKeys } from '../../src/runtime/utils/link-keys'
@@ -24,8 +25,8 @@ type HasIsAction<T> = 'isAction' extends keyof T ? true : false
  *
  * What can and cannot be asserted here, because it is not uniform:
  *
- *   - `ButtonProps`, `PageLink` and `FooterColumnLink` have no index signature,
- *     so removing it from their `Omit` genuinely removes it.
+ *   - `ButtonProps`, `PageLink`, `FooterColumnLink` and `ContentSearchLink` have
+ *     no index signature, so removing it from their `Omit` genuinely removes it.
  *   - `BreadcrumbItem`, `DropdownMenuItem`, `NavigationMenuItem`,
  *     `ContextMenuItem` and `CommandPaletteItem` each declare
  *     `[key: string]: any` so an item can carry arbitrary attributes. `keyof`
@@ -55,5 +56,6 @@ describe('isAction is not inherited by components that cannot honour it', () => 
   it('the link-shaped item types that can be held to it do not declare it', () => {
     expectTypeOf<HasIsAction<PageLink>>().toEqualTypeOf<false>()
     expectTypeOf<HasIsAction<FooterColumnLink>>().toEqualTypeOf<false>()
+    expectTypeOf<HasIsAction<ContentSearchLink>>().toEqualTypeOf<false>()
   })
 })

--- a/test/utils/link-props-inheritance.spec.ts
+++ b/test/utils/link-props-inheritance.spec.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, expectTypeOf } from 'vitest'
+import type { LinkProps } from '../../src/runtime/components/Link.vue'
+import type { PageLink } from '../../src/runtime/components/PageLinks.vue'
+import type { FooterColumnLink } from '../../src/runtime/components/FooterColumns.vue'
+import Button from '../../src/runtime/components/Button.vue'
+import Link from '../../src/runtime/components/Link.vue'
+import { linkKeys } from '../../src/runtime/utils/link-keys'
+
+/**
+ * Written out rather than using `toHaveProperty`, whose result on a type with
+ * an index signature is not what it reads as.
+ */
+type HasIsAction<T> = 'isAction' extends keyof T ? true : false
+
+/**
+ * `isAction` belongs to `Link` alone.
+ *
+ * It restyles a link as Bitrix24's dashed "action" text, and `src/theme/link.ts`
+ * is the only theme implementing it. It is deliberately absent from `linkKeys`,
+ * so `pickLinkProps` never forwards it — which meant every type spreading
+ * `LinkProps` advertised a prop a consumer could pass, that TypeScript
+ * accepted, that Vue registered, and that changed nothing on screen. `Button`
+ * carried it as a real runtime prop: 45 declared props, one of them dead.
+ *
+ * What can and cannot be asserted here, because it is not uniform:
+ *
+ *   - `ButtonProps`, `PageLink` and `FooterColumnLink` have no index signature,
+ *     so removing it from their `Omit` genuinely removes it.
+ *   - `BreadcrumbItem`, `DropdownMenuItem`, `NavigationMenuItem`,
+ *     `ContextMenuItem` and `CommandPaletteItem` each declare
+ *     `[key: string]: any` so an item can carry arbitrary attributes. `keyof`
+ *     therefore includes `string`, and no `Omit` can make `isAction` unassignable
+ *     on them. Their `Omit` is a statement of intent that the compiler cannot
+ *     enforce, which is why they are not asserted below — a test that cannot
+ *     fail is worse than none.
+ *
+ * The two halves are also caught by different commands: the `expect` assertions
+ * fail under `vitest run`, the `expectTypeOf` ones are erased at runtime and
+ * only `vue-tsc` — `pnpm run typecheck` — checks them.
+ */
+describe('isAction is not inherited by components that cannot honour it', () => {
+  it('Link keeps it, as a runtime prop and in its type', () => {
+    expect(Object.keys((Link as any).props)).toContain('isAction')
+    expectTypeOf<HasIsAction<LinkProps>>().toEqualTypeOf<true>()
+  })
+
+  it('is not forwarded, which is why nothing downstream could honour it', () => {
+    expect(linkKeys).not.toContain('isAction')
+  })
+
+  it('Button no longer declares it at runtime', () => {
+    expect(Object.keys((Button as any).props)).not.toContain('isAction')
+  })
+
+  it('the link-shaped item types that can be held to it do not declare it', () => {
+    expectTypeOf<HasIsAction<PageLink>>().toEqualTypeOf<false>()
+    expectTypeOf<HasIsAction<FooterColumnLink>>().toEqualTypeOf<false>()
+  })
+})


### PR DESCRIPTION
### Linked issue

None — found while re-measuring #88 against upstream.

### Type of change

- [ ] Documentation (updates to the documentation or readme)
- [x] Bug fix (a non-breaking change that fixes an issue)
- [ ] Enhancement (improving an existing functionality)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Chore (updates to the build process or auxiliary tools and libraries)
- [ ] Revert (undoing a merged change — retitle this PR `revert(Scope): ...`)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### ⚠️ Shipping as a patch, deliberately — but it can fail a downstream build

Runtime behaviour does not change: `isAction` never reached anything outside `Link`, so nothing that worked before stops working. What changes is that TypeScript now **rejects** `isAction` where it used to accept it silently. A project passing it to `B24Button` or to a page/footer/content-search link will fail to compile after upgrading.

That was weighed: a `BREAKING CHANGE` footer would take the package to a major version for the removal of a prop that never did anything, and a silent patch would hand people a red build with no warning. The middle course is this — `fix(types)` with the consequence stated plainly here and in the squash body, so it reads as a visible line in the changelog rather than a surprise. The fix is a one-word deletion at the call site.

### Description

`isAction` restyles a link as Bitrix24's dashed "action" text. `src/theme/link.ts` is the only theme that implements it, and it is deliberately absent from `linkKeys` — so `pickLinkProps` never forwards it downstream.

Everything spreading `LinkProps` inherited it anyway. A consumer could write `isAction` on a `B24Button` or a breadcrumb item, TypeScript accepted it, Vue registered it, and nothing changed on screen. `Button` declared it as a real runtime prop:

```
before   Object.keys(Button.props).length === 45   // includes 'isAction'
after    Object.keys(Button.props).length === 44
```

Ten types across nine files omit it now — `ButtonProps`, `BreadcrumbItem`, `CommandPaletteItem`, `ContentSearchItem`, `ContentSearchLink`, `ContextMenuItem`, `DropdownMenuItem`, `FooterColumnLink`, `NavigationMenuItem`, `PageLink` — and anything extending `ButtonProps` follows. `Link` keeps it.

Nothing in the repository passed it anywhere but `B24Link`, so no example, playground or documentation changes.

### What is enforceable, and what is not

The omission does not mean the same thing everywhere, and the spec says so rather than pretending:

| type | index signature | omission enforceable |
|---|---|---|
| `ButtonProps` | no | **yes** |
| `PageLink` | no | **yes** |
| `FooterColumnLink` | no | **yes** |
| `ContentSearchLink` | no | **yes** |
| `BreadcrumbItem`, `DropdownMenuItem`, `NavigationMenuItem`, `ContextMenuItem`, `CommandPaletteItem`, `ContentSearchItem` | `[key: string]: any` | no |

Those six accept arbitrary attributes by design, so `keyof` includes `string` and no `Omit` can make `isAction` unassignable on them. Their omission states intent the compiler cannot check. The spec asserts only the four it can — a test that cannot fail is worse than none.

### The guard, and why it is in two halves

They fail under different commands, and neither covers the other:

- `expect(Object.keys(Button.props)).not.toContain('isAction')` and `expect(linkKeys).not.toContain('isAction')` fail under `vitest run`.
- The `expectTypeOf` assertions are erased at runtime; only `vue-tsc` (`pnpm run typecheck`) checks them.

Both mutation-checked: reverting `Button`'s omit reddens two tests in `vitest run`; reverting `PageLink`'s or `ContentSearchLink`'s reddens `typecheck`.

The type predicate is written out as `type HasIsAction<T> = 'isAction' extends keyof T ? true : false` rather than using `expectTypeOf().not.toHaveProperty()`. The latter was tried first and gave results that did not match how it reads on types with an index signature, with `error TS2554: Expected 2 arguments, but got 1` as its failure message.

### Review

`/review` caught the first sweep reading only `src/runtime/components/*.vue` and never descending into `content/`, leaving `ContentSearchLink` and `ContentSearchItem` still advertising the prop. Fixed in the second commit; the sweep is now a search across all of `src/`, and `ContentSearchLink` is mutation-checked with the rest.

The five-reviewer panel was not convened: nine one-line type edits and one spec, with both halves already proven by mutation.

### Provenance

`isAction` is ours, not inherited: `nuxt/ui@v4` has no such prop anywhere.

### Gate

`lint`, `typecheck`, 322 test files / 7498 tests, `test:module`, and coverage 71.89 / 69.93 / 71.19 / 71.44 against thresholds of 70 / 68 / 70 / 70.

### Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.