### PR TITLE
test(skill): guard colour values and CSS custom properties in examples

### DIFF
--- a/skills/b24-ui-nuxt/references/guidelines/forms.md
+++ b/skills/b24-ui-nuxt/references/guidelines/forms.md
@@ -329,7 +329,7 @@ const scheduledAtInput = useTemplateRef('scheduledAtInput') // anchors the date 
 
   <!-- Nested sub-section: label outside + bordered container. clientGroupId = useId() so the label/group link stays unique if the form is rendered more than once. -->
   <div class="space-y-1.5">
-    <span :id="clientGroupId" class="block text-(length:--ui-font-size-sm) text-(--ui-color-typography-secondary)">Client</span>
+    <span :id="clientGroupId" class="block text-(length:--ui-font-size-sm) text-legend">Client</span>
     <div role="group" :aria-labelledby="clientGroupId" class="rounded-md border border-(--ui-color-design-outline-stroke) p-3 sm:p-4 space-y-4">
       <B24FormField label="Company" name="company">
         <B24Input v-model="state.company" :icon="UserCompanyIcon" placeholder="Company name, phone or email" class="w-full" />

--- a/skills/b24-ui-nuxt/references/recipes/data-tables.md
+++ b/skills/b24-ui-nuxt/references/recipes/data-tables.md
@@ -82,7 +82,7 @@ const filteredRows = computed(() => {
     <template #body>
       <B24Table :data="filteredRows" :columns="columns">
         <template #status-cell="{ row }">
-          <B24Badge :color="row.original.status === 'Active' ? 'air-primary-success' : 'air-secondary-no-accent'" :label="row.original.status" />
+          <B24Badge :color="row.original.status === 'Active' ? 'air-primary-success' : 'air-tertiary'" :label="row.original.status" />
         </template>
 
         <template #actions-cell="{ row }">

--- a/test/utils/skill-manifest.spec.ts
+++ b/test/utils/skill-manifest.spec.ts
@@ -81,6 +81,41 @@ const listComponentNames = async () => {
 /** Matches both registered prefixes, so neither direction of misnaming hides. */
 const COMPONENT_NAME = /\b(?:B24|Prose)[A-Z][A-Za-z0-9]*/g
 
+/**
+ * The `color` variant keys a component's theme actually declares.
+ *
+ * Read from `src/theme/<component>.ts` rather than from a list here, for the
+ * same reason as the component and icon checks: a second list drifts. Brace
+ * matching rather than a line regex because the map nests (`{ base: '…' }`
+ * entries) and a flat scan would pick up slot names from inside them.
+ */
+const colourKeys = (source: string): Set<string> | undefined => {
+  const start = source.indexOf('    color: {')
+  if (start === -1) {
+    return undefined
+  }
+
+  let depth = 0
+  let i = source.indexOf('{', start)
+  const open = i
+  for (; i < source.length; i++) {
+    if (source[i] === '{') {
+      depth++
+    } else if (source[i] === '}') {
+      depth--
+      if (depth === 0) {
+        break
+      }
+    }
+  }
+
+  return new Set([...source.slice(open, i).matchAll(/^\s{6}'?([a-z0-9-]+)'?\s*:/gim)].map(match => match[1]!))
+}
+
+/** `B24SelectMenu` -> `select-menu`, the theme file that names its colours. */
+const themeFileFor = (component: string) =>
+  component.replace(/^(?:B24|Prose)/, '').replace(/([a-z0-9])([A-Z])/g, '$1-$2').toLowerCase()
+
 const readManifest = async () =>
   JSON.parse(await readFile(join(skillsDir, 'index.json'), 'utf8')) as {
     skills: Array<{ name: string, description: string, files: string[] }>
@@ -434,6 +469,90 @@ describe('skill package', () => {
     }
 
     expect(phantom.sort()).toEqual([])
+  })
+
+  it('passes only colours the component theme declares', async () => {
+    // The third defect class in #345, and the one that proves the guard is
+    // worth having: `data-tables.md` shipped `color="neutral"` on `B24Badge`,
+    // that was fixed by hand to `air-secondary-no-accent` — which `Badge` does
+    // not declare either, only `Button` does — and it sat wrong for another
+    // month. Rendering it produces no `style-*` class at all, so the Inactive
+    // badge is simply uncoloured. Nothing throws, nothing warns.
+    const themes = new Map<string, Set<string>>()
+    for (const file of await glob('*.ts', { cwd: join(repoRoot, 'src/theme'), ...GLOB })) {
+      const keys = colourKeys(await readFile(join(repoRoot, 'src/theme', file), 'utf8'))
+      if (keys?.size) {
+        themes.set(file.replace(/\.ts$/, ''), keys)
+      }
+    }
+
+    expect(themes.get('button')?.has('air-secondary-no-accent')).toBe(true)
+    expect(themes.get('badge')?.has('air-secondary-no-accent')).toBe(false)
+    expect(themes.get('badge')?.has('air-tertiary')).toBe(true)
+
+    const unknown: string[] = []
+    for (const doc of await listDocs()) {
+      const body = await readFile(join(skillDir, doc), 'utf8')
+      for (const [, name, attrs] of body.matchAll(/<((?:B24|Prose)[A-Za-z0-9]+)\b([^>]*)>/g)) {
+        const theme = themes.get(themeFileFor(name!))
+        if (!theme) {
+          continue
+        }
+        // A static attribute is a literal. The leading boundary keeps `:color`
+        // and `active-color` out — those are expressions and other props.
+        for (const [, , value] of attrs!.matchAll(/(^|\s)color="([^"]+)"/g)) {
+          if (!theme.has(value!)) {
+            unknown.push(`${doc}: <${name} color="${value}">`)
+          }
+        }
+        // Quoted literals inside a bound expression are still checkable, and
+        // that is where the Badge defect lived — a ternary, not an attribute.
+        for (const [, expression] of attrs!.matchAll(/:color="([^"]+)"/g)) {
+          for (const [, literal] of expression!.matchAll(/'([a-z][a-z0-9-]*)'/g)) {
+            if (!theme.has(literal!)) {
+              unknown.push(`${doc}: <${name} :color="… '${literal}' …">`)
+            }
+          }
+        }
+      }
+    }
+
+    expect(unknown.sort()).toEqual([])
+  })
+
+  it('references only CSS custom properties that exist', async () => {
+    // Same shape one layer down, and the cheapest sibling of the colour check:
+    // `design-system.md` told readers to set `--b24ui-header-heights`, plural,
+    // which is declared nowhere — the singular is what every declaration uses.
+    // `forms.md` reached for `--ui-color-typography-secondary`, and there is no
+    // `--ui-color-typography-*` family at all. Both resolve to nothing and
+    // style nothing, silently.
+    const declared = new Set<string>()
+    for (const file of await glob('**/*.{css,ts,vue}', { cwd: join(repoRoot, 'src'), ...GLOB })) {
+      const body = await readFile(join(repoRoot, 'src', file), 'utf8')
+      for (const [, token] of body.matchAll(/(--(?:b24ui|ui)-[a-z0-9-]+)\s*:/g)) {
+        declared.add(token!)
+      }
+    }
+
+    expect(declared.has('--ui-color-base-5')).toBe(true)
+    expect(declared.has('--ui-color-typography-secondary')).toBe(false)
+
+    const unknown: string[] = []
+    for (const doc of await listDocs()) {
+      const body = await readFile(join(skillDir, doc), 'utf8')
+      // Only tokens being *used*: `var(--x)` or Tailwind's `text-(--x)`. The
+      // closing paren is what separates a real reference from the placeholders
+      // the prose writes — `--ui-color-base-N`, `…-bg-gradient-{1,2,3}`,
+      // `…-bg-content-*` — which would otherwise all read as phantom tokens.
+      for (const [, token] of body.matchAll(/\((--(?:b24ui|ui)-[a-z0-9-]+)\)/g)) {
+        if (!declared.has(token!)) {
+          unknown.push(`${doc}: ${token}`)
+        }
+      }
+    }
+
+    expect([...new Set(unknown)].sort()).toEqual([])
   })
 
   it('keeps example code free of the mistakes agents copy verbatim', async () => {

--- a/test/utils/skill-manifest.spec.ts
+++ b/test/utils/skill-manifest.spec.ts
@@ -90,13 +90,17 @@ const COMPONENT_NAME = /\b(?:B24|Prose)[A-Z][A-Za-z0-9]*/g
  * entries) and a flat scan would pick up slot names from inside them.
  */
 const colourKeys = (source: string): Set<string> | undefined => {
-  const start = source.indexOf('    color: {')
-  if (start === -1) {
+  // The indent is derived, not assumed: a factory theme nests the map one
+  // level deeper (`input-number.ts` declares it at six spaces), and a
+  // hardcoded four-space key pattern found the map there but read zero keys
+  // out of it — silently dropping that component from the check.
+  const header = /^([ \t]*)color: \{/m.exec(source)
+  if (!header) {
     return undefined
   }
 
   let depth = 0
-  let i = source.indexOf('{', start)
+  let i = source.indexOf('{', header.index)
   const open = i
   for (; i < source.length; i++) {
     if (source[i] === '{') {
@@ -109,7 +113,9 @@ const colourKeys = (source: string): Set<string> | undefined => {
     }
   }
 
-  return new Set([...source.slice(open, i).matchAll(/^\s{6}'?([a-z0-9-]+)'?\s*:/gim)].map(match => match[1]!))
+  const keyIndent = header[1]!.length + 2
+  const key = new RegExp(`^[ \\t]{${keyIndent}}'?([a-z0-9-]+)'?\\s*:`, 'gim')
+  return new Set([...source.slice(open, i).matchAll(key)].map(match => match[1]!))
 }
 
 /** `B24SelectMenu` -> `select-menu`, the theme file that names its colours. */
@@ -493,22 +499,27 @@ describe('skill package', () => {
     const unknown: string[] = []
     for (const doc of await listDocs()) {
       const body = await readFile(join(skillDir, doc), 'utf8')
-      for (const [, name, attrs] of body.matchAll(/<((?:B24|Prose)[A-Za-z0-9]+)\b([^>]*)>/g)) {
+      // Quoted attribute values are skipped over rather than treated as tag
+      // ends, so a `v-if="a > b"` no longer truncates the tag and hides every
+      // attribute after it.
+      for (const [, name, attrs] of body.matchAll(/<((?:B24|Prose)[A-Za-z0-9]+)\b((?:"[^"]*"|'[^']*'|[^>])*)>/g)) {
         const theme = themes.get(themeFileFor(name!))
         if (!theme) {
           continue
         }
-        // A static attribute is a literal. The leading boundary keeps `:color`
-        // and `active-color` out — those are expressions and other props.
-        for (const [, , value] of attrs!.matchAll(/(^|\s)color="([^"]+)"/g)) {
+        // `activeColor` takes the same map (`Button['variants']['color']`), so
+        // both attributes are checked; the boundary keeps `:`-bound forms out,
+        // they are handled below.
+        for (const [, , attribute, value] of attrs!.matchAll(/(^|\s)(active-color|color)="([^"]+)"/g)) {
           if (!theme.has(value!)) {
-            unknown.push(`${doc}: <${name} color="${value}">`)
+            unknown.push(`${doc}: <${name} ${attribute}="${value}">`)
           }
         }
-        // Quoted literals inside a bound expression are still checkable, and
-        // that is where the Badge defect lived — a ternary, not an attribute.
-        for (const [, expression] of attrs!.matchAll(/:color="([^"]+)"/g)) {
-          for (const [, literal] of expression!.matchAll(/'([a-z][a-z0-9-]*)'/g)) {
+        // Only the branches of a ternary, not every quoted string in the
+        // expression: a comparison operand (`row.status === 'active'`) is not
+        // a colour, and flagging it would fail a perfectly good example.
+        for (const [, expression] of attrs!.matchAll(/:(?:active-)?color="([^"]+)"/g)) {
+          for (const [, literal] of expression!.matchAll(/[?:]\s*'([a-z][a-z0-9-]*)'/g)) {
             if (!theme.has(literal!)) {
               unknown.push(`${doc}: <${name} :color="… '${literal}' …">`)
             }
@@ -537,17 +548,33 @@ describe('skill package', () => {
 
     expect(declared.has('--ui-color-base-5')).toBe(true)
     expect(declared.has('--ui-color-typography-secondary')).toBe(false)
+    expect(declared.has('--b24ui-header-height')).toBe(true)
+    expect(declared.has('--b24ui-header-heights')).toBe(false)
 
     const unknown: string[] = []
     for (const doc of await listDocs()) {
       const body = await readFile(join(skillDir, doc), 'utf8')
-      // Only tokens being *used*: `var(--x)` or Tailwind's `text-(--x)`. The
-      // closing paren is what separates a real reference from the placeholders
-      // the prose writes — `--ui-color-base-N`, `…-bg-gradient-{1,2,3}`,
-      // `…-bg-content-*` — which would otherwise all read as phantom tokens.
-      for (const [, token] of body.matchAll(/\((--(?:b24ui|ui)-[a-z0-9-]+)\)/g)) {
+
+      // Every shape the skill actually writes: `var(--x)`, `var(--x, fb)`,
+      // and Tailwind's arbitrary properties both bare — `text-(--x)` — and
+      // typed, `text-(length:--x)` / `font-(family-name:--x)`. An earlier
+      // draft matched only the bare form and so missed 27 of the references
+      // in this package, including the untouched half of the very line the
+      // phantom token above was found on.
+      for (const [, token] of body.matchAll(/\((?:[a-z-]+:)?(--(?:b24ui|ui)-[a-z0-9-]+)\s*[),]/g)) {
         if (!declared.has(token!)) {
           unknown.push(`${doc}: ${token}`)
+        }
+      }
+
+      // Declarations too, which is the form the original defect took:
+      // `design-system.md` told readers to set `--b24ui-header-heights` in
+      // their own CSS. Only the library's own namespaces are matched, so a
+      // reader defining `--my-thing` is left alone; writing `--b24ui-*` is a
+      // claim that the library reads it.
+      for (const [, token] of body.matchAll(/^\s*(--(?:b24ui|ui)-[a-z0-9-]+)\s*:/gm)) {
+        if (!declared.has(token!)) {
+          unknown.push(`${doc}: ${token} (declared, but the library has no such token)`)
         }
       }
     }


### PR DESCRIPTION
### Linked issue

Resolves #345

### Type of change

- [ ] Documentation (updates to the documentation or readme)
- [x] Bug fix (a non-breaking change that fixes an issue)
- [x] Enhancement (improving an existing functionality)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Chore (updates to the build process or auxiliary tools and libraries)
- [ ] Revert (undoing a merged change — retitle this PR `revert(Scope): ...`)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Description

Two new checks in `test/utils/skill-manifest.spec.ts`, and the two live defects they found. Starts where #345 says to start — colours, then CSS custom properties as the cheapest sibling. Prop names are the harder half and are left for a separate pass, as the issue itself notes.

**Both guards found something on their first run, which is the argument for having them at all.**

---

## The two defects

### `B24Badge` has been rendering uncoloured for a month

`data-tables.md` shipped `color="neutral"` on `B24Badge`. That is in #345's own table. It was fixed by hand in #343 to `air-secondary-no-accent` — a key **`Button` declares and `Badge` does not** — and sat wrong ever since.

Measured by rendering all three:

| | rendered `style-*` class |
| --- | --- |
| no colour (default) | `style-filled` |
| `air-secondary` (valid) | `style-tinted` |
| `air-secondary-no-accent` (shipped) | **none** |

The Inactive badge has no colour class at all. Nothing throws, nothing warns. Now `air-tertiary`, which `Badge` does declare (`style-outline-no-accent` — the muted outline that suits an inactive status next to a filled green one).

The manual fix for the defect in the issue was itself wrong. That is the case for doing this mechanically.

### A phantom CSS token

`forms.md` used `text-(--ui-color-typography-secondary)` to label a `role="group"`. It is declared nowhere, and there is no `--ui-color-typography-*` family in `src/` at all. Replaced with `text-legend` — the semantic utility the skill's own design-system guideline describes as being for group titles, and which `src/theme/timeline.ts` and `src/theme/dropdown-menu.ts` already use.

---

## The checks

Both follow the shape the file already uses: read the truth from the tree, anchor on a positive **and** a negative sentinel, then assert the scan finds nothing.

**Colours** come from each `src/theme/*.ts` `color` variant map, found by brace matching rather than a line regex — the map nests, and a flat scan picks up slot names from inside it. Static `color=` / `active-color=` attributes are checked, and so are the ternary branches of a bound `:color=`, which is where the Badge defect actually lived.

**CSS custom properties** are checked in every shape the skill writes: `var(--x)`, `var(--x, fallback)`, `text-(--x)`, and the typed arbitrary properties `text-(length:--x)` / `font-(family-name:--x)` — plus declarations, since writing `--b24ui-*` in your own CSS is a claim the library reads it.

Prose placeholders are deliberately not flagged: `--ui-color-base-N`, `…-bg-gradient-{1,2,3}` and `…-bg-content-*` are documentation, not references, and requiring a closing `)` or `,` separates them cleanly. Without that the check reports five false positives to one real finding.

## What `/review` caught

Six holes in the first draft. Four made the checks weaker than their own comments claimed, one was a false positive, one was a wrong statement:

| Finding | Consequence |
| --- | --- |
| `colourKeys` hardcoded a 4-space indent | `input-number.ts` nests its map at 6 — map found, **zero keys read**, component silently unchecked |
| tag matched with `[^>]*` | `<B24Badge v-if="a > b" color="bogus" />` passed green |
| `:color` flagged every quoted string | `row.status === 'active'` would fail as an unknown colour |
| `active-color` dismissed as an "other prop" | it takes the same colour map |
| token pattern matched only bare `(--x)` | missed 27 references, including the *untouched half of the very line* the phantom token was found on |
| the comment claimed it guards `--b24ui-header-heights` | it did not — that defect is a **declaration**, which a usage-only pattern cannot see |

All fixed, and each fix probed by injecting the case:

```
InputNumber colour (factory theme)         RED ✓
active-color attribute                     RED ✓
> inside an attribute value                RED ✓
typed token text-(length:--phantom)        RED ✓
var() with a fallback                      RED ✓
declaration form --b24ui-header-heights    RED ✓
row.status === 'active'                    green ✓  (no false positive)
```

The two original defects were also each restored and confirmed to fail exactly their matching check, naming the file and the value — and re-verified after `eslint --fix` rewrote one of the regexes.

### Checks

- `pnpm lint`, `pnpm typecheck` green
- Full suite: 340 files, **7818 passed**, 6 skipped (+4 — the two new checks × two projects)
- No runtime file touched

### Checklist

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012MsMuj8Fic9tjWVjyEyrxc

---
_Generated by [Claude Code](https://claude.ai/code/session_012MsMuj8Fic9tjWVjyEyrxc)_