### PR TITLE
test: cover the last of the thirteen, and the three upstream helpers a user can see

### DIFF
--- a/test/components/ModalDialogClose.spec.ts
+++ b/test/components/ModalDialogClose.spec.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest'
+import { ref } from 'vue'
+import { mountSuspended } from '@nuxt/test-utils/runtime'
+import ModalDialogClose from '../../src/runtime/components/ModalDialogClose.vue'
+import Modal from '../../src/runtime/components/Modal.vue'
+import Button from '../../src/runtime/components/Button.vue'
+
+/**
+ * A nineteen-line passthrough over reka-ui's `DialogClose`, used once — by
+ * `SidebarLayout`, to close the mobile sidebar. It renders `as-child`, so it
+ * contributes no element of its own, and everything depends on it forwarding
+ * both the slot and the close behaviour to whatever it wraps.
+ *
+ * Mounted inside a real `Modal`: on its own, `DialogClose` has no dialog to
+ * close and the test would be asserting that nothing happens. `open` is bound
+ * rather than passed as a literal `true`, because a literal one is never
+ * written back and the dialog would stay open however well the click worked.
+ */
+describe('ModalDialogClose', () => {
+  const mountInModal = () => {
+    const open = ref(true)
+
+    return mountSuspended({
+      components: { B24Modal: Modal, B24Button: Button, B24ModalDialogClose: ModalDialogClose },
+      setup: () => ({ open }),
+      template: `
+        <B24Modal v-model:open="open" :portal="false" title="Title">
+          <template #body>
+            <B24ModalDialogClose>
+              <B24Button label="Close it" />
+            </B24ModalDialogClose>
+          </template>
+        </B24Modal>
+      `
+    })
+  }
+
+  /** The dialog renders its own close button too; ours is the one with a label. */
+  const ourButton = (wrapper: Awaited<ReturnType<typeof mountInModal>>) =>
+    wrapper.findAll('button').find(button => button.text().includes('Close it'))!
+
+  it('renders its child and contributes no element of its own', async () => {
+    const wrapper = await mountInModal()
+
+    // `as-child` means the child *is* the trigger — reka-ui puts the dialog
+    // wiring onto the button rather than wrapping it in an element.
+    expect(ourButton(wrapper).exists()).toBe(true)
+    expect(wrapper.html()).not.toContain('data-slot="modalDialogClose"')
+  })
+
+  it('closes the dialog when its child is activated', async () => {
+    const wrapper = await mountInModal()
+
+    expect(wrapper.find('[data-slot="content"]').exists()).toBe(true)
+
+    await ourButton(wrapper).trigger('click')
+    await new Promise(resolve => setTimeout(resolve, 50))
+
+    expect(wrapper.find('[data-slot="content"]').exists()).toBe(false)
+  })
+})

