### PR TITLE
test: cover the two keyboard paths we hand-wrote

### DIFF
--- a/test/components/CommandPalette.keyboard.spec.ts
+++ b/test/components/CommandPalette.keyboard.spec.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from 'vitest'
+import { mountSuspended } from '@nuxt/test-utils/runtime'
+import CommandPalette from '../../src/runtime/components/CommandPalette.vue'
+
+/**
+ * Backspace in the palette does two different things depending on where the
+ * caret is, and only one of them is obvious.
+ *
+ * With text typed, it deletes a character — the ordinary meaning. With the
+ * field empty it steps back out of a group the user drilled into, which is the
+ * only keyboard way out of one. Confusing the two is immediately visible:
+ * hitting backspace to fix a typo would throw you out of the group instead.
+ *
+ * `keydown`/`keyup` appear in two spec files in this repository, and neither is
+ * this one — the guard was written and never exercised.
+ */
+describe('CommandPalette — Backspace', () => {
+  const groups = [{
+    id: 'files',
+    items: [
+      { label: 'Documents', placeholder: 'Search documents…', children: [{ label: 'Report' }, { label: 'Invoice' }] },
+      { label: 'Pictures' }
+    ]
+  }]
+
+  const mount = () => mountSuspended(CommandPalette, { props: { groups } as any })
+
+  const input = (wrapper: Awaited<ReturnType<typeof mount>>) => wrapper.find('input')
+
+  /** Drilling in is what puts something on the history stack to come back from. */
+  const drillIn = async (wrapper: Awaited<ReturnType<typeof mount>>) => {
+    await (wrapper.vm as any).navigate?.({ label: 'Documents', placeholder: 'Search documents…', children: [{ label: 'Report' }, { label: 'Invoice' }] })
+    await wrapper.vm.$nextTick()
+  }
+
+  it('steps back out of a group when the field is empty', async () => {
+    const wrapper = await mount()
+    await drillIn(wrapper)
+    expect(input(wrapper).attributes('placeholder')).toBe('Search documents…')
+
+    await input(wrapper).trigger('keydown', { key: 'Backspace' })
+    await wrapper.vm.$nextTick()
+
+    expect(input(wrapper).attributes('placeholder')).not.toBe('Search documents…')
+    expect(wrapper.text()).toContain('Pictures')
+  })
+
+  it('leaves the group alone while there is text to delete', async () => {
+    const wrapper = await mount()
+    await drillIn(wrapper)
+
+    await input(wrapper).setValue('rep')
+    await input(wrapper).trigger('keydown', { key: 'Backspace' })
+    await wrapper.vm.$nextTick()
+
+    // Read through the placeholder rather than the visible items: with text in
+    // the field the root's items are filtered out anyway, so "Pictures is not
+    // shown" is true whether or not we stepped back, and an assertion on it
+    // cannot fail. The placeholder comes from the group on the history stack.
+    expect(input(wrapper).attributes('placeholder')).toBe('Search documents…')
+  })
+
+  it('does nothing at the root, where there is nothing to go back to', async () => {
+    const wrapper = await mount()
+    const before = wrapper.text()
+
+    await input(wrapper).trigger('keydown', { key: 'Backspace' })
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.text()).toBe(before)
+  })
+})

--- a/test/components/FileUpload.keyboard.spec.ts
+++ b/test/components/FileUpload.keyboard.spec.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { mountSuspended } from '@nuxt/test-utils/runtime'
+import FileUpload from '../../src/runtime/components/FileUpload.vue'
+
+/**
+ * Reaching the dropzone without a mouse.
+ *
+ * A drop target is not a native control, so everything a keyboard user needs
+ * is hand-written here: a `tabindex` to reach it, `role="button"` to announce
+ * it, Enter and Space to activate it, and `@keydown.space.prevent` so Space
+ * does not scroll the page out from under them instead. All four are gated on
+ * `interactive` and `disabled`, and none of them was exercised — `keydown` and
+ * `keyup` appear in two spec files in this repository, and neither is this one.
+ */
+describe('FileUpload — keyboard', () => {
+  // `spyOn` on a prototype method hands back the existing spy when one is
+  // already installed, so without this the call count carries from case to
+  // case and "was not called" passes or fails on the wrong test's clicks.
+  afterEach(() => vi.restoreAllMocks())
+
+  /**
+   * `open()` ends in `fileDialog.open()`, which calls `.click()` on a detached
+   * `<input type="file">`. Nothing observable comes back from that, so the
+   * click is what gets counted.
+   */
+  const mountWithSpy = async (props: Record<string, unknown> = {}) => {
+    const clicked = vi.spyOn(HTMLInputElement.prototype, 'click').mockImplementation(() => {})
+    const wrapper = await mountSuspended(FileUpload, { props: { label: 'Drop here', ...props } as any })
+    return { wrapper, clicked, dropzone: wrapper.find('[data-slot="base"]') }
+  }
+
+  it('is reachable by Tab and announced as a button', async () => {
+    const { dropzone } = await mountWithSpy()
+
+    expect(dropzone.attributes('tabindex')).toBe('0')
+    expect(dropzone.attributes('role')).toBe('button')
+  })
+
+  it.each(['Enter', ' '])('opens the file dialog on %s', async (key) => {
+    const { dropzone, clicked } = await mountWithSpy()
+
+    await dropzone.trigger('keyup', { key })
+
+    expect(clicked).toHaveBeenCalled()
+  })
+
+  it('swallows the Space keydown so the page does not scroll', async () => {
+    // Space on a focused element scrolls by default. The dropzone activates on
+    // `keyup`, so the matching `keydown` has to be cancelled or the page moves
+    // between the two halves of the press.
+    const { dropzone } = await mountWithSpy()
+
+    const event = new KeyboardEvent('keydown', { key: ' ', cancelable: true, bubbles: true })
+    dropzone.element.dispatchEvent(event)
+
+    expect(event.defaultPrevented).toBe(true)
+  })
+
+  describe('when it cannot be used', () => {
+    it.each([
+      ['disabled', { disabled: true }],
+      ['not interactive', { interactive: false }]
+    ])('is skipped by Tab and ignores Enter when %s', async (_case, props) => {
+      const { dropzone, clicked } = await mountWithSpy(props)
+
+      expect(dropzone.attributes('tabindex')).toBe('-1')
+
+      await dropzone.trigger('keyup', { key: 'Enter' })
+
+      expect(clicked).not.toHaveBeenCalled()
+    })
+  })
+})


