### PR TITLE
refactor: clear the theme `@todo` ledger and the dead module config

### DIFF
--- a/docs/content/docs/2.components/form.md
+++ b/docs/content/docs/2.components/form.md
@@ -161,6 +161,20 @@ options:
 You can use the `useFormField` composable to implement this inside your own components.
 ::
 
+::warning
+The `change` event these inputs emit is a **synthetic** `Event`, and its `target` is `null`{lang="ts-type"} — it carries no value. `@change="e => e.target.value"`{lang="ts"} throws.
+
+It is emitted so the Form can react to a commit, not to deliver the value. Read the value from `@update:model-value`{lang="ts"} instead, or from `v-model`:
+
+```vue
+<template>
+  <B24Select v-model="value" :items="items" @update:model-value="onCommit" />
+</template>
+```
+
+This applies to every input that emits `change` without a native event behind it — `Select`, `SelectMenu`, `InputMenu`, `InputDate`, `InputTime`, `InputTags`, `InputNumber`, `InputRating`, `PinInput`, `Listbox`, `Range`, `Checkbox`, `CheckboxGroup`, `RadioGroup`, `Switch` and `FileUpload`. `Input` and `Textarea` forward the browser's own `change` event, so their `target` is the real element.
+::
+
 ### Error event
 
 You can listen to the `@error` event to handle errors. This event is triggered when the form is submitted and contains an array of `FormError` objects with the following fields:

--- a/docs/content/docs/2.components/form.md
+++ b/docs/content/docs/2.components/form.md
@@ -164,7 +164,7 @@ You can use the `useFormField` composable to implement this inside your own comp
 ::warning
 The `change` event these inputs emit is a **synthetic** `Event`, and its `target` is `null`{lang="ts-type"} — it carries no value. `@change="e => e.target.value"`{lang="ts"} throws.
 