--- a/test/utils/content-navigation.spec.ts
+++ b/test/utils/content-navigation.spec.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect } from 'vitest'
+import type { ContentNavigationItem } from '@nuxt/content'
+import { mapContentNavigation, mapContentNavigationItem } from '../../src/runtime/utils/content'
+
+/**
+ * Turns `@nuxt/content`'s navigation tree into the item shape the navigation
+ * components take — which is to say, it builds the sidebar of any docs site
+ * built on this kit. Nothing exercised it before.
+ *
+ * The rename is the whole of it: `title` becomes `label` and `path` becomes
+ * `to`, because that is what `NavigationMenu` and friends read. Get it wrong
+ * and the sidebar renders a column of blank, unclickable rows.
+ */
+describe('mapContentNavigationItem', () => {
+  const entry = (over: Partial<ContentNavigationItem> = {}) =>
+    ({ title: 'Getting started', path: '/docs/start', ...over }) as ContentNavigationItem
+
+  it('renames title to label and path to to', () => {
+    expect(mapContentNavigationItem(entry())).toMatchObject({
+      label: 'Getting started',
+      to: '/docs/start'
+    })
+  })
+
+  it('drops the original keys rather than carrying both', () => {
+    const link = mapContentNavigationItem(entry())
+
+    expect(link).not.toHaveProperty('title')
+    expect(link).not.toHaveProperty('path')
+  })
+
+  it('carries every other key through untouched', () => {
+    const link = mapContentNavigationItem(entry({ icon: 'i-lucide-home', badge: 'new' } as any))
+
+    expect(link).toMatchObject({ icon: 'i-lucide-home', badge: 'new' })
+  })
+
+  it('takes the label from labelAttribute when one is given', () => {
+    const link = mapContentNavigationItem(entry({ navTitle: 'Start here' } as any), { labelAttribute: 'navTitle' })
+
+    // `title` is no longer the mapped key, so it stays under its own name.
+    expect(link).toMatchObject({ label: 'Start here', title: 'Getting started' })
+  })
+
+  it('skips falsy values, so an empty title does not produce an empty label', () => {
+    const link = mapContentNavigationItem(entry({ title: '' }))
+
+    expect(link).not.toHaveProperty('label')
+  })
+
+  describe('children', () => {
+    const nested = entry({
+      children: [entry({ title: 'Install', path: '/docs/install', children: [entry({ title: 'CLI', path: '/docs/install/cli' })] })]
+    })
+
+    it('recurses, renaming at every level', () => {
+      const link = mapContentNavigationItem(nested)
+
+      expect(link.children?.[0]).toMatchObject({ label: 'Install', to: '/docs/install' })
+      expect((link.children?.[0] as any).children[0]).toMatchObject({ label: 'CLI', to: '/docs/install/cli' })
+    })
+
+    it('always sets children, so a leaf is an empty array rather than absent', () => {
+      expect(mapContentNavigationItem(entry()).children).toEqual([])
+    })
+
+    it('stops at the depth `deep` names', () => {
+      const link = mapContentNavigationItem(nested, { deep: 1 })
+
+      expect(link.children).toHaveLength(1)
+      // Depth 1 is the last level walked; its own children are cut.
+      expect(link.children?.[0]?.children).toEqual([])
+    })
+
+    it('flattens to a list of roots at deep: 0', () => {
+      expect(mapContentNavigationItem(nested, { deep: 0 }).children).toEqual([])
+    })
+  })
+})
+
+describe('mapContentNavigation', () => {
+  it('maps a whole tree and keeps its order', () => {
+    const result = mapContentNavigation([
+      { title: 'One', path: '/one' },
+      { title: 'Two', path: '/two' }
+    ] as ContentNavigationItem[])
+
+    expect(result.map(item => item.label)).toEqual(['One', 'Two'])
+    expect(result.map(item => item.to)).toEqual(['/one', '/two'])
+  })
+
+  it('passes its options down', () => {
+    const result = mapContentNavigation(
+      [{ navTitle: 'Renamed', title: 'Original', path: '/x' }] as unknown as ContentNavigationItem[],
+      { labelAttribute: 'navTitle' }
+    )
+
+    expect(result[0]).toMatchObject({ label: 'Renamed' })
+  })
+})

--- a/test/utils/link-partial-query.spec.ts
+++ b/test/utils/link-partial-query.spec.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest'
+import { isPartiallyEqual } from '../../src/runtime/utils/link'
+
+/**
+ * What `exactQuery: 'partial'` means for a link's active state.
+ *
+ * `Link` calls this with the link's own query and the current route's query, in
+ * that order. The current route carries whatever else the app put in the URL —
+ * a search term, a page number, a tracking parameter — and a link that declares
+ * `?tab=general` should stay highlighted through all of it. So keys the second
+ * object adds are ignored, and everything the link declares still has to match.
+ *
+ * Nothing exercised it before: `utils/link.ts` sat at 44% statements and 0%
+ * branches, and the only visible symptom of it breaking is a navigation item
+ * that highlights when it should not, or stops highlighting when it should.
+ */
+describe('isPartiallyEqual', () => {
+  it('ignores keys the current route adds', () => {
+    expect(isPartiallyEqual({ tab: 'general' }, { tab: 'general', page: '2', q: 'term' })).toBe(true)
+  })
+
+  it('refuses when a declared key holds a different value', () => {
+    expect(isPartiallyEqual({ tab: 'general' }, { tab: 'billing', page: '2' })).toBe(false)
+  })
+
+  it('refuses when a declared key is missing from the route', () => {
+    // The asymmetry that makes this "partial" rather than "subset either way":
+    // extra keys on the right are forgiven, missing ones are not.
+    expect(isPartiallyEqual({ tab: 'general' }, { page: '2' })).toBe(false)
+  })
+
+  it('matches two empty queries', () => {
+    expect(isPartiallyEqual({}, {})).toBe(true)
+  })
+
+  it('matches an empty declaration against any route', () => {
+    expect(isPartiallyEqual({}, { page: '2' })).toBe(true)
+  })
+
+  it('compares values rather than their string forms', () => {
+    expect(isPartiallyEqual({ page: 2 }, { page: '2' })).toBe(false)
+  })
+
+  it('handles a repeated query parameter, which vue-router gives as an array', () => {
+    expect(isPartiallyEqual({ tag: ['a', 'b'] }, { tag: ['a', 'b'], page: '2' })).toBe(true)
+    expect(isPartiallyEqual({ tag: ['a', 'b'] }, { tag: ['a'], page: '2' })).toBe(false)
+  })
+})

