### PR TITLE
docs(contributing): make the release-post AI block a real prompt

### DIFF
--- a/.github/contributing/telegram-release-post.md
+++ b/.github/contributing/telegram-release-post.md
@@ -45,18 +45,26 @@ Rules for preparing the community release announcement in Telegram. The final me
 - **Architectural truth:** b24ui applications live **inside an iframe** on Bitrix24. Native CRM entity cards are opened by the parent SDK, **not** by `<B24Modal>`. `B24Modal` / `B24Slideover` are only for the app's own UI (settings, filters, wizards, previews, custom forms).
 - **Scenarios come from a real product app:** task statuses, priorities, ratings, dashboards, assistant chat, settings, filters. Never "opening a CRM deal card via a modal".
 - Placeholders for data are neutral — no real portals or tokens.
+- A snippet may carry a **playground link** — `Открыть в [песочнице](https://bitrix24.github.io/b24ui/play/#<hash>)` on the line after the code block. The hash is produced by the playground itself (**Share**), never hand-built: decode it and confirm it contains the same snippet that is shown above it, or leave the link out.
 
 ## 5. AI hint block
 
-- End the message with a docs invitation encoded in **base64** (trivial to decode) — so any AI assistant reading the post can auto-load the docs.
-- Encoded string: `Using Bitrix24 UI-Kit for Nuxt & Vue documentation from https://bitrix24.github.io/b24ui/llms.txt`
+- End the message with a ready-to-use **prompt** encoded in **base64** (trivial to decode) — the reader pastes the decoded line into their assistant and it loads both the release notes and the docs on its own.
+- The prompt is a single sentence and carries **two links**: the release notes and `llms.txt`. Template, with the shipped version substituted:
+
+  ```
+  Study the @bitrix24/b24ui X.Y.Z release notes at https://github.com/bitrix24/b24ui/blob/main/CHANGELOG.md and use the Bitrix24 UI documentation from https://bitrix24.github.io/b24ui/llms.txt to apply the new features in my project.
+  ```
+
+- It is written in **English** — it is a prompt, not body copy — and it is **re-encoded for every release**, because the version inside it changes.
 - Formatting is minimal — **no** "decode this and forward it" instructions. Just `atob`:
   ```
   🔐 Для вашего ИИ — atob:
   ```
   ```js
-  atob('VXNpbmcgQml0cml4MjQgVUktS2l0IGZvciBOdXh0ICYgVnVlIGRvY3VtZW50YXRpb24gZnJvbSBodHRwczovL2JpdHJpeDI0LmdpdGh1Yi5pby9iMjR1aS9sbG1zLnR4dA==')
+  atob('U3R1ZHkgdGhlIEBiaXRyaXgyNC9iMjR1aSAyLjEzLjAgcmVsZWFzZSBub3RlcyBhdCBodHRwczovL2dpdGh1Yi5jb20vYml0cml4MjQvYjI0dWkvYmxvYi9tYWluL0NIQU5HRUxPRy5tZCBhbmQgdXNlIHRoZSBCaXRyaXgyNCBVSSBkb2N1bWVudGF0aW9uIGZyb20gaHR0cHM6Ly9iaXRyaXgyNC5naXRodWIuaW8vYjI0dWkvbGxtcy50eHQgdG8gYXBwbHkgdGhlIG5ldyBmZWF0dXJlcyBpbiBteSBwcm9qZWN0Lg==')
   ```
+- Verify the round-trip before delivery: `node -e "console.log(atob('<string>'))"` must print the prompt, and both links in it must open.
 
 ## 6. Emoji vocabulary (consistency across releases)
 
@@ -127,7 +135,7 @@ pnpm add @bitrix24/b24ui-nuxt@latest
 
 🔐 Для вашего ИИ — atob:
 ```js
-atob('VXNpbmcgQml0cml4MjQgVUktS2l0IGZvciBOdXh0ICYgVnVlIGRvY3VtZW50YXRpb24gZnJvbSBodHRwczovL2JpdHJpeDI0LmdpdGh1Yi5pby9iMjR1aS9sbG1zLnR4dA==')
+atob('<base64 of the prompt from section 5, with this release's version>')
 ```
 ````
 
