### PR TITLE
docs(error): show the `error.vue` note to Nuxt readers only (nuxt/ui@797feea)

### DIFF
--- a/.sync/dep-parity.json
+++ b/.sync/dep-parity.json
@@ -1,6 +1,6 @@
 {
   "$note": "Upstream's pinned versions for every dependency both trees declare in the SAME section, snapshotted at `cursor`. The sync ports deltas, which is correct per commit and lets a one-time divergence become permanent: once a version is off upstream's line, every later `chore(deps)` batch skips it, because those ports bump only where this fork already matched upstream's pre-image. `prettier` sat at ^3.8.4 against upstream's ^3.9.6 for that reason, through four ported batches, until this file was written. Section-aware on purpose: 18 packages are declared on both sides but in different sections — the whole `@tiptap/*` family is a peer `^3` upstream and a dependency `^3.29.2` here, and `ai` is a peer there and a devDependency here. Those are structural divergences, not drift, and comparing a peer range against a dependency range says nothing. They are absent from this file by construction rather than by omission. Guarded by `test/utils/dep-parity.spec.ts`. Refresh with `node .sync/dep-parity.mjs <path-to-nuxt-ui-mirror> [cursor]`, which preserves `exceptions`.",
-  "cursor": "6d6737af38d517f1d5bae9a4a0e063d169c17890",
+  "cursor": "797feeac4f5ba6e7d93353456337ae9198fba242",
   "manifests": {
     "package.json": {
       "dependencies": {

--- a/.sync/log/797feeac4f5ba6e7d93353456337ae9198fba242.md
+++ b/.sync/log/797feeac4f5ba6e7d93353456337ae9198fba242.md
@@ -1,0 +1,28 @@
+# port — nuxt/ui@797feeac4f5ba6e7d93353456337ae9198fba242
+
+**Upstream:** docs(error): display note to nuxt only (#6932)
+
+**Decision:** port, verbatim. First of three commits in this run.
+
+## Upstream change
+
+Three lines: the `error.vue` note in `error.md` is wrapped in
+`::framework-only` / `#nuxt`, so it renders for readers on the Nuxt tab and not
+on the Vue one.
+
+## b24ui port
+
+Applies verbatim — our `error.md` carries upstream's pre-image at that hunk, the
+same `::note{to="https://nuxt.com/docs/guide/directory-structure/error"}` block,
+unwrapped.
+
+**Checked that the directive does something here before taking it.** A wrapper
+with no implementation would not error; it would silently swallow the note, which
+is the failure this kind of change invites. `docs/app/components/content/FrameworkOnly.vue`
+exists and renders each named slot inside a `Slot` carrying `nuxt-only` /
+`vue-only`, and `useFrameworks.ts` declares both `nuxt` and `vue` with `nuxt` as
+the default. The directive is already used in five other pages.
+
+The note is Nuxt-specific on its own terms — `error.vue` is a Nuxt directory
+convention — and this fork ships a Vue build alongside the Nuxt one, so the
+reason upstream scoped it holds here unchanged.

--- a/.sync/nuxt-ui.json
+++ b/.sync/nuxt-ui.json
@@ -1,7 +1,7 @@
 {
   "upstream": "nuxt/ui",
   "branch": "v4",
-  "cursor": "6d6737af38d517f1d5bae9a4a0e063d169c17890",
+  "cursor": "797feeac4f5ba6e7d93353456337ae9198fba242",
   "_cursor_note": "cursor = last upstream commit ported into b24ui. The sync is manual by decision: one commit at a time, oldest-first, each with a `.sync/log/<sha>.md` journal and an entry in `processed`. There is no dispatcher, no porter workflow and no kill-switch — `.sync/PORTING.md` is the whole procedure. `processed` is maintained per port (backfilled #68-#72 on 2026-06-09).",
   "processed": {
     "2799fa6f2b25ce3eb15e050f3ef7c57d0d9a2fdb": {
@@ -1835,6 +1835,12 @@
       "b24ui_sha": "2b4ad139e2f4855cbf4d2ee54609e2e097520b08",
       "decision": "port",
       "summary": "fix(Input/Textarea): keep `0` with `nullable` and `optional` modifiers (nuxt/ui #6871) — PORT, verbatim. updateInput mapped empty values with ||=, which fires on every FALSY value rather than on emptiness. With the number modifier — or type=\"number\", which takes the same branch — looseToNumber('0') yields 0, and 0 ||= null is null, so a quantity of zero came back as no value at all; same for .optional producing undefined. Not a rendering nuisance: the model is what a form submits and what validation sees, so a required field holding 0 read as empty. Applies verbatim, our pre-image being upstream's line for line in both components, with the guard changing to isEmpty(value) and ||= replaced by a plain assignment. THE HELPER WAS ALREADY HERE AND SO WAS THE REASONING: isEmpty lives at src/runtime/utils/index.ts:194 and its doc comment states the exact principle this fix turns on — 'false and 0 are values, not emptiness — a checkbox bound to false is answered, and a quantity of 0 is a quantity'. So the fork had written down why ||= is wrong here and then left these two components using it; worth recording, because a rule stated in a comment does not propagate itself and nothing in lint, typecheck or the suite connected the two until upstream's cases arrived. Took upstream's five cases for Input and four for Textarea as written — Input gets one more because it has a type prop and Textarea does not, so type=\"number\" needs its own row. The empty-value rows matter as much as the 0 rows: the mapping still has to happen when the value really IS empty, or the fix would trade one bug for another. Mutation-checked, and the counts show both halves are separately covered: reverting the port turns 10 red (the five new cases in both projects), guarding nullable only while leaving optional on ||= turns 4 red (exactly the two .number + .optional rows), and inverting to !isEmpty(value) turns 26 red because the empty-value mapping then breaks everywhere."
+    },
+    "797feeac4f5ba6e7d93353456337ae9198fba242": {
+      "pr": "pending-merge",
+      "b24ui_sha": "pending-merge",
+      "decision": "port",
+      "summary": "docs(error): display note to nuxt only (nuxt/ui #6932) — PORT, verbatim. First of three commits in this run. Three lines: the error.vue note in error.md is wrapped in ::framework-only / #nuxt so it renders on the Nuxt tab and not the Vue one. Applies verbatim — our error.md carries upstream's pre-image at that hunk, the same ::note{to=\"https://nuxt.com/docs/guide/directory-structure/error\"} block, unwrapped. CHECKED THAT THE DIRECTIVE DOES SOMETHING HERE BEFORE TAKING IT: a wrapper with no implementation would not error, it would silently swallow the note, which is the failure this kind of change invites. docs/app/components/content/FrameworkOnly.vue exists and renders each named slot inside a Slot carrying nuxt-only / vue-only, useFrameworks.ts declares both nuxt and vue with nuxt as the default, and the directive is already used in five other pages. The note is Nuxt-specific on its own terms — error.vue is a Nuxt directory convention — and this fork ships a Vue build alongside the Nuxt one, so the reason upstream scoped it holds here unchanged."
     }
   }
 }

--- a/docs/content/docs/2.components/error.md
+++ b/docs/content/docs/2.components/error.md
@@ -22,8 +22,11 @@ The Error component renders a `<main>` element that works together with the [Sid
 
 Use the `error` prop to display an error message.
 
+::framework-only
+#nuxt
 ::note{to="https://nuxt.com/docs/guide/directory-structure/error" target="_blank"}
 In most cases, you will receive the `error` prop in your `error.vue` file.
+::
 ::
 
 ::component-code


### PR DESCRIPTION
Port of [`nuxt/ui@797feeac`](https://github.com/nuxt/ui/commit/797feeac4f5ba6e7d93353456337ae9198fba242) — first of three upstream commits in this run.

Three lines: the `error.vue` note in `error.md` is wrapped in `::framework-only` / `#nuxt`, so it renders for readers on the Nuxt tab and not on the Vue one.

Applies verbatim — our `error.md` carries upstream's pre-image at that hunk, the same `::note{to="https://nuxt.com/docs/guide/directory-structure/error"}` block, unwrapped. The note is Nuxt-specific on its own terms (`error.vue` is a Nuxt directory convention), and this fork ships a Vue build alongside the Nuxt one, so upstream's reason for scoping it holds here unchanged.

## Checked that the directive does something here before taking it

A wrapper with no implementation would not error — it would **silently swallow the note**, which is exactly the failure this kind of change invites.

- `docs/app/components/content/FrameworkOnly.vue` exists and renders each named slot inside a `Slot` carrying `nuxt-only` / `vue-only`
- `useFrameworks.ts` declares both `nuxt` and `vue`, with `nuxt` as the default
- the directive is already used on five other pages

## Verified against the built site, not the source

`docs:full:generate` run with `deploy.yml`'s env, per §6 step 3 — the `ci` gate never builds the docs site. On the generated `docs/components/error/` page the note's own element now carries `nuxt-only`, with the nuxt.com link inside it.

## One thing worth recording about the gate

`typecheck` first reported two `TS2339: Property 'prefix' does not exist` errors that had nothing to do with this change — stale generated types, left over from #562 landing on `main` after my last `dev:prepare`. Clean after regenerating. `ci.yml` runs `dev:prepare` first and so never sees this; my local gate was skipping it.

Local gate green: `lint` · `typecheck` · `test` (349 files, 7933 passed, 6 skipped) · `docs:full:generate`.

## Still ahead

Two upstream commits, both real fixes with tests: `22efd35d` (PinInput blur) and `cf9e8385` (SelectMenu arrow keys).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JS8ypVfQSFzYVZzkTHhURb

---
_Generated by [Claude Code](https://claude.ai/code/session_01JS8ypVfQSFzYVZzkTHhURb)_