-It is emitted so the Form can react to a commit, not to deliver the value. Read the value from `@update:model-value`{lang="ts"} instead, or from `v-model`:
+It exists so you can react to a commit; it is not how the value travels, and it is not how the Form learns about it either — validation is driven by a separate internal call. Read the value from `@update:model-value`{lang="ts"} instead, or from `v-model`:
 
 ```vue
 <template>

--- a/src/module.ts
+++ b/src/module.ts
@@ -136,28 +136,6 @@ export default defineNuxtModule<ModuleOptions>({
       '@bitrix24/b24icons-nuxt': {
         defaults: {}
       },
-      // '@nuxt/icon': {
-      //   defaults: {
-      //     cssLayer: 'base'
-      //   }
-      // },
-      // ...userUiOptions.fonts !== false && {
-      //   '@nuxt/fonts': {
-      //     defaults: {
-      //       defaults: {
-      //         weights: [400, 500, 600, 700]
-      //       }
-      //     }
-      //   }
-      // },
-      // ...userUiOptions.colorMode !== false && {
-      //   '@nuxtjs/color-mode': {
-      //     defaults: {
-      //       classSuffix: '',
-      //       disableTransition: true
-      //     }
-      //   }
-      // },
       '@nuxtjs/mdc': {
         optional: !userUiOptions.mdc,
         defaults: {

--- a/src/theme/button.ts
+++ b/src/theme/button.ts
@@ -359,7 +359,6 @@ export default {
     },
     // endregion ////
     // region size && useDropdown ////
-    // @todo ////
     {
       leading: false,
       useLabel: true,

--- a/src/theme/chat-messages.ts
+++ b/src/theme/chat-messages.ts
@@ -5,7 +5,6 @@
  * @todo add variant
  * @todo fix animation
  * @todo add demo
- * @todo add docs
  */
 
 export default {

--- a/src/theme/chat-tool.ts
+++ b/src/theme/chat-tool.ts
@@ -2,8 +2,8 @@
  * ChatTool
  * An expandable section that indicates whether an AI tool has been called and its execution state.
  * ---
- * @todo: make refactor for `--leftmenu-group-stroke`
- * @todo: make ChatTool.variant.card === NavigationMenu.orientation.vertical.item
+ * @todo make refactor for `--leftmenu-group-stroke`
+ * @todo make ChatTool.variant.card === NavigationMenu.orientation.vertical.item
  * A link
  */
 

--- a/src/theme/color-picker.ts
+++ b/src/theme/color-picker.ts
@@ -1,8 +1,6 @@
 /**
  * ColorPicker
  * ---
- * @todo add demo
- * @todo add docs
  */
 
 export default {

--- a/src/theme/countdown.ts
+++ b/src/theme/countdown.ts
@@ -7,8 +7,6 @@
  * @see bitrix/js/ui/countdown/src
  */
 
-/**
- */
 export default {
   slots: {
     base: [

--- a/src/theme/countdown.ts
+++ b/src/theme/countdown.ts
@@ -8,8 +8,6 @@
  */
 
 /**
- * @todo add tests
- * @todo add docs
  */
 export default {
   slots: {

--- a/src/theme/file-upload.ts
+++ b/src/theme/file-upload.ts
@@ -1,8 +1,6 @@
 /**
  * FileUpload
  * ---
- * @todo add demo
- * @todo add docs
  * @todo fix color
  */
 export default {

--- a/src/theme/input-rating.ts
+++ b/src/theme/input-rating.ts
@@ -1,6 +1,6 @@
 /**
  * InputRating
- * @todo this this `A component to display and collect ratings from users.`
+ * A component to display and collect ratings from users.
  * ---
  */
 

--- a/src/theme/modal.ts
+++ b/src/theme/modal.ts
@@ -5,8 +5,8 @@
  * @link: /api_d7/bitrix/ui/dialogs/dialogs.php
  * @see bitrix/js/ui/dialogs/messagebox/..
  *
- * @todo: use modal template from - What's new in Bitrix24 + set position ~> top-right
- * @todo: add wizard component
+ * @todo use modal template from - What's new in Bitrix24 + set position ~> top-right
+ * @todo add wizard component
  */
 
 export default {

--- a/src/theme/navbar-divider.ts
+++ b/src/theme/navbar-divider.ts
@@ -1,11 +1,7 @@
 /**
  * NavbarDivider
  * ---
- * @todo: docs
- * @todo: test
- * @todo: playground
- * @todo: demo
- * @todo: color
+ * @deprecated This component is deprecated and will be removed in version `3.0.0`
  */
 
 export default {

--- a/src/theme/navbar-section.ts
+++ b/src/theme/navbar-section.ts
@@ -1,11 +1,7 @@
 /**
  * NavbarSection
  * ---
- * @todo: docs
- * @todo: test
- * @todo: playground
- * @todo: demo
- * @todo: color
+ * @deprecated This component is deprecated and will be removed in version `3.0.0`
  */
 
 export default {

--- a/src/theme/navbar-spacer.ts
+++ b/src/theme/navbar-spacer.ts
@@ -1,11 +1,7 @@
 /**
  * NavbarSpacer
  * ---
- * @todo: docs
- * @todo: test
- * @todo: playground
- * @todo: demo
- * @todo: color
+ * @deprecated This component is deprecated and will be removed in version `3.0.0`
  */
 
 export default {

--- a/src/theme/pagination.ts
+++ b/src/theme/pagination.ts
@@ -2,8 +2,6 @@
  * Pagination
  * A navigation component with buttons or links for pagination.
  * ---
- * @todo add docs
- * @todo add demo
  * @todo add color
  */
 export default {

--- a/src/theme/prose/p.ts
+++ b/src/theme/prose/p.ts
@@ -2,8 +2,7 @@
  * Prose/P
  * Show p
  * ---
- * @todo: docs
- * @todo: playground
+ * @todo playground
  */
 
 export default {

--- a/src/theme/sidebar-body.ts
+++ b/src/theme/sidebar-body.ts
@@ -1,11 +1,7 @@
 /**
  * SidebarBody
  * ---
- * @todo: docs
- * @todo: test
- * @todo: playground
- * @todo: demo
- * @todo: color
+ * @deprecated This component is deprecated and will be removed in version `3.0.0`
  */
 
 export default {

--- a/src/theme/sidebar-footer.ts
+++ b/src/theme/sidebar-footer.ts
@@ -1,11 +1,7 @@
 /**
  * SidebarFooter
  * ---
- * @todo: docs
- * @todo: test
- * @todo: playground
- * @todo: demo
- * @todo: color
+ * @deprecated This component is deprecated and will be removed in version `3.0.0`
  */
 
 export default {

--- a/src/theme/sidebar-header.ts
+++ b/src/theme/sidebar-header.ts
@@ -1,11 +1,7 @@
 /**
  * SidebarHeader
  * ---
- * @todo: docs
- * @todo: test
- * @todo: playground
- * @todo: demo
- * @todo: color
+ * @deprecated This component is deprecated and will be removed in version `3.0.0`
  */
 
 export default {

--- a/src/theme/sidebar-heading.ts
+++ b/src/theme/sidebar-heading.ts
@@ -1,11 +1,7 @@
 /**
  * SidebarHeading
  * ---
- * @todo: docs
- * @todo: test
- * @todo: playground
- * @todo: demo
- * @todo: color
+ * @deprecated This component is deprecated and will be removed in version `3.0.0`
  */
 
 export default {

--- a/src/theme/sidebar-layout.ts
+++ b/src/theme/sidebar-layout.ts
@@ -1,5 +1,5 @@
 /**
- * @deprecate This component is deprecated and will be removed in version `3.0.0`
+ * @deprecated This component is deprecated and will be removed in version `3.0.0`
  * SidebarLayout
  * You incorporate a sidebar in the slider and CRM entity tab embedding. Overall, it's stylish, trendy, and youthful
  * ---

--- a/src/theme/sidebar-section.ts
+++ b/src/theme/sidebar-section.ts
@@ -1,11 +1,7 @@
 /**
  * SidebarSection
  * ---
- * @todo: docs
- * @todo: test
- * @todo: playground
- * @todo: demo
- * @todo: color
+ * @deprecated This component is deprecated and will be removed in version `3.0.0`
  */
 
 export default {

--- a/src/theme/sidebar-spacer.ts
+++ b/src/theme/sidebar-spacer.ts
@@ -1,11 +1,7 @@
 /**
  * SidebarSpacer
  * ---
- * @todo: docs
- * @todo: test
- * @todo: playground
- * @todo: demo
- * @todo: color
+ * @deprecated This component is deprecated and will be removed in version `3.0.0`
  */
 
 export default {

--- a/src/theme/slideover.ts
+++ b/src/theme/slideover.ts
@@ -109,13 +109,6 @@ export default {
         content: 'max-h-[calc(100%-2rem)] inset-x-4 top-4'
       }
     },
-    // @todo remove this ?
-    {
-      side: 'top',
-      inset: true,
-      useFooter: true,
-      class: {}
-    },
     {
       side: 'top',
       inset: false,
@@ -130,13 +123,6 @@ export default {
         content: 'w-[calc(100%-2rem)] max-h-[calc(100%-2rem)] inset-y-4 right-4 '
       }
     },
-    // @todo remove this ?
-    {
-      side: 'right',
-      inset: true,
-      useFooter: true,
-      class: {}
-    },
     {
       side: 'right',
       inset: false,
@@ -150,13 +136,6 @@ export default {
       class: {
         content: 'max-h-[calc(100%-2rem)] w-[calc(100%-2rem)] end-4 bottom-4'
       }
-    },
-    // @todo remove this ?
-    {
-      side: 'bottom',
-      inset: true,
-      useFooter: true,
-      class: {}
     },
     {
       side: 'bottom',
@@ -176,13 +155,6 @@ export default {
         content: 'w-[calc(100%-2rem)] max-h-[calc(100%-2rem)] inset-y-4 left-4'
       }
     },
-    // @todo remove this ?
-    {
-      side: 'left',
-      inset: true,
-      useFooter: true,
-      class: {}
-    },
     {
       side: 'left',
       inset: false,
@@ -192,13 +164,6 @@ export default {
     },
     // endregion ////
     // region bottom & footer -> min-h ////
-    // @todo remove this ?
-    {
-      side: 'bottom',
-      inset: false,
-      useFooter: true,
-      class: {}
-    },
     // endregion ////
     // region btn.close ////
     {

--- a/test/components/Slideover.spec.ts
+++ b/test/components/Slideover.spec.ts
@@ -35,7 +35,12 @@ describe('Slideover', () => {
     ['with actions slot', { props, slots: { actions: () => 'Actions slot' } }],
     ['with close slot', { props, slots: { close: () => 'Close slot' } }],
     ['with body slot', { props, slots: { body: () => 'Body slot' } }],
-    ['with footer slot', { props, slots: { footer: () => 'Footer slot' } }]
+    ['with footer slot', { props, slots: { footer: () => 'Footer slot' } }],
+    // `side` x `inset` x `useFooter` (which the component derives from the
+    // presence of the `footer` slot). These five combinations each had their
+    // own compound variant in the theme, and the matrix reached none of them.
+    ...sides.map((side: string) => [`with ${side} side inset and footer slot`, { props: { ...props, side, inset: true, title: 'Title' }, slots: { footer: () => 'Footer slot' } }]),
+    ['with bottom side and footer slot', { props: { ...props, side: 'bottom', title: 'Title' }, slots: { footer: () => 'Footer slot' } }]
   ])
 
   it('passes accessibility tests', async () => {

--- a/test/components/__snapshots__/Slideover-vue.spec.ts.snap
+++ b/test/components/__snapshots__/Slideover-vue.spec.ts.snap
@@ -81,6 +81,38 @@ exports[`Slideover > renders with body slot correctly 1`] = `
 <!--teleport end-->"
 `;
 
+exports[`Slideover > renders with bottom side and footer slot correctly 1`] = `
+"<!--v-if-->
+<!--teleport start-->
+
+
+
+<div data-state="open" style="pointer-events: auto;" data-slot="overlay" class="fixed inset-0 bg-linear-to-b from-[#00204e]/52 to-[#00204e] motion-safe:data-[state=open]:animate-[fade-in_200ms_var(--ease-out)] motion-safe:data-[state=closed]:animate-[fade-out_200ms_var(--ease-out)]" data-aria-hidden="true" aria-hidden="true"></div>
+<div data-dismissable-layer="" tabindex="-1" data-side="bottom" data-slot="content" class="base-mode fixed bg-(--ui-color-gray-05) dark:bg-(--ui-color-base-black-fixed) sm:shadow-lg flex flex-col focus:outline-none h-full max-h-full sm:max-h-[calc(100%-18px)] right-[5px] top-0 sm:top-4.5 bottom-0 w-[calc(100%-60px-5px)] sm:w-[calc(100%-150px-70px)] sm:rounded-t-[18px] motion-safe:data-[state=open]:animate-[slide-in-from-bottom_200ms_var(--ease-out)] motion-safe:data-[state=closed]:animate-[slide-out-to-bottom_200ms_var(--ease-out)]" id="" role="dialog" aria-describedby="reka-dialog-description-v-1" aria-labelledby="reka-dialog-title-v-0" data-state="open" style="pointer-events: auto;"><span aria-hidden="true" style="position: absolute; border: 0px; width: 1px; height: 1px; padding: 0px; margin: -1px; overflow: hidden; clip: rect(0, 0, 0, 0); clip-path: inset(50%); white-space: nowrap; word-wrap: normal; top: -1px; left: -1px;"><!--v-if--><p id="reka-dialog-description-v-1"></p></span><button type="button" aria-label="Close" data-slot="base" class="ui-btn font-[family-name:var(--ui-font-family-primary)] select-none cursor-pointer inline-flex items-center outline-transparent focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed aria-disabled:cursor-not-allowed disabled:opacity-30 aria-disabled:opacity-30 transition duration-0 ease-linear border-(length:--ui-btn-border-width) text-(--ui-btn-color) bg-(--ui-btn-background) border-(--ui-btn-border-color) hover:text-(--ui-btn-color-hover) hover:bg-(--ui-btn-background-hover) hover:border-(--ui-btn-border-color-hover) focus:text-(--ui-btn-color-hover) focus:bg-(--ui-btn-background-hover) focus:border-(--ui-btn-border-color-hover) active:text-(--ui-btn-color-active) active:bg-(--ui-btn-background-active) active:border-(--ui-btn-border-color-active) disabled:bg-(--ui-btn-background) disabled:border-(--ui-btn-border-color) aria-disabled:bg-(--ui-btn-background) aria-disabled:border-(--ui-btn-border-color) focus-visible:outline-(--ui-btn-background) ring-(--ui-btn-background-hover) focus:outline-none focus-visible:ring-(--ui-btn-background-hover) h-(--ui-btn-height) text-(length:--ui-btn-font-size) leading-(--ui-btn-height) font-(--ui-btn-font-weight) --style-filled ui-btn-lg rounded-(--ui-btn-radius) normal-case --air w-(--ui-btn-height) group absolute pl-1.5 pr-[4px] top-[17px] -translate-x-full left-0 rounded-l-full">
+    <!--v-if-->
+    <div data-slot="baseLine" class="w-full inline-flex items-center justify-center gap-(--ui-btn-icon-space) h-(--ui-btn-height) ps-1 pe-1"><svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" aria-hidden="true" data-slot="icon" class="text-(--ui-btn-color) shrink-0 size-(--ui-btn-icon-size)">
+        <path fill="currentColor" d="M8.46 7.54a.65.65 0 0 0-.92.92L11.08 12l-3.54 3.54a.65.65 0 1 0 .92.92L12 12.918l3.54 3.54a.65.65 0 1 0 .919-.92L12.919 12l3.54-3.54a.65.65 0 0 0-.92-.919L12 11.08z"></path>
+      </svg>
+      <!--v-if-->
+      <!--v-if-->
+    </div>
+  </button>
+  <div data-slot="header" class="py-5 px-5 flex items-center gap-x-3 gap-y-1.5">
+    <div data-slot="wrapper" class="">
+      <h2 id="reka-dialog-title-v-0" data-slot="title" class="font-[family-name:var(--ui-font-family-primary)] text-label font-(--ui-font-weight-semi-bold) mb-0 text-(length:--ui-font-size-4xl)/[calc(var(--ui-font-size-4xl)+2px)]">Title</h2>
+      <p id="reka-dialog-description-v-1"></p>
+    </div>
+    <!--v-if-->
+  </div>
+  <!--v-if-->
+  <div data-slot="footer" class="absolute inset-x-0 bottom-0 base-mode bg-(--ui-color-bg-content-primary) flex items-center justify-center gap-2.5 border-t-1 border-t-(--ui-color-divider-less) shadow-top-md py-[13px] px-[13px]">Footer slot</div>
+</div>
+
+
+
+<!--teleport end-->"
+`;
+
 exports[`Slideover > renders with bottom side correctly 1`] = `
 "<!--v-if-->
 <!--teleport start-->
