### PR TITLE
fix(playgrounds): add the InputMenu autocomplete-mode row both are missing

### DIFF
--- a/.sync/log/2799fa6f2b25ce3eb15e050f3ef7c57d0d9a2fdb.md
+++ b/.sync/log/2799fa6f2b25ce3eb15e050f3ef7c57d0d9a2fdb.md
@@ -60,13 +60,15 @@ Deliberately narrower than upstream in three places, two of which are right:
   contents (`autocomplete` → `mode="autocomplete"`) and kept the name, which
   keeps `name: 'input-menu-autocomplete-example'` in the docs page valid. Still
   the current state: the file is `InputMenuAutocompleteExample.vue` on `main`.
-- **Playground line dropped, and this one is a gap.** Upstream added
+- **Playground line dropped — a real gap, closed later.** Upstream added
   `<UInputMenu placeholder="Autocomplete" mode="autocomplete" … />` to
   `playgrounds/nuxt/app/pages/components/input-menu.vue`. Nothing equivalent was
-  added here, and re-checking at the time of writing, neither
-  `playgrounds/nuxt` nor `playgrounds/demo` has an autocomplete-mode row for
-  InputMenu. Small, but real: it is the only place the mode can be exercised by
-  hand, and the omission was not recorded anywhere until now.
+  added here, and when this log was first written neither `playgrounds/nuxt` nor
+  `playgrounds/demo` had an autocomplete-mode row for InputMenu — small, but the
+  only place the mode could be exercised by hand, and recorded nowhere until this
+  backfill turned it up. **Fixed on 2026-08-31 (#519):** both playgrounds now
+  carry the row, backed by its own `valueAutocomplete` ref, because in this mode
+  `modelValue` is the input text rather than a selected item.
 
 The native-attribute half of the change was ported and covered:
 

--- a/.sync/log/2799fa6f2b25ce3eb15e050f3ef7c57d0d9a2fdb.md
+++ b/.sync/log/2799fa6f2b25ce3eb15e050f3ef7c57d0d9a2fdb.md
@@ -66,7 +66,7 @@ Deliberately narrower than upstream in three places, two of which are right:
   added here, and when this log was first written neither `playgrounds/nuxt` nor
   `playgrounds/demo` had an autocomplete-mode row for InputMenu — small, but the
   only place the mode could be exercised by hand, and recorded nowhere until this
-  backfill turned it up. **Fixed on 2026-08-31 (#519):** both playgrounds now
+  backfill turned it up. **Fixed on 2026-08-31 (#520):** both playgrounds now
   carry the row, backed by its own `valueAutocomplete` ref, because in this mode
   `modelValue` is the input text rather than a selected item.
 

--- a/playgrounds/demo/app/pages/components/input-menu.vue
+++ b/playgrounds/demo/app/pages/components/input-menu.vue
@@ -34,6 +34,9 @@ const items = ref(['Prospecting', 'Qualifying', 'Presenting', 'Negotiating', 'Cl
 const itemsSimple = ref(['Prospecting', 'Qualifying', 'Presenting', 'Negotiating', 'Closed'])
 const valueForAdd = ref('Prospecting')
 const valueMultiple = ref(['Prospecting', 'Presenting'])
+// `mode="autocomplete"` makes modelValue the input text rather than a selected
+// item, so this one is a string where the rows above hold items.
+const valueAutocomplete = ref('')
 
 // #342 is only visible with labels long enough to want more room than the field
 // has. happy-dom does no layout, so no snapshot can show this — the check is a
@@ -231,6 +234,16 @@ const itemsObj = ref([
         multiple
         aria-label="Multiple with long labels"
         placeholder="Multiple, long labels"
+        v-bind="{ ...singleAttrs, ...props }"
+        class="w-full"
+      />
+      <B24InputMenu
+        v-model="valueAutocomplete"
+        :items="items"
+        mode="autocomplete"
+        name="some_value"
+        placeholder="Autocomplete"
+        aria-label="Autocomplete"
         v-bind="{ ...singleAttrs, ...props }"
         class="w-full"
       />

--- a/playgrounds/nuxt/app/pages/components/input-menu.vue
+++ b/playgrounds/nuxt/app/pages/components/input-menu.vue
@@ -34,6 +34,9 @@ const items = ref(['Prospecting', 'Qualifying', 'Presenting', 'Negotiating', 'Cl
 const itemsSimple = ref(['Prospecting', 'Qualifying', 'Presenting', 'Negotiating', 'Closed'])
 const valueForAdd = ref('Prospecting')
 const valueMultiple = ref(['Prospecting', 'Presenting'])
+// `mode="autocomplete"` makes modelValue the input text rather than a selected
+// item, so this one is a string where the rows above hold items.
+const valueAutocomplete = ref('')
 
 function onCreate(item: string) {
   itemsSimple.value.unshift(item)
@@ -212,6 +215,16 @@ const itemsObj = ref([
         v-bind="{ ...singleAttrs, ...props }"
         class="w-full"
         @create="onCreateMultiple"
+      />
+      <B24InputMenu
+        v-model="valueAutocomplete"
+        :items="items"
+        mode="autocomplete"
+        name="some_value"
+        placeholder="Autocomplete"
+        aria-label="Autocomplete"
+        v-bind="{ ...singleAttrs, ...props }"
+        class="w-full"
       />
       <B24InputMenu
         :icon="TaskListIcon"


### PR DESCRIPTION
Closes the one finding #518 recorded but did not fix.

## What was missing

Upstream's `2799fa6f` — the commit that renamed InputMenu's `autocomplete` boolean to `mode: 'combobox' | 'autocomplete'` — added a row exercising the new mode to its own playground:

```vue
<UInputMenu placeholder="Autocomplete" mode="autocomplete" :items="items" v-bind="props" />
```

The port (#68, `081a9799`) dropped that line, and nothing has added one since. So `mode="autocomplete"` has never been reachable by hand in either playground.

Nothing else covers it, either. The unit tests exercise the prop, but no snapshot pins the mode — the render is byte-identical and only the prop spelling changes, which is exactly why `081a9799` could say "snapshots unchanged" and be right. A person looking at the component was the only way to see the mode behave, and that path did not exist.

## The change

One row in each of `playgrounds/nuxt` and `playgrounds/demo`, placed identically (before the virtualized row) so the two pages stay aligned:

```vue
<B24InputMenu
  v-model="valueAutocomplete"
  :items="items"
  mode="autocomplete"
  name="some_value"
  placeholder="Autocomplete"
  aria-label="Autocomplete"
  v-bind="{ ...singleAttrs, ...props }"
  class="w-full"
/>
```

It takes **its own ref** rather than reusing one of the refs above it, and that is the substance of the change rather than boilerplate: in autocomplete mode `modelValue` is the input text — a `string` — where every other row on the page binds a selected item. Binding it to `valueMultiple` or `valueForAdd` would have typechecked in some shapes and shown the wrong thing in all of them. The comment on the declaration says so, since the reason is not visible from the row itself.

Deliberately not added: `:content="{ hideWhenEmpty: true }"`, which the docs example carries. The playground's job is to show default behaviour; hiding the empty panel is a separate prop with its own row elsewhere.

## Bookkeeping

`.sync/log/2799fa6f….md` — written in #518 — said "neither `playgrounds/nuxt` nor `playgrounds/demo` has an autocomplete-mode row". That is now false, so the log is updated to record that the gap was closed here rather than left standing as a stale claim.

## Verification

Full gate: `lint` · `typecheck` · `build` (3.86 MB) · `test` — **322 files, 7502 passed, 6 skipped**.

`typecheck` is the one that carries weight here: it runs `nuxt typecheck` over four projects, two of them these playgrounds, so a wrongly-typed `v-model` on the new row fails the gate rather than the eye.


---
_Generated by [Claude Code](https://claude.ai/code/session_01JS8ypVfQSFzYVZzkTHhURb)_