--- a/test/utils/overlay.spec.ts
+++ b/test/utils/overlay.spec.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi } from 'vitest'
+import type { PointerDownOutsideEvent } from 'reka-ui'
+import { pointerDownOutside } from '../../src/runtime/utils/overlay'
+
+/**
+ * What decides whether a click beside a `Modal`, `Drawer` or `Popover` closes
+ * it. Both of its branches exist because of a case where the honest answer —
+ * "the pointer went down outside, so close" — is wrong, and both are invisible
+ * until they misfire on a real user: an overlay that will not close, or one
+ * that closes while its scrollbar is being dragged.
+ */
+describe('pointerDownOutside', () => {
+  const event = (target: Partial<HTMLElement>, offsets: { offsetX?: number, offsetY?: number } = {}) => {
+    const preventDefault = vi.fn()
+    return {
+      event: { detail: { originalEvent: { target, offsetX: 0, offsetY: 0, ...offsets } }, preventDefault } as unknown as PointerDownOutsideEvent,
+      preventDefault
+    }
+  }
+
+  const connected = (over: Partial<HTMLElement> = {}) =>
+    ({ isConnected: true, clientWidth: 100, clientHeight: 100, ...over }) as Partial<HTMLElement>
+
+  it('closes on an ordinary click outside', () => {
+    const { event: e, preventDefault } = event(connected())
+
+    pointerDownOutside(e)
+
+    expect(preventDefault).not.toHaveBeenCalled()
+  })
+
+  describe('a target no longer in the document', () => {
+    // On touch, reka-ui defers the dispatch to the click event. If the element
+    // went away in between — a toast dismissing itself is the case this was
+    // written for — the overlay would take that as a click outside and close.
+    it('does not close', () => {
+      const { event: e, preventDefault } = event({ isConnected: false })
+
+      pointerDownOutside(e)
+
+      expect(preventDefault).toHaveBeenCalledOnce()
+    })
+
+    it('does not close when there is no target at all', () => {
+      const { event: e, preventDefault } = event(null as unknown as Partial<HTMLElement>)
+
+      pointerDownOutside(e)
+
+      expect(preventDefault).toHaveBeenCalledOnce()
+    })
+  })
+
+  describe('scrollable mode', () => {
+    // A scrollbar is painted outside the element's client box, so dragging one
+    // reads as a click outside. Only checked in scrollable mode: elsewhere the
+    // overlay has no scrollbar of its own to hit.
+    it('does not close when the pointer lands past the right edge', () => {
+      const { event: e, preventDefault } = event(connected(), { offsetX: 108 })
+
+      pointerDownOutside(e, { scrollable: true })
+
+      expect(preventDefault).toHaveBeenCalledOnce()
+    })
+
+    it('does not close when the pointer lands past the bottom edge', () => {
+      const { event: e, preventDefault } = event(connected(), { offsetY: 108 })
+
+      pointerDownOutside(e, { scrollable: true })
+
+      expect(preventDefault).toHaveBeenCalledOnce()
+    })
+
+    it('still closes on a click inside the client box', () => {
+      const { event: e, preventDefault } = event(connected(), { offsetX: 40, offsetY: 40 })
+
+      pointerDownOutside(e, { scrollable: true })
+
+      expect(preventDefault).not.toHaveBeenCalled()
+    })
+
+    it('ignores the scrollbar edges when scrollable is off', () => {
+      const { event: e, preventDefault } = event(connected(), { offsetX: 108, offsetY: 108 })
+
+      pointerDownOutside(e)
+
+      expect(preventDefault).not.toHaveBeenCalled()
+    })
+  })
+})


### PR DESCRIPTION
### Linked issue

Refs #86.

### Type of change