@@ -107,6 +139,38 @@ exports[`Slideover > renders with bottom side correctly 1`] = `
   </div>
   <!--v-if-->
   <!--v-if-->
+</div>
+
+
+
+<!--teleport end-->"
+`;
+
+exports[`Slideover > renders with bottom side inset and footer slot correctly 1`] = `
+"<!--v-if-->
+<!--teleport start-->
+
+
+
+<div data-state="open" style="pointer-events: auto;" data-slot="overlay" class="fixed inset-0 bg-linear-to-b from-[#00204e]/52 to-[#00204e] motion-safe:data-[state=open]:animate-[fade-in_200ms_var(--ease-out)] motion-safe:data-[state=closed]:animate-[fade-out_200ms_var(--ease-out)]" data-aria-hidden="true" aria-hidden="true"></div>
+<div data-dismissable-layer="" tabindex="-1" data-side="bottom" data-slot="content" class="base-mode fixed bg-(--ui-color-gray-05) dark:bg-(--ui-color-base-black-fixed) sm:shadow-lg flex flex-col focus:outline-none h-full rounded-[18px] max-h-[calc(100%-2rem)] w-[calc(100%-2rem)] end-4 bottom-4 motion-safe:data-[state=open]:animate-[slide-in-from-bottom_200ms_var(--ease-out)] motion-safe:data-[state=closed]:animate-[slide-out-to-bottom_200ms_var(--ease-out)]" id="" role="dialog" aria-describedby="reka-dialog-description-v-1" aria-labelledby="reka-dialog-title-v-0" data-state="open" style="pointer-events: auto;"><span aria-hidden="true" style="position: absolute; border: 0px; width: 1px; height: 1px; padding: 0px; margin: -1px; overflow: hidden; clip: rect(0, 0, 0, 0); clip-path: inset(50%); white-space: nowrap; word-wrap: normal; top: -1px; left: -1px;"><!--v-if--><p id="reka-dialog-description-v-1"></p></span>
+  <!--v-if-->
+  <div data-slot="header" class="py-5 px-5 flex items-center gap-x-3 gap-y-1.5">
+    <div data-slot="wrapper" class="">
+      <h2 id="reka-dialog-title-v-0" data-slot="title" class="font-[family-name:var(--ui-font-family-primary)] text-label font-(--ui-font-weight-semi-bold) mb-0 text-(length:--ui-font-size-4xl)/[calc(var(--ui-font-size-4xl)+2px)]">Title</h2>
+      <p id="reka-dialog-description-v-1"></p>
+    </div><button type="button" aria-label="Close" data-slot="base" class="ui-btn font-[family-name:var(--ui-font-family-primary)] select-none cursor-pointer inline-flex items-center outline-transparent focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed aria-disabled:cursor-not-allowed disabled:opacity-30 aria-disabled:opacity-30 transition duration-0 ease-linear border-(length:--ui-btn-border-width) text-(--ui-btn-color) bg-(--ui-btn-background) border-(--ui-btn-border-color) hover:text-(--ui-btn-color-hover) hover:bg-(--ui-btn-background-hover) hover:border-(--ui-btn-border-color-hover) focus:text-(--ui-btn-color-hover) focus:bg-(--ui-btn-background-hover) focus:border-(--ui-btn-border-color-hover) active:text-(--ui-btn-color-active) active:bg-(--ui-btn-background-active) active:border-(--ui-btn-border-color-active) disabled:bg-(--ui-btn-background) disabled:border-(--ui-btn-border-color) aria-disabled:bg-(--ui-btn-background) aria-disabled:border-(--ui-btn-border-color) focus-visible:outline-(--ui-btn-background) ring-(--ui-btn-background-hover) focus:outline-none focus-visible:ring-(--ui-btn-background-hover) h-(--ui-btn-height) text-(length:--ui-btn-font-size) leading-(--ui-btn-height) font-(--ui-btn-font-weight) --style-plain-no-accent ui-btn-lg rounded-(--ui-btn-radius) normal-case --air w-(--ui-btn-height) group absolute top-4 end-4">
+      <!--v-if-->
+      <div data-slot="baseLine" class="w-full inline-flex items-center justify-center gap-(--ui-btn-icon-space) h-(--ui-btn-height) ps-[4px] pe-[4px]"><svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" aria-hidden="true" data-slot="icon" class="text-(--ui-btn-color) shrink-0 size-(--ui-btn-icon-size)">
+          <path fill="currentColor" d="M8.46 7.54a.65.65 0 0 0-.92.92L11.08 12l-3.54 3.54a.65.65 0 1 0 .92.92L12 12.918l3.54 3.54a.65.65 0 1 0 .919-.92L12.919 12l3.54-3.54a.65.65 0 0 0-.92-.919L12 11.08z"></path>
+        </svg>
+        <!--v-if-->
+        <!--v-if-->
+      </div>
+    </button>
+  </div>
+  <!--v-if-->
+  <div data-slot="footer" class="absolute inset-x-0 bottom-0 base-mode bg-(--ui-color-bg-content-primary) flex items-center justify-center gap-2.5 border-t-1 border-t-(--ui-color-divider-less) shadow-top-md py-[13px] px-[13px]">Footer slot</div>
 </div>
 
 
@@ -415,6 +479,38 @@ exports[`Slideover > renders with left side correctly 1`] = `
 <!--teleport end-->"
 `;
 
+exports[`Slideover > renders with left side inset and footer slot correctly 1`] = `
+"<!--v-if-->
+<!--teleport start-->
+
+
+
+<div data-state="open" style="pointer-events: auto;" data-slot="overlay" class="fixed inset-0 bg-linear-to-b from-[#00204e]/52 to-[#00204e] motion-safe:data-[state=open]:animate-[fade-in_200ms_var(--ease-out)] motion-safe:data-[state=closed]:animate-[fade-out_200ms_var(--ease-out)]" data-aria-hidden="true" aria-hidden="true"></div>
+<div data-dismissable-layer="" tabindex="-1" data-side="left" data-slot="content" class="base-mode fixed bg-(--ui-color-gray-05) dark:bg-(--ui-color-base-black-fixed) sm:shadow-lg flex flex-col focus:outline-none h-full rounded-[18px] w-[calc(100%-2rem)] max-h-[calc(100%-2rem)] inset-y-4 left-4 motion-safe:data-[state=open]:animate-[slide-in-from-left_200ms_var(--ease-out)] motion-safe:data-[state=closed]:animate-[slide-out-to-left_200ms_var(--ease-out)]" id="" role="dialog" aria-describedby="reka-dialog-description-v-1" aria-labelledby="reka-dialog-title-v-0" data-state="open" style="pointer-events: auto;"><span aria-hidden="true" style="position: absolute; border: 0px; width: 1px; height: 1px; padding: 0px; margin: -1px; overflow: hidden; clip: rect(0, 0, 0, 0); clip-path: inset(50%); white-space: nowrap; word-wrap: normal; top: -1px; left: -1px;"><!--v-if--><p id="reka-dialog-description-v-1"></p></span>
+  <!--v-if-->
+  <div data-slot="header" class="px-5 flex items-center gap-x-3 gap-y-1.5 py-1 min-h-(--b24ui-header-height)">
+    <div data-slot="wrapper" class="">
+      <h2 id="reka-dialog-title-v-0" data-slot="title" class="font-[family-name:var(--ui-font-family-primary)] text-label font-(--ui-font-weight-semi-bold) mb-0 text-(length:--ui-font-size-4xl)/[calc(var(--ui-font-size-4xl)+2px)]">Title</h2>
+      <p id="reka-dialog-description-v-1"></p>
+    </div><button type="button" aria-label="Close" data-slot="base" class="ui-btn font-[family-name:var(--ui-font-family-primary)] select-none cursor-pointer inline-flex items-center outline-transparent focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed aria-disabled:cursor-not-allowed disabled:opacity-30 aria-disabled:opacity-30 transition duration-0 ease-linear border-(length:--ui-btn-border-width) text-(--ui-btn-color) bg-(--ui-btn-background) border-(--ui-btn-border-color) hover:text-(--ui-btn-color-hover) hover:bg-(--ui-btn-background-hover) hover:border-(--ui-btn-border-color-hover) focus:text-(--ui-btn-color-hover) focus:bg-(--ui-btn-background-hover) focus:border-(--ui-btn-border-color-hover) active:text-(--ui-btn-color-active) active:bg-(--ui-btn-background-active) active:border-(--ui-btn-border-color-active) disabled:bg-(--ui-btn-background) disabled:border-(--ui-btn-border-color) aria-disabled:bg-(--ui-btn-background) aria-disabled:border-(--ui-btn-border-color) focus-visible:outline-(--ui-btn-background) ring-(--ui-btn-background-hover) focus:outline-none focus-visible:ring-(--ui-btn-background-hover) h-(--ui-btn-height) text-(length:--ui-btn-font-size) leading-(--ui-btn-height) font-(--ui-btn-font-weight) --style-plain-no-accent ui-btn-lg rounded-(--ui-btn-radius) normal-case --air w-(--ui-btn-height) group absolute top-4 end-4">
+      <!--v-if-->
+      <div data-slot="baseLine" class="w-full inline-flex items-center justify-center gap-(--ui-btn-icon-space) h-(--ui-btn-height) ps-[4px] pe-[4px]"><svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" aria-hidden="true" data-slot="icon" class="text-(--ui-btn-color) shrink-0 size-(--ui-btn-icon-size)">
+          <path fill="currentColor" d="M8.46 7.54a.65.65 0 0 0-.92.92L11.08 12l-3.54 3.54a.65.65 0 1 0 .92.92L12 12.918l3.54 3.54a.65.65 0 1 0 .919-.92L12.919 12l3.54-3.54a.65.65 0 0 0-.92-.919L12 11.08z"></path>
+        </svg>
+        <!--v-if-->
+        <!--v-if-->
+      </div>
+    </button>
+  </div>
+  <!--v-if-->
+  <div data-slot="footer" class="absolute inset-x-0 bottom-0 base-mode bg-(--ui-color-bg-content-primary) flex items-center justify-center gap-2.5 border-t-1 border-t-(--ui-color-divider-less) shadow-top-md py-[13px] px-[13px]">Footer slot</div>
+</div>
+
+
+
+<!--teleport end-->"
+`;
+
 exports[`Slideover > renders with left side inset correctly 1`] = `
 "<!--v-if-->
 <!--teleport start-->