### PR DESCRIPTION
### Linked issue

Refs #86 — its last open workstream.

### Type of change

- [ ] Documentation (updates to the documentation or readme)
- [ ] Bug fix (a non-breaking change that fixes an issue)
- [ ] Enhancement (improving an existing functionality)
- [ ] New feature (a non-breaking change that adds functionality)
- [x] Chore (updates to the build process or auxiliary tools and libraries)
- [ ] Revert (undoing a merged change — retitle this PR `revert(Scope): ...`)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

No `src/` changes — two new spec files.

### The workstream is much smaller than it reads

#86 describes it as "no arrow-key/Home/End/Escape tests for menus, tabs, accordion, palette, pagination". That sounds like a large gap. It is not one: all of that is reka-ui's roving focus and typeahead, and a test here would be testing reka-ui.

Measured instead — **five places in `src/runtime` handle a key themselves**:

| | spec |
|---|---|
| `composables/defineShortcuts.ts` | ✅ has one |
| `components/ChatPrompt.vue` | ✅ has one |
| `composables/useEditorMenu.ts` | ✅ has one |
| `components/CommandPalette.vue` | **none** |
| `components/FileUpload.vue` | **none** |

Those two are what this covers, and both are things a keyboard user meets directly.

### `CommandPalette` — Backspace means two different things

With text typed it deletes a character, the ordinary meaning. With the field empty it steps back out of a group the user drilled into — the only keyboard way out of one. Confusing them is immediately visible: hitting backspace to fix a typo would throw you out of the group instead.

```ts
function onBackspace() {
  if (!searchTerm.value) {
    navigateBack()
  }
}
```

**The second case is asserted through the placeholder, not the visible items.** With text in the field the root group's items are filtered out anyway, so "Pictures is not shown" holds whether or not we stepped back — the first draft asserted exactly that and could not fail. Removing the empty-search guard left it green. The placeholder comes off the group on the history stack, which the filter does not touch.

### `FileUpload` — a dropzone is not a native control

Everything a keyboard user needs is hand-written on it, and none of it was exercised:

- `tabindex` to reach it
- `role="button"` to announce it
- Enter and Space to activate it
- `@keydown.space.prevent`, so Space does not scroll the page out from under them between keydown and keyup

All four are gated on `interactive` and `disabled`.

### Mutation-checked, branch by branch

| mutation | reddens |
|---|---|
| drop the empty-search guard | *leaves the group alone while there is text to delete* |
| remove `history.pop()` | *steps back out of a group when the field is empty* |
| drop `@keydown.space.prevent` | *swallows the Space keydown so the page does not scroll* |
| narrow `keyup.enter.space` to Enter | *opens the file dialog on Space* |
| pin `tabindex` at `0` | both *when it cannot be used* cases |
| drop the `interactive`/`disabled` guards | both *when it cannot be used* cases |

One note worth carrying to other specs: `vi.restoreAllMocks()` runs after each `FileUpload` case. `spyOn` on a prototype method hands back the *existing* spy when one is already installed, so without it the click count carries between cases and "was not called" passes or fails on another test's clicks.

### Gate

`lint`, `typecheck`, 340 test files / 7694 tests.

### Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

---
_Generated by [Claude Code](https://claude.ai/code/session_012MsMuj8Fic9tjWVjyEyrxc)_