### PR TITLE
docs(theme): document global config and the slot-class replacer

### DIFF
--- a/docs/content/docs/1.getting-started/5.theme/3.components.md
+++ b/docs/content/docs/1.getting-started/5.theme/3.components.md
@@ -68,7 +68,7 @@ export default {
 ::
 
 ::warning
-Components without slots don't have a [`b24ui` prop](#ui-prop), only the [`class` prop](#class-prop) is available to override styles.
+Components without slots don't have a [`b24ui` prop](#b24ui-prop), only the [`class` prop](#class-prop) is available to override styles.
 ::
 
 ### Variants
@@ -288,7 +288,7 @@ export default defineAppConfig({
 
 #vue
 :::div
-```ts [vite.config.ts]
+```ts
 bitrix24UIPluginVite({
   b24ui: {
     button: {

--- a/docs/content/docs/1.getting-started/5.theme/3.components.md
+++ b/docs/content/docs/1.getting-started/5.theme/3.components.md
@@ -210,6 +210,122 @@ You can explore the theme for each component in two ways:
 - Browse the source code directly in the GitHub repository at [`src/theme`](https://github.com/bitrix24/b24ui/tree/main/src/theme).
 ::
 
+### Global config
+
+::framework-only
+#nuxt
+Override the theme of a component for every instance in your app from `app.config.ts`, using the same structure as the theme object itself.
+#vue
+Override the theme of a component for every instance in your app from `vite.config.ts`, using the same structure as the theme object itself.
+::
+
+You can customize the [`slots`](#slots), [`variants`](#variants), [`compoundVariants`](#compound-variants) and [`defaultVariants`](#default-variants) of any component:
+
+::framework-only
+#nuxt
+:::div
+```ts [app/app.config.ts]
+export default defineAppConfig({
+  b24ui: {
+    button: {
+      slots: {
+        base: 'font-bold'
+      },
+      defaultVariants: {
+        size: 'lg'
+      }
+    }
+  }
+})
+```
+:::
+
+#vue
+:::div
+```ts [vite.config.ts]
+import { defineConfig } from 'vite'
+import vue from '@vitejs/plugin-vue'
+import bitrix24UIPluginVite from '@bitrix24/b24ui-nuxt/vite'
+
+export default defineConfig({
+  plugins: [
+    vue(),
+    bitrix24UIPluginVite({
+      b24ui: {
+        button: {
+          slots: {
+            base: 'font-bold'
+          },
+          defaultVariants: {
+            size: 'lg'
+          }
+        }
+      }
+    })
+  ]
+})
+```
+:::
+::
+
+By default these classes are **merged** onto the component's own. Set a slot to a function to **replace** them instead — it receives the slot's own classes so you can keep part of them:
+
+::framework-only
+#nuxt
+:::div
+```ts [app/app.config.ts]
+export default defineAppConfig({
+  b24ui: {
+    button: {
+      slots: {
+        label: () => 'text-base font-bold'
+      }
+    }
+  }
+})
+```
+:::
+
+#vue
+:::div
+```ts [vite.config.ts]
+bitrix24UIPluginVite({
+  b24ui: {
+    button: {
+      slots: {
+        label: () => 'text-base font-bold'
+      }
+    }
+  }
+})
+```
+:::
+::
+
+::warning
+**Where you write the replacer changes what it replaces.**
+
+In global config it takes the place of the slot's **own** classes, so `variants` and `compoundVariants` still merge on top — a replaced `base` still gets its size and colour classes.
+
+In the [`b24ui`](#b24ui-prop) and [`class`](#class-prop) props it runs **after** variants have resolved, so it replaces everything, variants included.
+::
+
+::tip{to="/docs/getting-started/installation/nuxt/#themeunstyled"}
+To remove the default classes from all components at once, use the `theme.unstyled` option instead.
+::
+
+### Theme component
+
+The [Theme](/docs/components/theme/) component overrides slots and prop defaults for every descendant, without touching the rest of the app. It takes priority over global config, and the `b24ui` and `class` props still win over it.
+
+Its slots accept the same `(defaults) => classes` function form. It resolves at the same point as the [`b24ui` prop](#b24ui-prop), so a replacer written there replaces the resolved classes, variants included.
+
+::component-example
+---
+name: 'theme-ui-example'
+---
+::
+
 ### `b24ui` prop
 
 You can override a component's **slots** using the `b24ui` prop. This takes priority over both global config and resolved `variants`.
@@ -240,7 +356,7 @@ slots:
 In this example, the `trailingIcon` slot is overwritten with `size-10` even though the `md` size variant would apply a `size-(--ui-btn-icon-size)` class to it.
 ::
 
-A slot value can also be a function to **replace** its classes instead of merging them. It receives the slot's fully resolved default class string as its argument, so you can reuse part of them if needed:
+A slot value can also be a function to **replace** its classes instead of merging them. Here it runs after variants have resolved, so it receives the slot's fully resolved class string — and replaces all of it. In [global config](#global-config) the same form replaces only the slot's own classes; see the note there.
 
 ```vue
 <template>

--- a/docs/content/docs/2.components/theme.md
+++ b/docs/content/docs/2.components/theme.md
@@ -37,7 +37,9 @@ Classes are merged onto the component defaults. To **replace** them instead, set
 ```
 
 ::warning
-Slot names go **directly** under the component name here — `{ button: { label: … } }`{lang="ts"}. This is not the theme-object shape used in [global config](/docs/getting-started/theme/components/#global-config), which nests them under `slots`. Writing `{ button: { slots: { label: … } } }`{lang="ts"} on this component is silently ignored: no error, no warning, the defaults simply stay.
+Slot names go **directly** under the component name here — `{ button: { label: … } }`{lang="ts"}. This is not the theme-object shape used in [global config](/docs/getting-started/theme/components/#global-config), which nests them under `slots`.
+
+TypeScript rejects the wrong one (`TS2353: 'slots' does not exist in type …`), so keep the prop typed. At runtime it is simply ignored — no error, no warning, the defaults stay — which is what you get if the object reaches the prop untyped.
 ::
 
 ::note{to="/docs/getting-started/theme/components/#global-config"}

--- a/docs/content/docs/2.components/theme.md
+++ b/docs/content/docs/2.components/theme.md
@@ -26,6 +26,24 @@ The Theme component doesn't render any HTML element, it only provides theme over
 
 Use the `b24ui` prop to override slot classes of descendant components. Keys are component names (camelCase) and values are their slot class overrides.
 
+Classes are merged onto the component defaults. To **replace** them instead, set the slot to a function — it receives the resolved defaults, so you can keep part of them:
+
+```vue
+<template>
+  <B24Theme :b24ui="{ button: { label: () => 'text-base font-bold' } }">
+    <B24Button label="Replaced" />
+  </B24Theme>
+</template>
+```
+
+::warning
+Slot names go **directly** under the component name here — `{ button: { label: … } }`{lang="ts"}. This is not the theme-object shape used in [global config](/docs/getting-started/theme/components/#global-config), which nests them under `slots`. Writing `{ button: { slots: { label: … } } }`{lang="ts"} on this component is silently ignored: no error, no warning, the defaults simply stay.
+::
+
+::note{to="/docs/getting-started/theme/components/#global-config"}
+Theme resolves at the same point as the `b24ui` prop, so a replacer here replaces the resolved classes, variants included. In global config it replaces only the slot's own classes and variants still apply on top.
+::
+
 ::component-example
 ---
 name: 'theme-ui-example'

--- a/skills/b24-ui-nuxt/references/guidelines/design-system.md
+++ b/skills/b24-ui-nuxt/references/guidelines/design-system.md
@@ -159,7 +159,7 @@ Override theme for a section of the component tree without affecting the rest of
 </B24Theme>
 ```
 
-Slot names go **directly** under the component name here — `{ button: { base: … } }`. This is *not* the global-config shape, which nests them under `slots`. Writing `{ button: { slots: { base: … } } }` on `B24Theme` is silently ignored — no error, the defaults just stay.
+Slot names go **directly** under the component name here — `{ button: { base: … } }`. This is *not* the global-config shape, which nests them under `slots`. TypeScript rejects the wrong one (`TS2353`); at runtime it is ignored with no error, so an untyped object loses the override silently.
 
 ### Tree-shaking with `experimental.componentDetection`
 

--- a/skills/b24-ui-nuxt/references/guidelines/design-system.md
+++ b/skills/b24-ui-nuxt/references/guidelines/design-system.md
@@ -75,6 +75,63 @@ Rules for `b24ui` overrides:
 - **Prefer `defaultVariants`** over slot class overrides when possible (e.g., changing default button color/size).
 - **Don't duplicate default classes** — check the generated theme file first to see what's already there.
 
+### Global config
+
+Change a component's theme for every instance.
+
+```ts
+// app/app.config.ts (Nuxt)
+export default defineAppConfig({
+  b24ui: {
+    button: {
+      slots: { base: 'font-bold' },
+      defaultVariants: { size: 'lg' }
+    }
+  }
+})
+```
+
+```ts
+// vite.config.ts (Vue) — same object, passed to the plugin
+bitrix24UIPluginVite({
+  b24ui: {
+    button: {
+      slots: { base: 'font-bold' },
+      defaultVariants: { size: 'lg' }
+    }
+  }
+})
+```
+
+Prefer `defaultVariants` over slot classes whenever a variant already expresses the change.
+
+### Replace instead of merge
+
+Classes from the `b24ui` prop, the `class` prop, `B24Theme` and global config are **merged onto** the component defaults. To replace them, set the slot to a function — it receives the default classes so you can keep part of them.
+
+```vue
+<B24Button :b24ui="{ label: () => 'text-base font-bold' }" label="Button" />
+```
+
+```ts
+// app/app.config.ts — applies to every instance
+export default defineAppConfig({
+  b24ui: {
+    button: {
+      slots: {
+        label: () => 'text-base font-bold'
+      }
+    }
+  }
+})
+```
+
+**Where you write it changes what it replaces:**
+- In **global config** it replaces the slot's *own* classes — `variants` and `compoundVariants` still merge on top.
+- In the **`b24ui` / `class` props and `B24Theme`** it runs after variants resolve, so it replaces everything, variants included.
+
+Reach for this when merging cannot win — `tailwind-merge` only resolves conflicts inside a class group, so an override that has to drop unrelated defaults (layout, transitions, ring utilities) needs the function form.
+
 ### `class` prop
 
 Override the **root** (or `base`) slot only — simpler than `b24ui` for single-slot changes.
@@ -101,6 +158,8 @@ Override theme for a section of the component tree without affecting the rest of
   <B24Button label="Also rounded" />
 </B24Theme>
 ```
+
+Slot names go **directly** under the component name here — `{ button: { base: … } }`. This is *not* the global-config shape, which nests them under `slots`. Writing `{ button: { slots: { base: … } } }` on `B24Theme` is silently ignored — no error, the defaults just stay.
 
 ### Tree-shaking with `experimental.componentDetection`
 


### PR DESCRIPTION
### Linked issue

Resolves #184

### Type of change

- [x] Documentation (updates to the documentation or readme)
- [ ] Bug fix (a non-breaking change that fixes an issue)
- [ ] Enhancement (improving an existing functionality)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Chore (updates to the build process or auxiliary tools and libraries)
- [ ] Revert (undoing a merged change — retitle this PR `revert(Scope): ...`)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Description

Three files, docs and skill only. This is the documentation half of #183, deliberately deferred at port time.

**Unlike the last few issues, upstream *has* this documentation and we skipped it.** So matching upstream means writing it, not closing the issue — the opposite conclusion from #56/#59/#90.

The runtime feature was verified working before a word was written: mounting `B24Button` with `:b24ui="{ base: () => 'ZZ' }"` renders exactly `ZZ`, a plain string still merges, and the replacer receives the resolved defaults as a string.

---

## A missing section, found on the way

`5.theme/3.components.md` referred to "global config" **three times** — in the `b24ui` prop section, the `class` prop section, and the priority notes — and never documented it. Global theme config was described nowhere in the docs; `defineAppConfig` appeared only inside a VSCode settings snippet on the install page.

Upstream has a `### Global config` section on this exact page. This adds one, for both frameworks:

- Nuxt — `app.config.ts`
- Vue — `bitrix24UIPluginVite({ b24ui })`, the shape `Bitrix24UIOptions` actually declares (checked in `src/unplugin.ts:35`, not assumed)

## The replacer, and the distinction that matters

Where you write it changes what it replaces. Both halves are pinned by tests that already exist in `test/utils/tv.spec.ts`, so this is read off our behaviour rather than copied from upstream's prose:

| Written in | Replaces | Test |
| --- | --- | --- |
| global config | the slot's **own** classes — `variants` and `compoundVariants` still merge on top | `keeps the variants merging on top of a construction-time replacer` — asserts `inline-flex`/`rounded-md` gone, `bg-primary`/`px-2.5`/`gap-1.5` present |
| `b24ui` / `class` props, `B24Theme` | **everything**, variants included — it runs after variants resolve | `replaces a slot via a function in ':ui' and drops the defaults` — asserts the output is exactly the replacement |

That distinction is now a `::warning` on the theme page, repeated in the skill.

## A trap on `B24Theme`, measured

Its `b24ui` prop takes slot names **directly** under the component name, not the theme-object shape. Rendering both through a real Button:

```
{ button: { base: () => 'ZZFLAT' } }          → "ZZFLAT"
{ button: { slots: { base: () => 'ZZ' } } }   → the full untouched default class chain
```

The first draft of this PR documented the wrong one. `theme.md` and the skill now warn about it — and, after `/review`, warn about it *accurately*: `nuxt typecheck` does reject the nested form with `TS2353: 'slots' does not exist in type '{ base?: SlotClass; … }'`. Only the runtime ignores it, which is what an untyped object gets you.

## Skill

`skills/b24-ui-nuxt/references/guidelines/design-system.md` gains `### Global config` and `### Replace instead of merge`, mirroring upstream's own `design-system.md`, plus the shape warning on the existing `B24Theme` example.

This is the half that decides what an assistant generates. Without it, every override it writes is a merge — and "why is my class not applying" is precisely the question the replacer was built to answer.

## What `/review` caught

Four, all reproduced before fixing:

- the shape warning claimed "no error, no warning" — **false**, TypeScript catches it; corrected in both files
- the same claim in the skill
- the second Vue example was labelled `vite.config.ts` but is a bare `bitrix24UIPluginVite({…})` call — copied as labelled it would replace a working config with a fragment; label dropped
- `#ui-prop` on line 71 pointed at an anchor this page has never had (it is `#b24ui-prop`) — pre-existing, fixed while here

### Checks

- `pnpm lint` green
- Full suite: 340 files, 7814 passed, 6 skipped — no runtime file touched
- `tv`, `Theme`, and the docs guard specs green
- Both cross-page links fetched: `/docs/getting-started/theme/components/` and `/docs/components/theme/` return 200
- Not done: the docs site was not built, so the rendered pages have not been looked at — the dev server does not start in this environment (`@nuxtjs/mcp-toolkit` throws `completable is not defined` from its own bundle)

### Checklist

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012MsMuj8Fic9tjWVjyEyrxc

---
_Generated by [Claude Code](https://claude.ai/code/session_012MsMuj8Fic9tjWVjyEyrxc)_