@@ -500,6 +596,38 @@ exports[`Slideover > renders with right side correctly 1`] = `
   </div>
   <!--v-if-->
   <!--v-if-->
+</div>
+
+
+
+<!--teleport end-->"
+`;
+
+exports[`Slideover > renders with right side inset and footer slot correctly 1`] = `
+"<!--v-if-->
+<!--teleport start-->
+
+
+
+<div data-state="open" style="pointer-events: auto;" data-slot="overlay" class="fixed inset-0 bg-linear-to-b from-[#00204e]/52 to-[#00204e] motion-safe:data-[state=open]:animate-[fade-in_200ms_var(--ease-out)] motion-safe:data-[state=closed]:animate-[fade-out_200ms_var(--ease-out)]" data-aria-hidden="true" aria-hidden="true"></div>
+<div data-dismissable-layer="" tabindex="-1" data-side="right" data-slot="content" class="base-mode fixed bg-(--ui-color-gray-05) dark:bg-(--ui-color-base-black-fixed) sm:shadow-lg flex flex-col focus:outline-none h-full rounded-[18px] w-[calc(100%-2rem)] max-h-[calc(100%-2rem)] inset-y-4 right-4 motion-safe:data-[state=open]:animate-[slide-in-from-right_200ms_var(--ease-out)] motion-safe:data-[state=closed]:animate-[slide-out-to-right_200ms_var(--ease-out)]" id="" role="dialog" aria-describedby="reka-dialog-description-v-1" aria-labelledby="reka-dialog-title-v-0" data-state="open" style="pointer-events: auto;"><span aria-hidden="true" style="position: absolute; border: 0px; width: 1px; height: 1px; padding: 0px; margin: -1px; overflow: hidden; clip: rect(0, 0, 0, 0); clip-path: inset(50%); white-space: nowrap; word-wrap: normal; top: -1px; left: -1px;"><!--v-if--><p id="reka-dialog-description-v-1"></p></span>
+  <!--v-if-->
+  <div data-slot="header" class="px-5 flex items-center gap-x-3 gap-y-1.5 py-1 min-h-(--b24ui-header-height)">
+    <div data-slot="wrapper" class="">
+      <h2 id="reka-dialog-title-v-0" data-slot="title" class="font-[family-name:var(--ui-font-family-primary)] text-label font-(--ui-font-weight-semi-bold) mb-0 text-(length:--ui-font-size-4xl)/[calc(var(--ui-font-size-4xl)+2px)]">Title</h2>
+      <p id="reka-dialog-description-v-1"></p>
+    </div><button type="button" aria-label="Close" data-slot="base" class="ui-btn font-[family-name:var(--ui-font-family-primary)] select-none cursor-pointer inline-flex items-center outline-transparent focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed aria-disabled:cursor-not-allowed disabled:opacity-30 aria-disabled:opacity-30 transition duration-0 ease-linear border-(length:--ui-btn-border-width) text-(--ui-btn-color) bg-(--ui-btn-background) border-(--ui-btn-border-color) hover:text-(--ui-btn-color-hover) hover:bg-(--ui-btn-background-hover) hover:border-(--ui-btn-border-color-hover) focus:text-(--ui-btn-color-hover) focus:bg-(--ui-btn-background-hover) focus:border-(--ui-btn-border-color-hover) active:text-(--ui-btn-color-active) active:bg-(--ui-btn-background-active) active:border-(--ui-btn-border-color-active) disabled:bg-(--ui-btn-background) disabled:border-(--ui-btn-border-color) aria-disabled:bg-(--ui-btn-background) aria-disabled:border-(--ui-btn-border-color) focus-visible:outline-(--ui-btn-background) ring-(--ui-btn-background-hover) focus:outline-none focus-visible:ring-(--ui-btn-background-hover) h-(--ui-btn-height) text-(length:--ui-btn-font-size) leading-(--ui-btn-height) font-(--ui-btn-font-weight) --style-plain-no-accent ui-btn-lg rounded-(--ui-btn-radius) normal-case --air w-(--ui-btn-height) group absolute top-4 end-4">
+      <!--v-if-->
+      <div data-slot="baseLine" class="w-full inline-flex items-center justify-center gap-(--ui-btn-icon-space) h-(--ui-btn-height) ps-[4px] pe-[4px]"><svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" aria-hidden="true" data-slot="icon" class="text-(--ui-btn-color) shrink-0 size-(--ui-btn-icon-size)">
+          <path fill="currentColor" d="M8.46 7.54a.65.65 0 0 0-.92.92L11.08 12l-3.54 3.54a.65.65 0 1 0 .92.92L12 12.918l3.54 3.54a.65.65 0 1 0 .919-.92L12.919 12l3.54-3.54a.65.65 0 0 0-.92-.919L12 11.08z"></path>
+        </svg>
+        <!--v-if-->
+        <!--v-if-->
+      </div>
+    </button>
+  </div>
+  <!--v-if-->
+  <div data-slot="footer" class="absolute inset-x-0 bottom-0 base-mode bg-(--ui-color-bg-content-primary) flex items-center justify-center gap-2.5 border-t-1 border-t-(--ui-color-divider-less) shadow-top-md py-[13px] px-[13px]">Footer slot</div>
 </div>
 
 
@@ -630,6 +758,38 @@ exports[`Slideover > renders with top side correctly 1`] = `
   </div>
   <!--v-if-->
   <!--v-if-->
