### PR TITLE
docs: cover the undocumented composables and the deprecated layout kit

### DIFF
--- a/docs/content/docs/1.getting-started/1.index.md
+++ b/docs/content/docs/1.getting-started/1.index.md
@@ -139,4 +139,10 @@ Bitrix24 UI ensures reliability with 1000+ Vitest tests covering core functional
 Yes! Bitrix24 UI is used in production by thousands of applications with extensive tests, regular updates, and active maintenance.
 :::
 
+:::accordion-item{label="Can I import from `@bitrix24/b24ui/utils`?"}
+It resolves, but treat it as internal. The `./utils` and `./utils/*` subpaths exist so the components and the Nuxt module can reach their own helpers across build boundaries — they are not a supported public API, they are not documented, and they change without a deprecation cycle or a major version bump.
+
+Everything meant for your application is already reachable: the components themselves, and the auto-imported composables under [Composables](/docs/composables/use-overlay/). If something you need is only in `utils`, [open an issue](https://github.com/bitrix24/b24ui/issues) — that is a gap worth closing properly rather than working around.
+:::
+
 ::

--- a/docs/content/docs/1.getting-started/6.integrations/4.i18n/1.nuxt.md
+++ b/docs/content/docs/1.getting-started/6.integrations/4.i18n/1.nuxt.md
@@ -188,6 +188,10 @@ External links and absolute URLs are automatically detected and skip localizatio
 
 Each locale has a `dir` property which will be used by the `App` component to set the directionality of all components.
 
+::note
+Inside a component you rarely need to reach for the locale files at all — the `useLocale` composable reads the locale `<B24App>` is already providing: `const { t, lang, code, dir, locale } = useLocale()`{lang="ts"}. Use `t()`{lang="ts"} to translate against the active messages, and `dir` when a component of your own has to follow the text direction.
+::
+
 In a multilingual application, you might want to set the `lang` and `dir` attributes on the `<html>` element dynamically based on the user's locale, which you can do with the [useHead](https://nuxt.com/docs/api/composables/use-head) composable:
 
 ```vue [app.vue]

--- a/docs/content/docs/1.getting-started/6.integrations/4.i18n/2.vue.md
+++ b/docs/content/docs/1.getting-started/6.integrations/4.i18n/2.vue.md
@@ -183,6 +183,10 @@ const { locale } = useI18n()
 
 Each locale has a `dir` property which will be used by the `App` component to set the directionality of all components.
 
+::note
+Inside a component you rarely need to reach for the locale files at all — the `useLocale` composable reads the locale `<B24App>` is already providing: `const { t, lang, code, dir, locale } = useLocale()`{lang="ts"}. Use `t()`{lang="ts"} to translate against the active messages, and `dir` when a component of your own has to follow the text direction.
+::
+
 In a multilingual application, you might want to set the `lang` and `dir` attributes on the `<html>` element dynamically based on the user's locale, which you can do with the [useHead](https://unhead.unjs.io/docs/head/api/composables/use-head) composable:
 
 ```vue [App.vue]

--- a/docs/content/docs/2.components/content-toc.md
+++ b/docs/content/docs/2.components/content-toc.md
@@ -20,6 +20,10 @@ This component is only available when the `@nuxt/content` module is installed.
 
 Use the `links` prop with the `page?.body?.toc?.links`{lang="ts-type"} you get when fetching a page.
 
+::note
+Highlighting the reader's position is handled for you. The `useScrollspy` composable behind it is exported too, if you are building your own table of contents: `const { activeHeadings, updateHeadings } = useScrollspy()`{lang="ts"}. Call `updateHeadings()`{lang="ts"} with the heading elements to observe after the content changes. Prefer `activeHeadings` over `visibleHeadings` — it keeps the last heading lit while the reader is between two, where `visibleHeadings` goes empty and the highlight flickers.
+::
+
 ::component-example
 ---
 name: 'content-toc-example'

--- a/docs/content/docs/2.components/dashboard-panel.md
+++ b/docs/content/docs/2.components/dashboard-panel.md
@@ -63,7 +63,25 @@ Most of the time, you will use the [`DashboardNavbar`](/docs/components/dashboar
 Use the `resizable` prop to make the panel resizable.
 
 ::note
-The dragging, the size persistence and the collapse behaviour all come from the `useResizable` composable, which is exported if you need a resizable region of your own: `const { el, size, isDragging, isCollapsed, onMouseDown, onTouchStart, onDoubleClick, collapse } = useResizable('my-panel', { side: 'left', minSize: 10, maxSize: 50 })`{lang="ts"}. Bind `el` to the element being sized and the handlers to your handle. The first argument is the storage key the size is remembered under, so give each region its own.
+The dragging, the remembered size and the collapse behaviour all come from the `useResizable` composable, which is exported if you need a resizable region of your own:
+
+```ts
+const { el, size, isDragging, isCollapsed, onMouseDown, onTouchStart, onDoubleClick, collapse } = useResizable('my-panel', {
+  side: 'left',
+  unit: '%',
+  defaultSize: 25,
+  minSize: 10,
+  maxSize: 50,
+  collapsible: true,
+  storage: 'local'
+})
+```
+
+Bind `el` to the element being sized and the handlers to your handle. The first argument is the storage key, so give each region its own — two regions sharing a key share a width.
+::
+
+::warning
+Four defaults are worth setting explicitly, because they are not what the prop names suggest. `unit` is `'px'`{lang="ts-type"}, so bare `minSize`/`maxSize` numbers are pixels, not percentages. `defaultSize` is `0`{lang="ts-type"}. `collapsible` is `false`{lang="ts-type"} in the composable, so `collapse()`{lang="ts"} and `isCollapsed` do nothing until you turn it on. And `storage` is `'cookie'`{lang="ts-type"}, which relies on `useCookie` — outside Nuxt that is a stub and nothing persists, so use `'local'`{lang="ts-type"} in a plain Vue app.
 ::
 
 ::component-code

--- a/docs/content/docs/2.components/dashboard-panel.md
+++ b/docs/content/docs/2.components/dashboard-panel.md
@@ -62,6 +62,10 @@ Most of the time, you will use the [`DashboardNavbar`](/docs/components/dashboar
 
 Use the `resizable` prop to make the panel resizable.
 
+::note
+The dragging, the size persistence and the collapse behaviour all come from the `useResizable` composable, which is exported if you need a resizable region of your own: `const { el, size, isDragging, isCollapsed, onMouseDown, onTouchStart, onDoubleClick, collapse } = useResizable('my-panel', { side: 'left', minSize: 10, maxSize: 50 })`{lang="ts"}. Bind `el` to the element being sized and the handlers to your handle. The first argument is the storage key the size is remembered under, so give each region its own.
+::
+
 ::component-code
 ---
 prettier: true

--- a/docs/content/docs/2.components/file-upload.md
+++ b/docs/content/docs/2.components/file-upload.md
@@ -286,7 +286,11 @@ name: 'file-upload-form-validation-example'
 You can use the default slot to make your own FileUpload component.
 
 ::note
-If you need the file picking without the component around it, the `useFileUpload` composable is what FileUpload itself is built on: `const { open, isDragging, inputRef, dropzoneRef } = useFileUpload({ accept: 'image/*', multiple: true, onUpdate: files => {} })`{lang="ts"}. It gives you the hidden `<input type="file">`, the drop zone and the `accept` wiring; the markup is yours.
+If you need the file picking without the component around it, the `useFileUpload` composable is what FileUpload itself is built on: `const { open, isDragging, inputRef, dropzoneRef } = useFileUpload({ accept: 'image/*', multiple: true, onUpdate: files => {} })`{lang="ts"}. Call `open()`{lang="ts"} to raise the file dialog, bind `dropzoneRef` to the element that accepts drops, and read `isDragging` for the hover state. The markup is yours — the composable renders nothing.
+::
+
+::warning
+`inputRef` is only needed if you also want a real `<input type="file">` in the DOM, for native form submission or validation. It expects a **component**, not an element: it is read as `inputRef.value.$el`{lang="ts"}, and FileUpload binds it to a `VisuallyHidden as="input"`. Bound to a plain `<input>`{lang="html"} it silently does nothing — `$el` is undefined, so dropped files are never synced onto the input. Leave it unbound if you do not need one.
 ::
 
 ::warning

--- a/docs/content/docs/2.components/file-upload.md
+++ b/docs/content/docs/2.components/file-upload.md
@@ -285,6 +285,14 @@ name: 'file-upload-form-validation-example'
 
 You can use the default slot to make your own FileUpload component.
 
+::note
+If you need the file picking without the component around it, the `useFileUpload` composable is what FileUpload itself is built on: `const { open, isDragging, inputRef, dropzoneRef } = useFileUpload({ accept: 'image/*', multiple: true, onUpdate: files => {} })`{lang="ts"}. It gives you the hidden `<input type="file">`, the drop zone and the `accept` wiring; the markup is yours.
+::
+
+::warning
+`accept` reaches the dialog verbatim, but the drop zone only gets the MIME half of it — a drag exposes a type, not a filename. An `accept` written purely as extensions (`'.pdf,.docx'`{lang="ts"}) therefore leaves the drop zone accepting anything, so validate by name in `onUpdate` when extensions are the contract.
+::
+
 ::component-example
 ---
 prettier: true

--- a/docs/content/docs/2.components/sidebar-layout.md
+++ b/docs/content/docs/2.components/sidebar-layout.md
@@ -12,4 +12,25 @@ links:
 This component is `deprecated` and will be removed in version `3.0.0`
 ::
 
-Use [DashboardSidebar](https://github.com/bitrix24/b24ui/blob/6b3f7b039883c96274a92dc2f15a35826901cd6f/playgrounds/nuxt/app/pages/components/slideover.vue#L314) components to build a `layout`. 
+Build layouts with the [DashboardSidebar](/docs/components/dashboard-sidebar/), [DashboardPanel](/docs/components/dashboard-panel/) and [DashboardGroup](/docs/components/dashboard-group/) components instead. For a standalone collapsible sidebar without the dashboard shell, use [Sidebar](/docs/components/sidebar/).
+
+## Deprecated sub-components
+
+`SidebarLayout` came with a set of building blocks. They are all still exported and still work, and they are all being removed in `3.0.0` together with it. None of them has its own documentation page — this section exists so that code using them leads somewhere.
+
+| Deprecated | Replacement |
+| ---------- | ----------- |
+| `B24Navbar` | [DashboardNavbar](/docs/components/dashboard-navbar/) |
+| `B24NavbarSection` | [DashboardNavbar](/docs/components/dashboard-navbar/) slots (`#left`, `#right`, `#trailing`) |
+| `B24NavbarDivider` | [Separator](/docs/components/separator/) |
+| `B24NavbarSpacer` | a flex spacer of your own, or the DashboardNavbar slots |
+| `B24SidebarHeader` | [DashboardSidebar](/docs/components/dashboard-sidebar/) `#header` slot |
+| `B24SidebarBody` | [DashboardSidebar](/docs/components/dashboard-sidebar/) `#default` slot |
+| `B24SidebarFooter` | [DashboardSidebar](/docs/components/dashboard-sidebar/) `#footer` slot |
+| `B24SidebarSection` | [NavigationMenu](/docs/components/navigation-menu/) with `orientation="vertical"` |
+| `B24SidebarHeading` | [NavigationMenu](/docs/components/navigation-menu/) item labels |
+| `B24SidebarSpacer` | a flex spacer of your own |
+
+::note
+Nothing here changes before `3.0.0` — this is a heads-up, not a break. If you are starting something new, start on the Dashboard components.
+::

--- a/src/runtime/composables/useResizable.ts
+++ b/src/runtime/composables/useResizable.ts
@@ -37,7 +37,8 @@ export type UseResizableProps = {
   resizable?: boolean
   /**
    * Whether to allow the user to collapse the panel.
-   * @defaultValue true
+   * `collapse()` and `isCollapsed` do nothing while this is off.
+   * @defaultValue false
    */
   collapsible?: boolean
   /**


### PR DESCRIPTION
### Linked issue

Resolves #95

### Type of change

- [x] Documentation (updates to the documentation or readme)
- [ ] Bug fix (a non-breaking change that fixes an issue)
- [ ] Enhancement (improving an existing functionality)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Chore (updates to the build process or auxiliary tools and libraries)
- [ ] Revert (undoing a merged change — retitle this PR `revert(Scope): ...`)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Description

Eight files, +76 −2. Seven are docs; the eighth is a one-line `@defaultValue` correction in `src`, explained at the bottom — it is what caused one of the wrong snippets in the first commit.

Two of #95's three parts are done differently from how the issue asks — it was written in June and the ground has moved under it since.

---

## §1 — all ten components are deprecated now

The issue asks for docs pages for `Navbar`, `NavbarSection`, `NavbarDivider`, `NavbarSpacer`, `SidebarHeader`, `SidebarBody`, `SidebarFooter`, `SidebarSection`, `SidebarHeading` and `SidebarSpacer`.

Every one of them carries `@deprecated ... removed in 3.0.0`, added on **10 August** in `07481295` — two months *after* this issue was filed. Eleven of the twelve `Navbar*`/`Sidebar*` components are tagged; only `Sidebar` is live, and it already has a page.

None of the ten is used anywhere in `docs/` or `playgrounds/` — checked by name, zero hits each.

Writing ten pages for ten components scheduled for removal is the wrong work. Saying nothing is also wrong: someone with `<B24SidebarSection>` in their code needs somewhere to learn it is going away. So `sidebar-layout.md` — already the deprecated page for this same legacy kit, already carrying a `::warning` — gains a table naming all ten against their replacement.

Every replacement was read off the source, not recalled:

| Claim | Verified |
| --- | --- |
| `DashboardNavbar` has `#left` / `#right` / `#trailing` | `<slot name="left">`, `"right"`, `"trailing"` (also `leading`, `title`, `toggle`) |
| `DashboardSidebar` has `#header` / `#footer` / default | `DashboardSidebar.vue:217`, `:225`, and the unnamed `<slot :collapsed :collapse />` at `:221` |
| `NavigationMenu` takes `orientation="vertical"` | `orientation?: O`, and the `collapsed` prop's JSDoc: *"Only works when `orientation` is `vertical`"* |

That page's migration pointer was also broken as guidance — it linked to a **playground source file at a pinned SHA** rather than to documentation. It now points at the Dashboard pages.

## §2 — upstream has exactly the same gap

`nuxt/ui@v4` ships all seven of these composables and gives **none** of them a page — 8 composable pages there to our 11.

| | upstream pages mentioning it | ours, before |
| --- | --- | --- |
| `useResizable` | 0 | 0 |
| `useScrollspy` | 0 | 0 |
| `useFileUpload` | 0 | 0 |
| `useLocale` | 0 | 1 (in passing, on an unrelated page) |
| `useKbd` | 1 | 1 |
| `useContentSearch` | 1 | 1 |
| `useFormField` | 1 | 2 |

That changes the shape of the work, not the answer. Upstream does have a convention for these — a short `::note`/`::tip` on the page of the component the composable powers, with the call shown inline (`useFormField` on `form.md`, `useContentSearch` on `content-search.md`). Followed that instead of inventing dedicated pages.

The four with no real home now have one:

- **`useFileUpload`** → `file-upload.md`, next to *"use the default slot to make your own FileUpload component"* — exactly who needs it
- **`useScrollspy`** → `content-toc.md`
- **`useResizable`** → `dashboard-panel.md`, under "Resizable"
- **`useLocale`** → both i18n pages. Its own JSDoc already links *to* that page, so the link was one-way

**The issue lists six composables; there are seven.** It misses `useFormField`, which is already mentioned on `form-field.md` and `form.md` — the same treatment upstream gives it. Left alone, as are `useKbd` and `useContentSearch`, for the same reason.

## §3 — `./utils` is internal

Stated as an FAQ entry on the introduction page, where the other "can I…" questions live: the subpath resolves, it exists so the components and the Nuxt module can reach their own helpers across build boundaries, it is not documented, and it changes without a deprecation cycle or a major bump. With a pointer to open an issue instead of working around it.

---

## What `/review` caught, in the second commit

Both code snippets in the first commit would have misled anyone who copied them. All four points were reproduced before fixing.

**`useResizable`** — four defaults are not what the prop names suggest, and the snippet relied on every one of them:

| Default | Actual | Consequence for the snippet as written |
| --- | --- | --- |
| `unit` | `'px'` | `minSize: 10, maxSize: 50` read as percentages, are pixels |
| `defaultSize` | `0` | panel starts collapsed to nothing |
| `collapsible` | `false` | the documented `collapse()` and `isCollapsed` are **inert** |
| `storage` | `'cookie'` | goes through `useCookie`, which outside Nuxt is the stub in `src/runtime/vue/stubs/base.ts` — nothing persists. `'local'` uses `useStorage` and does |

The snippet now sets all four explicitly and a `::warning` names them.

**`useFileUpload`** — the note claimed it "gives you the hidden `<input type="file">`". It renders nothing at all. Worse, `inputRef` is `ref<ComponentPublicInstance>()` read as `inputRef.value.$el`, so it expects a **component** — `FileUpload.vue` binds it to a `VisuallyHidden as="input"`. Bound to a plain `<input>`, `$el` is undefined, `useFileDialog` quietly falls back to its own detached input, and dropped files are never synced onto the visible one. Silent until native form submission or validation. Rewritten with that trap in a `::warning`.

**The `@defaultValue` behind it — the only `src` change.** `UseResizableProps.collapsible` was annotated `@defaultValue true` while the composable defaults it to `false`; `DashboardSidebar` also sets `false`, so no consumer ever made it true and the tag was wrong everywhere. That tag is where the bad snippet came from.

Checked every `@defaultValue` in that type against the `opts` object — `collapsible` is the **only** mismatch, and `storageKey`'s `'dashboard'` is correct because `DashboardGroup` supplies it. The rendered props table was never affected (`withDefaults` wins over the tag in `compactProp`); the wrong one was the IDE hint.

### Checks

- `pnpm lint`, `pnpm typecheck` green
- Full suite green after the `src` touch: 340 files, **7804 passed**, 6 skipped
- Every URL added was fetched first. `github.com/bitrix24/b24ui/issues/new/choose` returns **403** to a plain fetch, even with a browser user agent, so the FAQ links to `/issues` (200) rather than to a link I could not verify
- Not done: the docs site was not built, so the rendered pages have not been looked at

### Checklist

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012MsMuj8Fic9tjWVjyEyrxc