- [ ] Documentation (updates to the documentation or readme)
- [ ] Bug fix (a non-breaking change that fixes an issue)
- [ ] Enhancement (improving an existing functionality)
- [ ] New feature (a non-breaking change that adds functionality)
- [x] Chore (updates to the build process or auxiliary tools and libraries)
- [ ] Revert (undoing a merged change — retitle this PR `revert(Scope): ...`)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

No `src/` changes at all — four new spec files.

### 1. `ModalDialogClose` — the last of the thirteen

#519 covered eleven of the thirteen components that are ours and had no coverage anywhere. This is the twelfth: a nineteen-line passthrough over reka-ui's `DialogClose`, used once, by `SidebarLayout`, to close the mobile sidebar.

Two things the spec had to get right, and one of them it got wrong first:

- **Mounted inside a real `Modal`.** On its own, `DialogClose` has no dialog to close, and the test would assert that nothing happens.
- **`open` is bound, not a literal `true`.** A literal is never written back, so the dialog stays open however well the click works. The first draft passed exactly that way and proved nothing.

Replacing `DialogClose` with a plain `span` reddens it.

### 2. A change of direction, and what it cost to establish

The plan recorded on #86 put the nine untested `src/runtime/utils` modules next. Measured first, that workstream is almost empty — "has no spec named after it" is not the same as uncovered:

| | statements | ours? |
|---|---|---|
| `ai.ts` | 0% | byte-identical to `nuxt/ui@v4` |
| `content.ts` | 0% | +14 lines, all JSDoc bar one type widening |
| `overlay.ts` | 0% | byte-identical to upstream |
| `editor.ts` | 12% | +85 lines, none of them the `as any` (see #88) |
| `link.ts` | 44%, **0% branches** | +21 lines, all JSDoc |
| `virtualizer.ts` | 71% | +4/−2 lines |
| `dashboard.ts`, `link-keys.ts`, `prototype-guard.ts` | **100%** | — |

`prototype-guard.ts` looked like the prize — 81 lines, entirely ours, closing two prototype-pollution holes. It is already at 100%, exercised through `get`/`set` and `getAtPath`/`setAtPath`, including the case where `set({}, 'toString.x', 1)` reached `Object.prototype.toString` with no reserved word in the path.

So everything left uncovered there is upstream's logic, and the question became whether we test code we ship but did not write. **Decided with the maintainer: yes, but only what a user can see.** A test does not diverge from upstream the way a rewrite does — it lives in `test/`, `src/` stays byte-identical, and nothing new conflicts on a sync. Upstream having no tests is the argument *for* writing them: when we port their changes, ours are the only safety net (#75).

### 3. The three that passed that filter

| helper | was | what it sits under |
|---|---|---|
| `utils/overlay.ts` | 0% | whether a click beside a `Modal`, `Drawer` or `Popover` closes it |
| `utils/link.ts` | 44% / **0% branches** | which navigation item is highlighted |
| `utils/content.ts` | 0% | the sidebar of any docs site built on this kit |

**`pointerDownOutside`** has two branches, and both exist for a case where the honest answer — "the pointer went down outside, so close" — is wrong: a target that left the DOM between pointerdown and click (a toast dismissing itself on touch), and a click on the overlay's own scrollbar, which is painted outside the client box. Misfiring either way gives an overlay that will not close, or one that closes mid-drag.

**`isPartiallyEqual`** is what `exactQuery: 'partial'` means. The current route carries whatever else is in the URL; a link declaring `?tab=general` has to stay highlighted through a search term and a page number. Keys the route adds are forgiven, keys the link declares are not — the asymmetry that makes it "partial" rather than "subset either way".

**`mapContentNavigationItem`** renames `title` to `label` and `path` to `to` for every entry in a `@nuxt/content` tree. Get it wrong and the sidebar is a column of blank, unclickable rows.

All three reach **100% of statements and branches.** Every branch is mutation-checked: forgiving removed keys as well as added ones, dropping the `isConnected` guard, narrowing the scrollbar check to one axis, removing the `deep` limit, and four more each redden a named test.

### Not covered, deliberately

`ai.ts` — streaming-state predicates, visible only inside a chat UI. `virtualizer.ts` — 71%, and what is left is measurement arithmetic. `editor.ts` — 12% of 587 lines, a slice of its own if it is worth one at all.

### Gate

`lint`, `typecheck`, 336 test files / 7676 tests, and coverage **74.31 → 74.76%** statements, 71.53 → 71.86 branches.

### Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.