+</div>
+
+
+
+<!--teleport end-->"
+`;
+
+exports[`Slideover > renders with top side inset and footer slot correctly 1`] = `
+"<!--v-if-->
+<!--teleport start-->
+
+
+
+<div data-state="open" style="pointer-events: auto;" data-slot="overlay" class="fixed inset-0 bg-linear-to-b from-[#00204e]/52 to-[#00204e] motion-safe:data-[state=open]:animate-[fade-in_200ms_var(--ease-out)] motion-safe:data-[state=closed]:animate-[fade-out_200ms_var(--ease-out)]" data-aria-hidden="true" aria-hidden="true"></div>
+<div data-dismissable-layer="" tabindex="-1" data-side="top" data-slot="content" class="base-mode fixed bg-(--ui-color-gray-05) dark:bg-(--ui-color-base-black-fixed) sm:shadow-lg flex flex-col focus:outline-none h-full rounded-[18px] max-h-[calc(100%-2rem)] inset-x-4 top-4 motion-safe:data-[state=open]:animate-[slide-in-from-top_200ms_var(--ease-out)] motion-safe:data-[state=closed]:animate-[slide-out-to-top_200ms_var(--ease-out)]" id="" role="dialog" aria-describedby="reka-dialog-description-v-1" aria-labelledby="reka-dialog-title-v-0" data-state="open" style="pointer-events: auto;"><span aria-hidden="true" style="position: absolute; border: 0px; width: 1px; height: 1px; padding: 0px; margin: -1px; overflow: hidden; clip: rect(0, 0, 0, 0); clip-path: inset(50%); white-space: nowrap; word-wrap: normal; top: -1px; left: -1px;"><!--v-if--><p id="reka-dialog-description-v-1"></p></span>
+  <!--v-if-->
+  <div data-slot="header" class="py-5 px-5 flex items-center gap-x-3 gap-y-1.5">
+    <div data-slot="wrapper" class="">
+      <h2 id="reka-dialog-title-v-0" data-slot="title" class="font-[family-name:var(--ui-font-family-primary)] text-label font-(--ui-font-weight-semi-bold) mb-0 text-(length:--ui-font-size-4xl)/[calc(var(--ui-font-size-4xl)+2px)]">Title</h2>
+      <p id="reka-dialog-description-v-1"></p>
+    </div><button type="button" aria-label="Close" data-slot="base" class="ui-btn font-[family-name:var(--ui-font-family-primary)] select-none cursor-pointer inline-flex items-center outline-transparent focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed aria-disabled:cursor-not-allowed disabled:opacity-30 aria-disabled:opacity-30 transition duration-0 ease-linear border-(length:--ui-btn-border-width) text-(--ui-btn-color) bg-(--ui-btn-background) border-(--ui-btn-border-color) hover:text-(--ui-btn-color-hover) hover:bg-(--ui-btn-background-hover) hover:border-(--ui-btn-border-color-hover) focus:text-(--ui-btn-color-hover) focus:bg-(--ui-btn-background-hover) focus:border-(--ui-btn-border-color-hover) active:text-(--ui-btn-color-active) active:bg-(--ui-btn-background-active) active:border-(--ui-btn-border-color-active) disabled:bg-(--ui-btn-background) disabled:border-(--ui-btn-border-color) aria-disabled:bg-(--ui-btn-background) aria-disabled:border-(--ui-btn-border-color) focus-visible:outline-(--ui-btn-background) ring-(--ui-btn-background-hover) focus:outline-none focus-visible:ring-(--ui-btn-background-hover) h-(--ui-btn-height) text-(length:--ui-btn-font-size) leading-(--ui-btn-height) font-(--ui-btn-font-weight) --style-plain-no-accent ui-btn-lg rounded-(--ui-btn-radius) normal-case --air w-(--ui-btn-height) group absolute top-4 end-4">
+      <!--v-if-->
+      <div data-slot="baseLine" class="w-full inline-flex items-center justify-center gap-(--ui-btn-icon-space) h-(--ui-btn-height) ps-[4px] pe-[4px]"><svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" aria-hidden="true" data-slot="icon" class="text-(--ui-btn-color) shrink-0 size-(--ui-btn-icon-size)">
+          <path fill="currentColor" d="M8.46 7.54a.65.65 0 0 0-.92.92L11.08 12l-3.54 3.54a.65.65 0 1 0 .92.92L12 12.918l3.54 3.54a.65.65 0 1 0 .919-.92L12.919 12l3.54-3.54a.65.65 0 0 0-.92-.919L12 11.08z"></path>
+        </svg>
+        <!--v-if-->
+        <!--v-if-->
+      </div>
+    </button>
+  </div>
+  <!--v-if-->
+  <div data-slot="footer" class="absolute inset-x-0 bottom-0 base-mode bg-(--ui-color-bg-content-primary) flex items-center justify-center gap-2.5 border-t-1 border-t-(--ui-color-divider-less) shadow-top-md py-[13px] px-[13px]">Footer slot</div>
 </div>
 
 

--- a/test/components/__snapshots__/Slideover.spec.ts.snap
+++ b/test/components/__snapshots__/Slideover.spec.ts.snap
@@ -81,6 +81,38 @@ exports[`Slideover > renders with body slot correctly 1`] = `
 <!--teleport end-->"
 `;
 
+exports[`Slideover > renders with bottom side and footer slot correctly 1`] = `
+"<!--v-if-->
+<!--teleport start-->
+
+
+
+<div data-state="open" style="pointer-events: auto;" data-slot="overlay" class="fixed inset-0 bg-linear-to-b from-[#00204e]/52 to-[#00204e] motion-safe:data-[state=open]:animate-[fade-in_200ms_var(--ease-out)] motion-safe:data-[state=closed]:animate-[fade-out_200ms_var(--ease-out)]" data-aria-hidden="true" aria-hidden="true"></div>
+<div data-dismissable-layer="" tabindex="-1" data-side="bottom" data-slot="content" class="base-mode fixed bg-(--ui-color-gray-05) dark:bg-(--ui-color-base-black-fixed) sm:shadow-lg flex flex-col focus:outline-none h-full max-h-full sm:max-h-[calc(100%-18px)] right-[5px] top-0 sm:top-4.5 bottom-0 w-[calc(100%-60px-5px)] sm:w-[calc(100%-150px-70px)] sm:rounded-t-[18px] motion-safe:data-[state=open]:animate-[slide-in-from-bottom_200ms_var(--ease-out)] motion-safe:data-[state=closed]:animate-[slide-out-to-bottom_200ms_var(--ease-out)]" id="" role="dialog" aria-describedby="reka-dialog-description-v-0-0-1" aria-labelledby="reka-dialog-title-v-0-0-0" data-state="open" style="pointer-events: auto;"><span aria-hidden="true" style="position: absolute; border: 0px; width: 1px; height: 1px; padding: 0px; margin: -1px; overflow: hidden; clip: rect(0, 0, 0, 0); clip-path: inset(50%); white-space: nowrap; word-wrap: normal; top: -1px; left: -1px;"><!--v-if--><p id="reka-dialog-description-v-0-0-1"></p></span><button type="button" aria-label="Close" data-slot="base" class="ui-btn font-[family-name:var(--ui-font-family-primary)] select-none cursor-pointer inline-flex items-center outline-transparent focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed aria-disabled:cursor-not-allowed disabled:opacity-30 aria-disabled:opacity-30 transition duration-0 ease-linear border-(length:--ui-btn-border-width) text-(--ui-btn-color) bg-(--ui-btn-background) border-(--ui-btn-border-color) hover:text-(--ui-btn-color-hover) hover:bg-(--ui-btn-background-hover) hover:border-(--ui-btn-border-color-hover) focus:text-(--ui-btn-color-hover) focus:bg-(--ui-btn-background-hover) focus:border-(--ui-btn-border-color-hover) active:text-(--ui-btn-color-active) active:bg-(--ui-btn-background-active) active:border-(--ui-btn-border-color-active) disabled:bg-(--ui-btn-background) disabled:border-(--ui-btn-border-color) aria-disabled:bg-(--ui-btn-background) aria-disabled:border-(--ui-btn-border-color) focus-visible:outline-(--ui-btn-background) ring-(--ui-btn-background-hover) focus:outline-none focus-visible:ring-(--ui-btn-background-hover) h-(--ui-btn-height) text-(length:--ui-btn-font-size) leading-(--ui-btn-height) font-(--ui-btn-font-weight) --style-filled ui-btn-lg rounded-(--ui-btn-radius) normal-case --air w-(--ui-btn-height) group absolute pl-1.5 pr-[4px] top-[17px] -translate-x-full left-0 rounded-l-full">
+    <!--v-if-->
+    <div data-slot="baseLine" class="w-full inline-flex items-center justify-center gap-(--ui-btn-icon-space) h-(--ui-btn-height) ps-1 pe-1"><svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" aria-hidden="true" data-slot="icon" class="text-(--ui-btn-color) shrink-0 size-(--ui-btn-icon-size)">
+        <path fill="currentColor" d="M8.46 7.54a.65.65 0 0 0-.92.92L11.08 12l-3.54 3.54a.65.65 0 1 0 .92.92L12 12.918l3.54 3.54a.65.65 0 1 0 .919-.92L12.919 12l3.54-3.54a.65.65 0 0 0-.92-.919L12 11.08z"></path>
+      </svg>
+      <!--v-if-->
+      <!--v-if-->
+    </div>
+  </button>
+  <div data-slot="header" class="py-5 px-5 flex items-center gap-x-3 gap-y-1.5">
+    <div data-slot="wrapper" class="">
+      <h2 id="reka-dialog-title-v-0-0-0" data-slot="title" class="font-[family-name:var(--ui-font-family-primary)] text-label font-(--ui-font-weight-semi-bold) mb-0 text-(length:--ui-font-size-4xl)/[calc(var(--ui-font-size-4xl)+2px)]">Title</h2>
+      <p id="reka-dialog-description-v-0-0-1"></p>
+    </div>
+    <!--v-if-->
+  </div>
+  <!--v-if-->
+  <div data-slot="footer" class="absolute inset-x-0 bottom-0 base-mode bg-(--ui-color-bg-content-primary) flex items-center justify-center gap-2.5 border-t-1 border-t-(--ui-color-divider-less) shadow-top-md py-[13px] px-[13px]">Footer slot</div>
+</div>
+
+
+
+<!--teleport end-->"
+`;
+
 exports[`Slideover > renders with bottom side correctly 1`] = `
 "<!--v-if-->
 <!--teleport start-->
@@ -107,6 +139,38 @@ exports[`Slideover > renders with bottom side correctly 1`] = `
   </div>
   <!--v-if-->
   <!--v-if-->
