### PR TITLE
fix(Input,Textarea): keep `0` with `nullable` and `optional` (nuxt/ui@6d6737a)

### DIFF
--- a/.sync/dep-parity.json
+++ b/.sync/dep-parity.json
@@ -1,6 +1,6 @@
 {
   "$note": "Upstream's pinned versions for every dependency both trees declare in the SAME section, snapshotted at `cursor`. The sync ports deltas, which is correct per commit and lets a one-time divergence become permanent: once a version is off upstream's line, every later `chore(deps)` batch skips it, because those ports bump only where this fork already matched upstream's pre-image. `prettier` sat at ^3.8.4 against upstream's ^3.9.6 for that reason, through four ported batches, until this file was written. Section-aware on purpose: 18 packages are declared on both sides but in different sections — the whole `@tiptap/*` family is a peer `^3` upstream and a dependency `^3.29.2` here, and `ai` is a peer there and a devDependency here. Those are structural divergences, not drift, and comparing a peer range against a dependency range says nothing. They are absent from this file by construction rather than by omission. Guarded by `test/utils/dep-parity.spec.ts`. Refresh with `node .sync/dep-parity.mjs <path-to-nuxt-ui-mirror> [cursor]`, which preserves `exceptions`.",
-  "cursor": "970025f9e045c953a3339a68ed05aa06e8f62e93",
+  "cursor": "6d6737af38d517f1d5bae9a4a0e063d169c17890",
   "manifests": {
     "package.json": {
       "dependencies": {

--- a/.sync/log/6d6737af38d517f1d5bae9a4a0e063d169c17890.md
+++ b/.sync/log/6d6737af38d517f1d5bae9a4a0e063d169c17890.md
@@ -1,0 +1,58 @@
+# port — nuxt/ui@6d6737af38d517f1d5bae9a4a0e063d169c17890
+
+**Upstream:** fix(Input/Textarea): keep `0` with `nullable` and `optional` modifiers (#6871)
+
+**Decision:** port, verbatim.
+
+## The defect
+
+`updateInput` mapped empty values with `||=`:
+
+```ts
+if (props.modelModifiers?.nullable) {
+  value ||= null
+}
+```
+
+`||=` fires on every falsy value, not on emptiness. With the `number` modifier —
+or `type="number"`, which takes the same branch — `looseToNumber('0')` yields
+`0`, and `0 ||= null` is `null`. A quantity of zero came back as *no value at
+all*, and the same for `.optional` producing `undefined`.
+
+Not a rendering nuisance: the model is what a form submits and what validation
+sees, so a required field holding `0` read as empty.
+
+## b24ui port
+
+Applies verbatim — our pre-image is upstream's line for line in both components,
+and the guard changes to `isEmpty(value)` with `||=` replaced by a plain
+assignment.
+
+**The helper was already here, and so was the reasoning.** `isEmpty` lives in
+`src/runtime/utils/index.ts:194`, and its doc comment states the exact principle
+this fix turns on:
+
+> `false` and `0` are values, not emptiness — a checkbox bound to `false` is
+> answered, and a quantity of `0` is a quantity.
+
+So the fork had written down why `||=` is wrong here and then left these two
+components using it. Worth recording: a rule stated in a comment does not
+propagate itself, and nothing in `lint`, `typecheck` or the suite connected the
+two until upstream's test cases arrived.
+
+## Tests
+
+Upstream's five cases for `Input` and four for `Textarea`, taken as written —
+`Input` gets one more because it has a `type` prop and `Textarea` does not, so
+`type="number"` needs its own row there.
+
+The empty-value rows matter as much as the `0` rows: the mapping still has to
+happen when the value really is empty, or the fix would trade one bug for
+another. Mutation-checked, and the counts show both halves are separately
+covered:
+
+| mutation | result |
+| --- | --- |
+| revert the port | **10 red** — the five new cases in both projects |
+| guard `nullable` only, leave `optional` on `||=` | **4 red** — exactly the two `.number` + `.optional` rows |
+| invert to `!isEmpty(value)` | **26 red** — the empty-value mapping breaks everywhere |

--- a/.sync/nuxt-ui.json
+++ b/.sync/nuxt-ui.json
@@ -1,7 +1,7 @@
 {
   "upstream": "nuxt/ui",
   "branch": "v4",
-  "cursor": "970025f9e045c953a3339a68ed05aa06e8f62e93",
+  "cursor": "6d6737af38d517f1d5bae9a4a0e063d169c17890",
   "_cursor_note": "cursor = last upstream commit ported into b24ui. The sync is manual by decision: one commit at a time, oldest-first, each with a `.sync/log/<sha>.md` journal and an entry in `processed`. There is no dispatcher, no porter workflow and no kill-switch — `.sync/PORTING.md` is the whole procedure. `processed` is maintained per port (backfilled #68-#72 on 2026-06-09).",
   "processed": {
     "2799fa6f2b25ce3eb15e050f3ef7c57d0d9a2fdb": {
@@ -1829,6 +1829,12 @@
       "b24ui_sha": "7b2a7cf909f3b2ca7218231cb69cd11ab75f064e",
       "decision": "n/a",
       "summary": "docs(theme): add og image and canonical — N/A: the page it decorates does not exist here. Tenth and last of this run. Upstream's docs/app/pages/theme.vue gains a defineOgImage call and a canonical URL, plus docs/public/theme/og-image.png. theme.vue is the Theme Studio page added in 5fd94e13, which this fork did not take — the Studio reshapes a Tailwind colour palette and this fork's colours are a fixed enumerated set of Bitrix24 air styles with no palette to reshape. Our docs pages are index, showcase, templates, docs and examples; there is no theme.vue for this commit to modify. The other half is inapplicable for the reason given under f5699461: this fork generates no OG images and has no defineOgImage call anywhere. A follow-on to a commit that was itself n/a, recorded on its own rather than folded into that entry, because the ledger is keyed one row per upstream commit and a reader looking this SHA up must find it."
+    },
+    "6d6737af38d517f1d5bae9a4a0e063d169c17890": {
+      "pr": "pending-merge",
+      "b24ui_sha": "pending-merge",
+      "decision": "port",
+      "summary": "fix(Input/Textarea): keep `0` with `nullable` and `optional` modifiers (nuxt/ui #6871) — PORT, verbatim. updateInput mapped empty values with ||=, which fires on every FALSY value rather than on emptiness. With the number modifier — or type=\"number\", which takes the same branch — looseToNumber('0') yields 0, and 0 ||= null is null, so a quantity of zero came back as no value at all; same for .optional producing undefined. Not a rendering nuisance: the model is what a form submits and what validation sees, so a required field holding 0 read as empty. Applies verbatim, our pre-image being upstream's line for line in both components, with the guard changing to isEmpty(value) and ||= replaced by a plain assignment. THE HELPER WAS ALREADY HERE AND SO WAS THE REASONING: isEmpty lives at src/runtime/utils/index.ts:194 and its doc comment states the exact principle this fix turns on — 'false and 0 are values, not emptiness — a checkbox bound to false is answered, and a quantity of 0 is a quantity'. So the fork had written down why ||= is wrong here and then left these two components using it; worth recording, because a rule stated in a comment does not propagate itself and nothing in lint, typecheck or the suite connected the two until upstream's cases arrived. Took upstream's five cases for Input and four for Textarea as written — Input gets one more because it has a type prop and Textarea does not, so type=\"number\" needs its own row. The empty-value rows matter as much as the 0 rows: the mapping still has to happen when the value really IS empty, or the fix would trade one bug for another. Mutation-checked, and the counts show both halves are separately covered: reverting the port turns 10 red (the five new cases in both projects), guarding nullable only while leaving optional on ||= turns 4 red (exactly the two .number + .optional rows), and inverting to !isEmpty(value) turns 26 red because the empty-value mapping then breaks everywhere."
     }
   }
 }

--- a/src/runtime/components/Input.vue
+++ b/src/runtime/components/Input.vue
@@ -111,7 +111,7 @@ import { useComponentProps } from '../composables/useComponentProps'
 import { useFieldGroup } from '../composables/useFieldGroup'
 import { useComponentIcons } from '../composables/useComponentIcons'
 import { useFormField } from '../composables/useFormField'
-import { looseToNumber } from '../utils'
+import { isEmpty, looseToNumber } from '../utils'
 import { tv } from '../utils/tv'
 import B24Badge from './Badge.vue'
 import B24Avatar from './Avatar.vue'
@@ -179,12 +179,13 @@ function updateInput(value: string | null | undefined) {
     value = looseToNumber(value)
   }
 
-  if (props.modelModifiers?.nullable) {
-    value ||= null
+  // Only empty values are mapped, `0` is a value on its own with the `number` modifier
+  if (props.modelModifiers?.nullable && isEmpty(value)) {
+    value = null
   }
 
-  if (props.modelModifiers?.optional && !props.modelModifiers?.nullable && value !== null) {
-    value ||= undefined
+  if (props.modelModifiers?.optional && !props.modelModifiers?.nullable && value !== null && isEmpty(value)) {
+    value = undefined
   }
 
   modelValue.value = value as ApplyModifiers<T, Mod>

--- a/src/runtime/components/Textarea.vue
+++ b/src/runtime/components/Textarea.vue
@@ -102,7 +102,7 @@ import { useAppConfig } from '#imports'
 import { useComponentProps } from '../composables/useComponentProps'
 import { useComponentIcons } from '../composables/useComponentIcons'
 import { useFormField } from '../composables/useFormField'
-import { looseToNumber } from '../utils'
+import { isEmpty, looseToNumber } from '../utils'
 import { tv } from '../utils/tv'
 import B24Badge from './Badge.vue'
 import B24Avatar from './Avatar.vue'
@@ -168,12 +168,13 @@ function updateInput(value: string | null | undefined) {
     value = looseToNumber(value)
   }
 
-  if (props.modelModifiers?.nullable) {
-    value ||= null
+  // Only empty values are mapped, `0` is a value on its own with the `number` modifier
+  if (props.modelModifiers?.nullable && isEmpty(value)) {
+    value = null
   }
 
-  if (props.modelModifiers?.optional && !props.modelModifiers?.nullable && value !== null) {
-    value ||= undefined
+  if (props.modelModifiers?.optional && !props.modelModifiers?.nullable && value !== null && isEmpty(value)) {
+    value = undefined
   }
 
   modelValue.value = value as ApplyModifiers<T, Mod>

--- a/test/components/Input.spec.ts
+++ b/test/components/Input.spec.ts
@@ -69,7 +69,16 @@ describe('Input', () => {
       ['with .number modifier', { props: { modelModifiers: { number: true } } }, { input: '42', expected: 42 }],
       ['with .lazy modifier', { props: { modelModifiers: { lazy: true } } }, { input: 'input', expected: 'input' }],
       ['with .nullable modifier', { props: { modelModifiers: { nullable: true } } }, { input: '', expected: null }],
-      ['with .optional modifier', { props: { modelModifiers: { optional: true } } }, { input: '', expected: undefined }]
+      ['with .optional modifier', { props: { modelModifiers: { optional: true } } }, { input: '', expected: undefined }],
+      // `0` is the case the fix is about: `value ||= null` treated it as empty,
+      // so a quantity of zero came back as `null`. The empty-value rows are the
+      // other half — the mapping still has to happen when the value really is
+      // empty, or the fix would trade one bug for another.
+      ['with .number and .nullable modifiers', { props: { modelModifiers: { number: true, nullable: true } } }, { input: '0', expected: 0 }],
+      ['with .number and .optional modifiers', { props: { modelModifiers: { number: true, optional: true } } }, { input: '0', expected: 0 }],
+      ['with .number and .nullable modifiers on an empty value', { props: { modelModifiers: { number: true, nullable: true } } }, { input: '', expected: null }],
+      ['with .number and .optional modifiers on an empty value', { props: { modelModifiers: { number: true, optional: true } } }, { input: '', expected: undefined }],
+      ['with number type and .nullable modifier', { props: { type: 'number', modelModifiers: { nullable: true } } }, { input: '0', expected: 0 }]
     ],
     '%s works',
     async (_nameOrHtml, options, spec) => {

--- a/test/components/Textarea.spec.ts
+++ b/test/components/Textarea.spec.ts
@@ -76,7 +76,15 @@ describe('Textarea', () => {
       ['with .number modifier', { props: { modelModifiers: { number: true } } }, { input: '42', expected: 42 }],
       ['with .lazy modifier', { props: { modelModifiers: { lazy: true } } }, { input: 'input', expected: 'input' }],
       ['with .nullable modifier', { props: { modelModifiers: { nullable: true } } }, { input: '', expected: null }],
-      ['with .optional modifier', { props: { modelModifiers: { optional: true } } }, { input: '', expected: undefined }]
+      ['with .optional modifier', { props: { modelModifiers: { optional: true } } }, { input: '', expected: undefined }],
+      // `0` is the case the fix is about: `value ||= null` treated it as empty,
+      // so a quantity of zero came back as `null`. The empty-value rows are the
+      // other half — the mapping still has to happen when the value really is
+      // empty, or the fix would trade one bug for another.
+      ['with .number and .nullable modifiers', { props: { modelModifiers: { number: true, nullable: true } } }, { input: '0', expected: 0 }],
+      ['with .number and .optional modifiers', { props: { modelModifiers: { number: true, optional: true } } }, { input: '0', expected: 0 }],
+      ['with .number and .nullable modifiers on an empty value', { props: { modelModifiers: { number: true, nullable: true } } }, { input: '', expected: null }],
+      ['with .number and .optional modifiers on an empty value', { props: { modelModifiers: { number: true, optional: true } } }, { input: '', expected: undefined }]
     ],
     '%s works',
     async (_, options, spec) => {


### PR DESCRIPTION
Port of [`nuxt/ui@6d6737af`](https://github.com/nuxt/ui/commit/6d6737af38d517f1d5bae9a4a0e063d169c17890).

## The defect

`updateInput` mapped empty values with `||=`:

```ts
if (props.modelModifiers?.nullable) {
  value ||= null
}
```

`||=` fires on every **falsy** value, not on emptiness. With the `number` modifier — or `type="number"`, which takes the same branch — `looseToNumber('0')` yields `0`, and `0 ||= null` is `null`. A quantity of zero came back as *no value at all*, and the same for `.optional` producing `undefined`.

Not a rendering nuisance: the model is what a form submits and what validation sees, so a required field holding `0` read as empty.

Applies verbatim — our pre-image is upstream's line for line in both components.

## The helper was already here, and so was the reasoning

`isEmpty` lives in `src/runtime/utils/index.ts:194`, and its doc comment states the exact principle this fix turns on:

> `false` and `0` are values, not emptiness — a checkbox bound to `false` is answered, and a quantity of `0` is a quantity.

So the fork had written down why `||=` is wrong here, and then left these two components using it. Worth recording: **a rule stated in a comment does not propagate itself**, and nothing in `lint`, `typecheck` or the suite connected the two until upstream's test cases arrived.

## Tests

Upstream's five cases for `Input` and four for `Textarea`, taken as written. `Input` gets one more because it has a `type` prop and `Textarea` does not, so `type="number"` needs its own row there.

The empty-value rows matter as much as the `0` rows: the mapping still has to happen when the value really *is* empty, or the fix would trade one bug for another.

| mutation | result |
| --- | --- |
| revert the port | **10 red** — the five new cases in both projects |
| guard `nullable` only, leave `optional` on `\|\|=` | **4 red** — exactly the two `.number` + `.optional` rows |
| invert to `!isEmpty(value)` | **26 red** — the empty-value mapping breaks everywhere |

The middle row is the one that shows both halves are separately covered rather than riding on one assertion.

## Bookkeeping

- `.sync/nuxt-ui.json` — cursor `970025f9` → `6d6737af`, entry added (305 total).
- `.sync/dep-parity.json` — refreshed at the new cursor.
- `.sync/log/6d6737af….md` — the long-form reasoning.

Local gate green: `lint` · `typecheck` · `test` (349 files, 7931 passed, 6 skipped) · `build` (3.87 MB) · `test:module`.

This is the only commit ahead of the cursor — the previous run of ten closed with #558.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JS8ypVfQSFzYVZzkTHhURb

---
_Generated by [Claude Code](https://claude.ai/code/session_01JS8ypVfQSFzYVZzkTHhURb)_