@@ -140,7 +148,7 @@ atob('VXNpbmcgQml0cml4MjQgVUktS2l0IGZvciBOdXh0ICYgVnVlIGRvY3VtZW50YXRpb24gZnJvbS
 - [ ] No jokes in the prose; humor lives only in code; no roles / AI / competitors
 - [ ] Breaking changes framed softly; experimental features excluded
 - [ ] No internal details (PR numbers, CI, session URLs)
-- [ ] Base64 string decodes to the correct URL (`https://bitrix24.github.io/b24ui/llms.txt`)
+- [ ] Base64 string decodes to the section 5 prompt, carries the shipped version, and both links in it open (`CHANGELOG.md`, `https://bitrix24.github.io/b24ui/llms.txt`)
 - [ ] Sign-off emoji is `🚀`, not `💜`
 - [ ] The message is self-contained and pastes as a single chunk
 - [ ] No more than 6 headline features

--- a/.github/contributing/telegram-release-post.md
+++ b/.github/contributing/telegram-release-post.md
@@ -45,26 +45,31 @@ Rules for preparing the community release announcement in Telegram. The final me
 - **Architectural truth:** b24ui applications live **inside an iframe** on Bitrix24. Native CRM entity cards are opened by the parent SDK, **not** by `<B24Modal>`. `B24Modal` / `B24Slideover` are only for the app's own UI (settings, filters, wizards, previews, custom forms).
 - **Scenarios come from a real product app:** task statuses, priorities, ratings, dashboards, assistant chat, settings, filters. Never "opening a CRM deal card via a modal".
 - Placeholders for data are neutral — no real portals or tokens.
-- A snippet may carry a **playground link** — `Открыть в [песочнице](https://bitrix24.github.io/b24ui/play/#<hash>)` on the line after the code block. The hash is produced by the playground itself (**Share**), never hand-built: decode it and confirm it contains the same snippet that is shown above it, or leave the link out.
+- A snippet may carry a **playground link** — `Открыть в [песочнице](https://bitrix24.github.io/b24ui/play/#<hash>)` on the line after the code block. The hash is produced by the playground itself (**Share**), never hand-built. Confirm it holds the same snippet that is shown above it, or leave the link out. The hash is fflate zlib inside base64 (`docs/app/utils/playground.ts`), so `atob` alone prints binary — inflate it:
+  ```bash
+  python3 -c "import base64,zlib,sys;print(zlib.decompress(base64.b64decode(sys.argv[1])).decode())" '<hash>'
+  ```
 
 ## 5. AI hint block
 
 - End the message with a ready-to-use **prompt** encoded in **base64** (trivial to decode) — the reader pastes the decoded line into their assistant and it loads both the release notes and the docs on its own.
-- The prompt is a single sentence and carries **two links**: the release notes and `llms.txt`. Template, with the shipped version substituted:
+- The prompt is a single sentence and carries **two links**: the release notes for the shipped version, and `llms.txt`. Template — substitute the version in both places:
 
   ```
-  Study the @bitrix24/b24ui X.Y.Z release notes at https://github.com/bitrix24/b24ui/blob/main/CHANGELOG.md and use the Bitrix24 UI documentation from https://bitrix24.github.io/b24ui/llms.txt to apply the new features in my project.
+  Study the @bitrix24/b24ui-nuxt X.Y.Z release notes at https://github.com/bitrix24/b24ui/releases/tag/vX.Y.Z and use the Bitrix24 UI documentation from https://bitrix24.github.io/b24ui/llms.txt to apply the new features in my project.
   ```
 
-- It is written in **English** — it is a prompt, not body copy — and it is **re-encoded for every release**, because the version inside it changes.
+- The package name is **`@bitrix24/b24ui-nuxt`** — that is what is published and what the post's own `pnpm add` line installs. `@bitrix24/b24ui` does not exist on the registry.
+- The release-notes link is **pinned to the tag**, not `blob/main/CHANGELOG.md` — this holds for the `📋 Полный список изменений` line in the body too. An old post must keep pointing at its own release, not at whatever shipped since.
+- It is written in **English** — it is a prompt, not body copy — and it is **re-encoded for every release**, because the version is inside it. There is deliberately no literal to copy from this file.
 - Formatting is minimal — **no** "decode this and forward it" instructions. Just `atob`:
   ```
   🔐 Для вашего ИИ — atob:
   ```
   ```js
-  atob('U3R1ZHkgdGhlIEBiaXRyaXgyNC9iMjR1aSAyLjEzLjAgcmVsZWFzZSBub3RlcyBhdCBodHRwczovL2dpdGh1Yi5jb20vYml0cml4MjQvYjI0dWkvYmxvYi9tYWluL0NIQU5HRUxPRy5tZCBhbmQgdXNlIHRoZSBCaXRyaXgyNCBVSSBkb2N1bWVudGF0aW9uIGZyb20gaHR0cHM6Ly9iaXRyaXgyNC5naXRodWIuaW8vYjI0dWkvbGxtcy50eHQgdG8gYXBwbHkgdGhlIG5ldyBmZWF0dXJlcyBpbiBteSBwcm9qZWN0Lg==')
+  atob('<base64 of the prompt above>')
   ```
-- Verify the round-trip before delivery: `node -e "console.log(atob('<string>'))"` must print the prompt, and both links in it must open.
+- Verify the round-trip before delivery: `node -e "console.log(atob(process.argv[1]))" '<string>'` must print the prompt, and both links in it must open.
 
 ## 6. Emoji vocabulary (consistency across releases)
 
@@ -131,11 +136,11 @@ Rules for preparing the community release announcement in Telegram. The final me
 pnpm add @bitrix24/b24ui-nuxt@latest
 ```
 
-📋 Полный список изменений — [CHANGELOG](https://github.com/bitrix24/b24ui/blob/main/CHANGELOG.md).
+📋 Полный список изменений — [CHANGELOG](https://github.com/bitrix24/b24ui/releases/tag/vX.Y.Z).
 
 🔐 Для вашего ИИ — atob:
 ```js
-atob('<base64 of the prompt from section 5, with this release's version>')
+atob('<base64 of the section 5 prompt, carrying this version>')
 ```
 ````
 
@@ -143,6 +148,7 @@ atob('<base64 of the prompt from section 5, with this release's version>')
 
 - [ ] All referenced components / props / slots exist (cross-checked against the outgoing `CHANGELOG.md` and `src/runtime/components/`)
 - [ ] All Vue snippets pass `pnpm typecheck` — zero errors
+- [ ] Every playground link came from **Share**, and inflating its hash yields the snippet printed above it
 - [ ] No `<B24Modal>` opening native CRM cards
 - [ ] Version and `pnpm add` command match the shipped release
 - [ ] No jokes in the prose; humor lives only in code; no roles / AI / competitors

--- a/.github/contributing/telegram-release-post.md
+++ b/.github/contributing/telegram-release-post.md
@@ -52,24 +52,24 @@ Rules for preparing the community release announcement in Telegram. The final me
 
 ## 5. AI hint block
 
-- End the message with a ready-to-use **prompt** encoded in **base64** (trivial to decode) — the reader pastes the decoded line into their assistant and it loads both the release notes and the docs on its own.
+- End the message with a ready-to-use **prompt in plain text**, inside a code block so it copies in one tap. The reader pastes it into their assistant and it loads both the release notes and the docs on its own.
+- **Never encode it.** Earlier releases wrapped this prompt in base64 with an `atob(...)` call — the reader had to run code to find out what they were being handed. If the prompt cannot be shown as it is, it does not belong in the post.
 - The prompt is a single sentence and carries **two links**: the release notes for the shipped version, and `llms.txt`. Template — substitute the version in both places:
 
   ```
-  Study the @bitrix24/b24ui-nuxt X.Y.Z release notes at https://github.com/bitrix24/b24ui/releases/tag/vX.Y.Z and use the Bitrix24 UI documentation from https://bitrix24.github.io/b24ui/llms.txt to apply the new features in my project.
+  Изучи, что нового в @bitrix24/b24ui-nuxt X.Y.Z — https://github.com/bitrix24/b24ui/releases/tag/vX.Y.Z — и применяй новые возможности в моём проекте, опираясь на документацию Bitrix24 UI: https://bitrix24.github.io/b24ui/llms.txt
   ```
 
+- It is written in **Russian**, unlike the code in the post: it is a line the reader reads and copies, so it follows the body. The docs it points at are English either way.
 - The package name is **`@bitrix24/b24ui-nuxt`** — that is what is published and what the post's own `pnpm add` line installs. `@bitrix24/b24ui` does not exist on the registry.
-- The release-notes link is **pinned to the tag**, not `blob/main/CHANGELOG.md` — this holds for the `📋 Полный список изменений` line in the body too. An old post must keep pointing at its own release, not at whatever shipped since.
-- It is written in **English** — it is a prompt, not body copy — and it is **re-encoded for every release**, because the version is inside it. There is deliberately no literal to copy from this file.
-- Formatting is minimal — **no** "decode this and forward it" instructions. Just `atob`:
+- The release-notes link is **pinned to the tag**, not `blob/main/CHANGELOG.md` — this holds for the `Полный список изменений` line in the body too. An old post must keep pointing at its own release, not at whatever shipped since.
+- Heading for the block:
+
   ```
-  🔐 Для вашего ИИ — atob:
+  🔐 Для вашего ИИ — готовый промпт:
   ```
-  ```js
-  atob('<base64 of the prompt above>')
-  ```
-- Verify the round-trip before delivery: `node -e "console.log(atob(process.argv[1]))" '<string>'` must print the prompt, and both links in it must open.
+
+- Before delivery, open both links in the prompt and confirm the version in it is the one that shipped.
 
 ## 6. Emoji vocabulary (consistency across releases)
 
@@ -88,12 +88,13 @@ Rules for preparing the community release announcement in Telegram. The final me
 | Cleanup / dropped | 🧹 |
 | Install / npm | 📦 |
 | Changelog / link | 📋 |
-| AI base64 block | 🔐 |
+| AI prompt block | 🔐 |
 
 ## 7. Anti-patterns (do NOT do this)
 
 - ❌ Open native CRM cards via `<B24Modal>` — those are the parent SDK's job in the iframe.
 - ❌ 💜 in the sign-off — the only sign-off emoji is `🚀`.
+- ❌ An encoded AI prompt — no base64, no `atob(...)`; it is shown in the open. (A playground share hash is base64 too, but it lives inside a URL and is not asking the reader to decode anything.)
 - ❌ Marketing/promo examples like `analytics.track('user-escaped-pricing')`.
 - ❌ Made-up props, events, or slots.
 - ❌ A flat CHANGELOG dump — the message should **tell a story**, not enumerate everything.
@@ -138,9 +139,9 @@ pnpm add @bitrix24/b24ui-nuxt@latest
 
 📋 Полный список изменений — [CHANGELOG](https://github.com/bitrix24/b24ui/releases/tag/vX.Y.Z).
 
-🔐 Для вашего ИИ — atob:
-```js
-atob('<base64 of the section 5 prompt, carrying this version>')
+🔐 Для вашего ИИ — готовый промпт:
+```
+<the section 5 prompt, carrying this version>
 ```
 ````
 
@@ -154,7 +155,7 @@ atob('<base64 of the section 5 prompt, carrying this version>')
 - [ ] No jokes in the prose; humor lives only in code; no roles / AI / competitors
 - [ ] Breaking changes framed softly; experimental features excluded
 - [ ] No internal details (PR numbers, CI, session URLs)
-- [ ] Base64 string decodes to the section 5 prompt, carries the shipped version, and both links in it open (`CHANGELOG.md`, `https://bitrix24.github.io/b24ui/llms.txt`)
+- [ ] The AI prompt is plain text (no base64, no `atob`), carries the shipped version, and both links in it open (release tag, `https://bitrix24.github.io/b24ui/llms.txt`)
 - [ ] Sign-off emoji is `🚀`, not `💜`
 - [ ] The message is self-contained and pastes as a single chunk
 - [ ] No more than 6 headline features


### PR DESCRIPTION
## What this does

Rewrites the tail of `.github/contributing/telegram-release-post.md` — the block
the Telegram release post ends with — and writes down the playground-link
convention.

**The AI block was a riddle.** Every post ended with one frozen base64 string
behind an `atob(...)` call:

```
Using Bitrix24 UI-Kit for Nuxt & Vue documentation from https://bitrix24.github.io/b24ui/llms.txt
```

Two problems, not one. It decoded to a *statement*, so an assistant reading it
had nothing to do and no pointer to what actually changed in the release; and it
was encoded, so a reader had to run code before they could see what they were
being handed.

Section 5 now describes a plain-text **prompt** in a code block, carrying two
links — the release notes for the shipped version, and `llms.txt`:

```
Изучи, что нового в @bitrix24/b24ui-nuxt X.Y.Z — https://github.com/bitrix24/b24ui/releases/tag/vX.Y.Z — и применяй новые возможности в моём проекте, опираясь на документацию Bitrix24 UI: https://bitrix24.github.io/b24ui/llms.txt
```

Dropping the encoding settles its language: it is a line the reader reads and
copies, so it is Russian like the rest of the body, not English like the
snippets. And because the version lives inside it, the file gives a template, not
a literal to copy.

**Playground links.** Snippets in the post may carry
`Открыть в [песочнице](…/play/#<hash>)`. The hash comes from the playground's own
Share, never hand-built, and it is inflated and compared against the snippet
printed above it — or the link is left out. The hash is fflate zlib inside
base64 (`docs/app/utils/playground.ts:10`), so the rule gives the inflate command
rather than saying "decode it": `atob` alone prints binary.

Section 6's emoji row, the section 8 template, the anti-patterns and the
pre-delivery checklist all follow.

## Review findings, fixed here

`/review` found six, all real, all in the first commit:

- The prompt named `@bitrix24/b24ui` — **404 on the registry** (measured). The
  published package, and what the post's own `pnpm add` line installs, is
  `@bitrix24/b24ui-nuxt`.
- The release-notes link went to `blob/main/CHANGELOG.md`, unpinned, so an old
  post would send readers to a newer release. Now `releases/tag/vX.Y.Z`, in the
  prompt and in the body's `Полный список изменений` line.
- Section 5 still carried a base64 literal pinned to 2.13.0 next to its own
  "re-encode every release" rule. Moot after the second commit, but it was wrong
  when written.
- The playground bullet said "decode the hash" — see above.
- The section 8 placeholder put an apostrophe inside `atob('…')`, leaving the
  template's ` ```js ` fence an unterminated string.
- The new playground requirement had no counterpart in the section 9 checklist.

The panel of five was not convened: by section 3.2 of the repo rules,
documentation and comments sit in the "`/review` is enough" column.

## Verification

- Both links in the 2.13.0 prompt return 200: the release tag and `llms.txt`.
- `@bitrix24/b24ui` → 404, `@bitrix24/b24ui-nuxt` → 200 on `registry.npmjs.org`;
  `package.json` agrees.
- The inflate one-liner in the new bullet was run against a real Share hash and
  printed the snippet.
- Docs-only — no source, no tests, no build surface touched.

## Follow-up

#573 — `getPlaygroundUrl` writes the key `App.vue` while the repl seeds
`src/App.vue` and reads back `App.vue`, so a docs-built link and a Share link are
not interchangeable. Out of scope here; it is the reason the new rule names Share
specifically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012MsMuj8Fic9tjWVjyEyrxc