+</div>
+
+
+
+<!--teleport end-->"
+`;
+
+exports[`Slideover > renders with bottom side inset and footer slot correctly 1`] = `
+"<!--v-if-->
+<!--teleport start-->
+
+
+
+<div data-state="open" style="pointer-events: auto;" data-slot="overlay" class="fixed inset-0 bg-linear-to-b from-[#00204e]/52 to-[#00204e] motion-safe:data-[state=open]:animate-[fade-in_200ms_var(--ease-out)] motion-safe:data-[state=closed]:animate-[fade-out_200ms_var(--ease-out)]" data-aria-hidden="true" aria-hidden="true"></div>
+<div data-dismissable-layer="" tabindex="-1" data-side="bottom" data-slot="content" class="base-mode fixed bg-(--ui-color-gray-05) dark:bg-(--ui-color-base-black-fixed) sm:shadow-lg flex flex-col focus:outline-none h-full rounded-[18px] max-h-[calc(100%-2rem)] w-[calc(100%-2rem)] end-4 bottom-4 motion-safe:data-[state=open]:animate-[slide-in-from-bottom_200ms_var(--ease-out)] motion-safe:data-[state=closed]:animate-[slide-out-to-bottom_200ms_var(--ease-out)]" id="" role="dialog" aria-describedby="reka-dialog-description-v-0-0-1" aria-labelledby="reka-dialog-title-v-0-0-0" data-state="open" style="pointer-events: auto;"><span aria-hidden="true" style="position: absolute; border: 0px; width: 1px; height: 1px; padding: 0px; margin: -1px; overflow: hidden; clip: rect(0, 0, 0, 0); clip-path: inset(50%); white-space: nowrap; word-wrap: normal; top: -1px; left: -1px;"><!--v-if--><p id="reka-dialog-description-v-0-0-1"></p></span>
+  <!--v-if-->
+  <div data-slot="header" class="py-5 px-5 flex items-center gap-x-3 gap-y-1.5">
+    <div data-slot="wrapper" class="">
+      <h2 id="reka-dialog-title-v-0-0-0" data-slot="title" class="font-[family-name:var(--ui-font-family-primary)] text-label font-(--ui-font-weight-semi-bold) mb-0 text-(length:--ui-font-size-4xl)/[calc(var(--ui-font-size-4xl)+2px)]">Title</h2>
+      <p id="reka-dialog-description-v-0-0-1"></p>
+    </div><button type="button" aria-label="Close" data-slot="base" class="ui-btn font-[family-name:var(--ui-font-family-primary)] select-none cursor-pointer inline-flex items-center outline-transparent focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed aria-disabled:cursor-not-allowed disabled:opacity-30 aria-disabled:opacity-30 transition duration-0 ease-linear border-(length:--ui-btn-border-width) text-(--ui-btn-color) bg-(--ui-btn-background) border-(--ui-btn-border-color) hover:text-(--ui-btn-color-hover) hover:bg-(--ui-btn-background-hover) hover:border-(--ui-btn-border-color-hover) focus:text-(--ui-btn-color-hover) focus:bg-(--ui-btn-background-hover) focus:border-(--ui-btn-border-color-hover) active:text-(--ui-btn-color-active) active:bg-(--ui-btn-background-active) active:border-(--ui-btn-border-color-active) disabled:bg-(--ui-btn-background) disabled:border-(--ui-btn-border-color) aria-disabled:bg-(--ui-btn-background) aria-disabled:border-(--ui-btn-border-color) focus-visible:outline-(--ui-btn-background) ring-(--ui-btn-background-hover) focus:outline-none focus-visible:ring-(--ui-btn-background-hover) h-(--ui-btn-height) text-(length:--ui-btn-font-size) leading-(--ui-btn-height) font-(--ui-btn-font-weight) --style-plain-no-accent ui-btn-lg rounded-(--ui-btn-radius) normal-case --air w-(--ui-btn-height) group absolute top-4 end-4">
+      <!--v-if-->
+      <div data-slot="baseLine" class="w-full inline-flex items-center justify-center gap-(--ui-btn-icon-space) h-(--ui-btn-height) ps-[4px] pe-[4px]"><svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" aria-hidden="true" data-slot="icon" class="text-(--ui-btn-color) shrink-0 size-(--ui-btn-icon-size)">
+          <path fill="currentColor" d="M8.46 7.54a.65.65 0 0 0-.92.92L11.08 12l-3.54 3.54a.65.65 0 1 0 .92.92L12 12.918l3.54 3.54a.65.65 0 1 0 .919-.92L12.919 12l3.54-3.54a.65.65 0 0 0-.92-.919L12 11.08z"></path>
+        </svg>
+        <!--v-if-->
+        <!--v-if-->
+      </div>
+    </button>
+  </div>
+  <!--v-if-->
+  <div data-slot="footer" class="absolute inset-x-0 bottom-0 base-mode bg-(--ui-color-bg-content-primary) flex items-center justify-center gap-2.5 border-t-1 border-t-(--ui-color-divider-less) shadow-top-md py-[13px] px-[13px]">Footer slot</div>
 </div>
 
 
@@ -415,6 +479,38 @@ exports[`Slideover > renders with left side correctly 1`] = `
 <!--teleport end-->"
 `;
 
+exports[`Slideover > renders with left side inset and footer slot correctly 1`] = `
+"<!--v-if-->
+<!--teleport start-->
+
+
+
+<div data-state="open" style="pointer-events: auto;" data-slot="overlay" class="fixed inset-0 bg-linear-to-b from-[#00204e]/52 to-[#00204e] motion-safe:data-[state=open]:animate-[fade-in_200ms_var(--ease-out)] motion-safe:data-[state=closed]:animate-[fade-out_200ms_var(--ease-out)]" data-aria-hidden="true" aria-hidden="true"></div>
+<div data-dismissable-layer="" tabindex="-1" data-side="left" data-slot="content" class="base-mode fixed bg-(--ui-color-gray-05) dark:bg-(--ui-color-base-black-fixed) sm:shadow-lg flex flex-col focus:outline-none h-full rounded-[18px] w-[calc(100%-2rem)] max-h-[calc(100%-2rem)] inset-y-4 left-4 motion-safe:data-[state=open]:animate-[slide-in-from-left_200ms_var(--ease-out)] motion-safe:data-[state=closed]:animate-[slide-out-to-left_200ms_var(--ease-out)]" id="" role="dialog" aria-describedby="reka-dialog-description-v-0-0-1" aria-labelledby="reka-dialog-title-v-0-0-0" data-state="open" style="pointer-events: auto;"><span aria-hidden="true" style="position: absolute; border: 0px; width: 1px; height: 1px; padding: 0px; margin: -1px; overflow: hidden; clip: rect(0, 0, 0, 0); clip-path: inset(50%); white-space: nowrap; word-wrap: normal; top: -1px; left: -1px;"><!--v-if--><p id="reka-dialog-description-v-0-0-1"></p></span>
+  <!--v-if-->
+  <div data-slot="header" class="px-5 flex items-center gap-x-3 gap-y-1.5 py-1 min-h-(--b24ui-header-height)">
+    <div data-slot="wrapper" class="">
+      <h2 id="reka-dialog-title-v-0-0-0" data-slot="title" class="font-[family-name:var(--ui-font-family-primary)] text-label font-(--ui-font-weight-semi-bold) mb-0 text-(length:--ui-font-size-4xl)/[calc(var(--ui-font-size-4xl)+2px)]">Title</h2>
+      <p id="reka-dialog-description-v-0-0-1"></p>
+    </div><button type="button" aria-label="Close" data-slot="base" class="ui-btn font-[family-name:var(--ui-font-family-primary)] select-none cursor-pointer inline-flex items-center outline-transparent focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed aria-disabled:cursor-not-allowed disabled:opacity-30 aria-disabled:opacity-30 transition duration-0 ease-linear border-(length:--ui-btn-border-width) text-(--ui-btn-color) bg-(--ui-btn-background) border-(--ui-btn-border-color) hover:text-(--ui-btn-color-hover) hover:bg-(--ui-btn-background-hover) hover:border-(--ui-btn-border-color-hover) focus:text-(--ui-btn-color-hover) focus:bg-(--ui-btn-background-hover) focus:border-(--ui-btn-border-color-hover) active:text-(--ui-btn-color-active) active:bg-(--ui-btn-background-active) active:border-(--ui-btn-border-color-active) disabled:bg-(--ui-btn-background) disabled:border-(--ui-btn-border-color) aria-disabled:bg-(--ui-btn-background) aria-disabled:border-(--ui-btn-border-color) focus-visible:outline-(--ui-btn-background) ring-(--ui-btn-background-hover) focus:outline-none focus-visible:ring-(--ui-btn-background-hover) h-(--ui-btn-height) text-(length:--ui-btn-font-size) leading-(--ui-btn-height) font-(--ui-btn-font-weight) --style-plain-no-accent ui-btn-lg rounded-(--ui-btn-radius) normal-case --air w-(--ui-btn-height) group absolute top-4 end-4">
+      <!--v-if-->
+      <div data-slot="baseLine" class="w-full inline-flex items-center justify-center gap-(--ui-btn-icon-space) h-(--ui-btn-height) ps-[4px] pe-[4px]"><svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" aria-hidden="true" data-slot="icon" class="text-(--ui-btn-color) shrink-0 size-(--ui-btn-icon-size)">
+          <path fill="currentColor" d="M8.46 7.54a.65.65 0 0 0-.92.92L11.08 12l-3.54 3.54a.65.65 0 1 0 .92.92L12 12.918l3.54 3.54a.65.65 0 1 0 .919-.92L12.919 12l3.54-3.54a.65.65 0 0 0-.92-.919L12 11.08z"></path>
+        </svg>
+        <!--v-if-->
+        <!--v-if-->
+      </div>
+    </button>
+  </div>
+  <!--v-if-->
+  <div data-slot="footer" class="absolute inset-x-0 bottom-0 base-mode bg-(--ui-color-bg-content-primary) flex items-center justify-center gap-2.5 border-t-1 border-t-(--ui-color-divider-less) shadow-top-md py-[13px] px-[13px]">Footer slot</div>
+</div>
+
+
+
+<!--teleport end-->"
+`;
+
 exports[`Slideover > renders with left side inset correctly 1`] = `
 "<!--v-if-->
 <!--teleport start-->
@@ -500,6 +596,38 @@ exports[`Slideover > renders with right side correctly 1`] = `
   </div>
   <!--v-if-->
   <!--v-if-->
+</div>
+
+
+
+<!--teleport end-->"
+`;
+
+exports[`Slideover > renders with right side inset and footer slot correctly 1`] = `
+"<!--v-if-->
+<!--teleport start-->
+
+
+
+<div data-state="open" style="pointer-events: auto;" data-slot="overlay" class="fixed inset-0 bg-linear-to-b from-[#00204e]/52 to-[#00204e] motion-safe:data-[state=open]:animate-[fade-in_200ms_var(--ease-out)] motion-safe:data-[state=closed]:animate-[fade-out_200ms_var(--ease-out)]" data-aria-hidden="true" aria-hidden="true"></div>
+<div data-dismissable-layer="" tabindex="-1" data-side="right" data-slot="content" class="base-mode fixed bg-(--ui-color-gray-05) dark:bg-(--ui-color-base-black-fixed) sm:shadow-lg flex flex-col focus:outline-none h-full rounded-[18px] w-[calc(100%-2rem)] max-h-[calc(100%-2rem)] inset-y-4 right-4 motion-safe:data-[state=open]:animate-[slide-in-from-right_200ms_var(--ease-out)] motion-safe:data-[state=closed]:animate-[slide-out-to-right_200ms_var(--ease-out)]" id="" role="dialog" aria-describedby="reka-dialog-description-v-0-0-1" aria-labelledby="reka-dialog-title-v-0-0-0" data-state="open" style="pointer-events: auto;"><span aria-hidden="true" style="position: absolute; border: 0px; width: 1px; height: 1px; padding: 0px; margin: -1px; overflow: hidden; clip: rect(0, 0, 0, 0); clip-path: inset(50%); white-space: nowrap; word-wrap: normal; top: -1px; left: -1px;"><!--v-if--><p id="reka-dialog-description-v-0-0-1"></p></span>
+  <!--v-if-->
+  <div data-slot="header" class="px-5 flex items-center gap-x-3 gap-y-1.5 py-1 min-h-(--b24ui-header-height)">
+    <div data-slot="wrapper" class="">
+      <h2 id="reka-dialog-title-v-0-0-0" data-slot="title" class="font-[family-name:var(--ui-font-family-primary)] text-label font-(--ui-font-weight-semi-bold) mb-0 text-(length:--ui-font-size-4xl)/[calc(var(--ui-font-size-4xl)+2px)]">Title</h2>
+      <p id="reka-dialog-description-v-0-0-1"></p>
+    </div><button type="button" aria-label="Close" data-slot="base" class="ui-btn font-[family-name:var(--ui-font-family-primary)] select-none cursor-pointer inline-flex items-center outline-transparent focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed aria-disabled:cursor-not-allowed disabled:opacity-30 aria-disabled:opacity-30 transition duration-0 ease-linear border-(length:--ui-btn-border-width) text-(--ui-btn-color) bg-(--ui-btn-background) border-(--ui-btn-border-color) hover:text-(--ui-btn-color-hover) hover:bg-(--ui-btn-background-hover) hover:border-(--ui-btn-border-color-hover) focus:text-(--ui-btn-color-hover) focus:bg-(--ui-btn-background-hover) focus:border-(--ui-btn-border-color-hover) active:text-(--ui-btn-color-active) active:bg-(--ui-btn-background-active) active:border-(--ui-btn-border-color-active) disabled:bg-(--ui-btn-background) disabled:border-(--ui-btn-border-color) aria-disabled:bg-(--ui-btn-background) aria-disabled:border-(--ui-btn-border-color) focus-visible:outline-(--ui-btn-background) ring-(--ui-btn-background-hover) focus:outline-none focus-visible:ring-(--ui-btn-background-hover) h-(--ui-btn-height) text-(length:--ui-btn-font-size) leading-(--ui-btn-height) font-(--ui-btn-font-weight) --style-plain-no-accent ui-btn-lg rounded-(--ui-btn-radius) normal-case --air w-(--ui-btn-height) group absolute top-4 end-4">
+      <!--v-if-->
+      <div data-slot="baseLine" class="w-full inline-flex items-center justify-center gap-(--ui-btn-icon-space) h-(--ui-btn-height) ps-[4px] pe-[4px]"><svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" aria-hidden="true" data-slot="icon" class="text-(--ui-btn-color) shrink-0 size-(--ui-btn-icon-size)">
+          <path fill="currentColor" d="M8.46 7.54a.65.65 0 0 0-.92.92L11.08 12l-3.54 3.54a.65.65 0 1 0 .92.92L12 12.918l3.54 3.54a.65.65 0 1 0 .919-.92L12.919 12l3.54-3.54a.65.65 0 0 0-.92-.919L12 11.08z"></path>
+        </svg>
+        <!--v-if-->
+        <!--v-if-->
+      </div>
+    </button>
+  </div>
+  <!--v-if-->
+  <div data-slot="footer" class="absolute inset-x-0 bottom-0 base-mode bg-(--ui-color-bg-content-primary) flex items-center justify-center gap-2.5 border-t-1 border-t-(--ui-color-divider-less) shadow-top-md py-[13px] px-[13px]">Footer slot</div>
 </div>
 
 
@@ -630,6 +758,38 @@ exports[`Slideover > renders with top side correctly 1`] = `
   </div>
   <!--v-if-->
   <!--v-if-->
+</div>
+
+
+
+<!--teleport end-->"
+`;
+
+exports[`Slideover > renders with top side inset and footer slot correctly 1`] = `
+"<!--v-if-->
+<!--teleport start-->
+
+
+
+<div data-state="open" style="pointer-events: auto;" data-slot="overlay" class="fixed inset-0 bg-linear-to-b from-[#00204e]/52 to-[#00204e] motion-safe:data-[state=open]:animate-[fade-in_200ms_var(--ease-out)] motion-safe:data-[state=closed]:animate-[fade-out_200ms_var(--ease-out)]" data-aria-hidden="true" aria-hidden="true"></div>
+<div data-dismissable-layer="" tabindex="-1" data-side="top" data-slot="content" class="base-mode fixed bg-(--ui-color-gray-05) dark:bg-(--ui-color-base-black-fixed) sm:shadow-lg flex flex-col focus:outline-none h-full rounded-[18px] max-h-[calc(100%-2rem)] inset-x-4 top-4 motion-safe:data-[state=open]:animate-[slide-in-from-top_200ms_var(--ease-out)] motion-safe:data-[state=closed]:animate-[slide-out-to-top_200ms_var(--ease-out)]" id="" role="dialog" aria-describedby="reka-dialog-description-v-0-0-1" aria-labelledby="reka-dialog-title-v-0-0-0" data-state="open" style="pointer-events: auto;"><span aria-hidden="true" style="position: absolute; border: 0px; width: 1px; height: 1px; padding: 0px; margin: -1px; overflow: hidden; clip: rect(0, 0, 0, 0); clip-path: inset(50%); white-space: nowrap; word-wrap: normal; top: -1px; left: -1px;"><!--v-if--><p id="reka-dialog-description-v-0-0-1"></p></span>
+  <!--v-if-->
+  <div data-slot="header" class="py-5 px-5 flex items-center gap-x-3 gap-y-1.5">
+    <div data-slot="wrapper" class="">
+      <h2 id="reka-dialog-title-v-0-0-0" data-slot="title" class="font-[family-name:var(--ui-font-family-primary)] text-label font-(--ui-font-weight-semi-bold) mb-0 text-(length:--ui-font-size-4xl)/[calc(var(--ui-font-size-4xl)+2px)]">Title</h2>
+      <p id="reka-dialog-description-v-0-0-1"></p>
+    </div><button type="button" aria-label="Close" data-slot="base" class="ui-btn font-[family-name:var(--ui-font-family-primary)] select-none cursor-pointer inline-flex items-center outline-transparent focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed aria-disabled:cursor-not-allowed disabled:opacity-30 aria-disabled:opacity-30 transition duration-0 ease-linear border-(length:--ui-btn-border-width) text-(--ui-btn-color) bg-(--ui-btn-background) border-(--ui-btn-border-color) hover:text-(--ui-btn-color-hover) hover:bg-(--ui-btn-background-hover) hover:border-(--ui-btn-border-color-hover) focus:text-(--ui-btn-color-hover) focus:bg-(--ui-btn-background-hover) focus:border-(--ui-btn-border-color-hover) active:text-(--ui-btn-color-active) active:bg-(--ui-btn-background-active) active:border-(--ui-btn-border-color-active) disabled:bg-(--ui-btn-background) disabled:border-(--ui-btn-border-color) aria-disabled:bg-(--ui-btn-background) aria-disabled:border-(--ui-btn-border-color) focus-visible:outline-(--ui-btn-background) ring-(--ui-btn-background-hover) focus:outline-none focus-visible:ring-(--ui-btn-background-hover) h-(--ui-btn-height) text-(length:--ui-btn-font-size) leading-(--ui-btn-height) font-(--ui-btn-font-weight) --style-plain-no-accent ui-btn-lg rounded-(--ui-btn-radius) normal-case --air w-(--ui-btn-height) group absolute top-4 end-4">
+      <!--v-if-->
+      <div data-slot="baseLine" class="w-full inline-flex items-center justify-center gap-(--ui-btn-icon-space) h-(--ui-btn-height) ps-[4px] pe-[4px]"><svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" aria-hidden="true" data-slot="icon" class="text-(--ui-btn-color) shrink-0 size-(--ui-btn-icon-size)">
+          <path fill="currentColor" d="M8.46 7.54a.65.65 0 0 0-.92.92L11.08 12l-3.54 3.54a.65.65 0 1 0 .92.92L12 12.918l3.54 3.54a.65.65 0 1 0 .919-.92L12.919 12l3.54-3.54a.65.65 0 0 0-.92-.919L12 11.08z"></path>
+        </svg>
+        <!--v-if-->
+        <!--v-if-->
+      </div>
+    </button>
+  </div>
+  <!--v-if-->
+  <div data-slot="footer" class="absolute inset-x-0 bottom-0 base-mode bg-(--ui-color-bg-content-primary) flex items-center justify-center gap-2.5 border-t-1 border-t-(--ui-color-divider-less) shadow-top-md py-[13px] px-[13px]">Footer slot</div>
 </div>
 
 


### PR DESCRIPTION
### Linked issue

Resolves #90

### Type of change

- [ ] Documentation (updates to the documentation or readme)
- [ ] Bug fix (a non-breaking change that fixes an issue)
- [x] Enhancement (improving an existing functionality)
- [x] Chore (updates to the build process or auxiliary tools and libraries)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Revert (undoing a merged change — retitle this PR `revert(Scope): ...`)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Description

#90 lists seven items. **Two are ours and are done here. Four are upstream's, byte for byte. One sits on a component being deleted.** The audit is three months old, so everything was re-measured before anything was touched.

| # | Item | Whose | Outcome |
| --- | --- | --- | --- |
| 1 | shared `dispatchChangeEvent` | **upstream's** — identical line in 16 files there | documented, not extracted — and the pattern turns out to be broken |
| 2 | commented-out `moduleDependencies` | **ours** — upstream's block is live | 22 lines deleted |
| 3 | `SidebarLayout` slots typed `: any` | ours, but the component is `@deprecated` for `3.0.0` | skipped |
| 4 | `limit ?? 42` in `useEditorMenu` | **upstream's** — same value, same line 177 | skipped |
| 5 | warn prefix in `useFileUpload` | **upstream's** — same warn, same missing prefix | skipped |
| 6 | drag listener leak in `useResizable` | **upstream's** — no teardown there either | skipped |
| 7 | 94 `@todo` in `src/theme` | **ours** — upstream has **0** | 94 → 32 |

---

## Item 7 — the `@todo` ledger, 94 → 32

Repo-wide 102 → 41. The audit called it "an untracked debt ledger invisible to the issue tracker", which was right; most of it turned out to be dead or already done.

**45 removed — they sit on components being deleted.** The nine `Navbar*` / `Sidebar*` theme files each carried the same five asks — docs, test, playground, demo, color — for components deprecated for `3.0.0` (see #530). Investing in them is exactly the wrong call. Their headers now carry the deprecation note instead, matching the convention `sidebar-layout.ts` already used. That file's own tag was also misspelled `@deprecate`; fixed.

**10 removed — the thing they asked for now exists.** Each was checked against the actual artefact, not assumed:

| Marker | Satisfied by |
| --- | --- |
| `chat-messages` add docs | `docs/content/docs/2.components/chat-messages.md` |
| `color-picker` add docs / add demo | docs page + `playgrounds/demo/.../color-picker.vue` |
| `countdown` add docs / add tests | docs page + `test/components/Countdown.spec.ts` |
| `file-upload` add docs / add demo | docs page + demo playground page |
| `pagination` add docs / add demo | docs page + demo playground page |
| `prose/p` docs | the "Paragraph" section of `4.typography/2.headers-and-text.md` |

**1 resolved.** `input-rating.ts` carried `@todo this this \`A component to display and collect ratings from users.\``. That text is verbatim the `description` on the docs page, and the file convention puts the description under the component name — so it was moved there rather than tracked.

**1 removed** as meaningless: a bare `// @todo ////` region marker in `button.ts`.

**5 answered by deleting what they asked about.** `slideover.ts` had five `// @todo remove this ?` sitting on compound variants whose `class` was `{}`.

### Proving those five were dead

This is the part worth reading. All five need `side` × `inset` × `useFooter`, and **the snapshot matrix reached none of those combinations** — `useFooter` is derived from the presence of the `footer` slot, and the only footer case in the spec used the default side with `inset: false`. So "I removed them and no snapshot changed" would have proved nothing at all.

So: five cases covering exactly those combinations were added **first** and recorded with the variants still in place. Removing the variants then left every one of them byte-identical. The `/review` pass reproduced this independently by restoring `main`'s theme file and re-running.

Those five cases stay. They cannot go red against *this* removal — that is the point — but they guard the combinations against future edits, and `useFooter` was an untested prop either way.

**The remaining 32 are real design intentions and stay.** The five written `@todo:` are normalised to `@todo ` so one grep finds them all.

## Item 2 — 22 lines of dead config

Three commented-out `moduleDependencies` entries in `src/module.ts`, all dead rather than pending:

- `fonts` is **not a module option at all** — `userUiOptions.fonts` appears nowhere but inside the comment
- `colorMode` is handled by live code further down (`if (options.colorMode || hasNuxtModule('@nuxtjs/color-mode'))`)
- `@nuxt/icon` is superseded by the `@bitrix24/b24icons-nuxt` entry directly above it

Upstream has this block live and uncommented, so it is our leftover, not a port in progress.

## Item 1 — the pattern the issue wants extracted does not work

The issue proposes folding the copy-pasted `new Event('change', { target: { value } })` into a shared helper, which would clear 16 of the repo's 27 `@ts-expect-error`s. Two measurements say no:

**It would be a 16-file divergence.** `nuxt/ui@v4` has the identical line in 16 component files — the highest-churn files in the sync.

**And the pattern is broken.** `target` is not an `EventInit` field, and the runtime drops it. Mounting `B24Switch` and reading the emitted event:

```
{ isEvent: true, type: "change", target: null, ownKeys: ["NONE", "CAPTURING_PHASE", "AT_TARGET", "BUBBLING_PHASE"] }
```

The `@ts-expect-error` is suppressing TypeScript being **correct**. And the replacement the issue suggests throws:

```
Object.assign(new Event('change'), { target: { value } })
  → TypeError: Cannot set property target of #<Event> which has only a getter
```

Nothing inside the library reads that `target` — the `event.target` reads in `Input`/`Textarea` are on real DOM events — so nothing is broken today. What is exposed is anyone writing `@change="e => e.target.value"`, which throws.

Per the maintainer's call: **documented, not fixed here.** `form.md` now carries a warning naming the sixteen affected components and pointing at `@update:model-value`, and calls out `Input` and `Textarea` as unaffected because they re-emit the browser's own event (`Input.vue:264`). Fixing it properly belongs upstream.

## What `/review` caught

- `form.md` claimed the synthetic `change` is "emitted so the Form can react to a commit". It is not — `emits('change', event)` and `emitFormChange()` are separate calls (`Select.vue:329-332`) and validation runs off the second. Reworded.
- Removing `countdown.ts`'s two `@todo`s emptied a second JSDoc block, leaving `/**` `*/` dangling above `export default`. Fixed, and `src/` scanned for the same shape — it was the only one.

### Checks

- `pnpm lint`, `pnpm typecheck` green
- Full suite: 340 files, **7814 passed**, 6 skipped (+10 — the new Slideover cases)
- No snapshot changed except the 10 new entries

### Checklist

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012MsMuj8Fic9tjWVjyEyrxc

---
_Generated by [Claude Code](https://claude.ai/code/session_012MsMuj8Fic9tjWVjyEyrxc)_